### PR TITLE
chore: Set go_version in linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,16 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-20.04
+    needs: vars
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
+      - name: Setup Golang Environment
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ needs.vars.outputs.go_version }}
       - name: Lint Code
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3.1.0
         with:
           args: --timeout ${{ env.GOLANGCI_TIMEOUT }}
 


### PR DESCRIPTION
### Proposed changes
We need to run the setup-go action as part of the lint job for v3 of the golint action to work (this was previously bundled with the golint action but has since been removed - see https://github.com/golangci/golangci-lint-action/pull/403).


### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
