### PR TITLE
Handle repeated headers

### DIFF
--- a/internal/nginx/config/generator_test.go
+++ b/internal/nginx/config/generator_test.go
@@ -640,6 +640,16 @@ func TestCreateHTTPMatch(t *testing.T) {
 			Value: "val-3",
 		},
 	}
+
+	testDuplicateHeaders := make([]v1alpha2.HTTPHeaderMatch, 0, 5)
+	duplicateHeaderMatch := v1alpha2.HTTPHeaderMatch{
+		Type:  helpers.GetHeaderMatchTypePointer(v1alpha2.HeaderMatchExact),
+		Name:  "HEADER-2", // header names are case-insensitive
+		Value: "val-2",
+	}
+	testDuplicateHeaders = append(testDuplicateHeaders, testHeaderMatches...)
+	testDuplicateHeaders = append(testDuplicateHeaders, duplicateHeaderMatch)
+
 	testQueryParamMatches := []v1alpha2.HTTPQueryParamMatch{
 		{
 			Type:  helpers.GetQueryParamMatchTypePointer(v1alpha2.QueryParamMatchExact),
@@ -762,6 +772,16 @@ func TestCreateHTTPMatch(t *testing.T) {
 				RedirectPath: testPath,
 			},
 			msg: "method, headers, and query params match",
+		},
+		{
+			match: v1alpha2.HTTPRouteMatch{
+				Headers: testDuplicateHeaders,
+			},
+			expected: httpMatch{
+				Headers:      expectedHeaders,
+				RedirectPath: testPath,
+			},
+			msg: "duplicate header names",
 		},
 	}
 	for _, tc := range tests {

--- a/internal/nginx/modules/src/httpmatches.js
+++ b/internal/nginx/modules/src/httpmatches.js
@@ -129,8 +129,6 @@ function testMatch(r, match) {
   return true;
 }
 
-// FIXME(osborn): Need to add special handling for repeated headers.
-// Should follow guidance from https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2.
 function headersMatch(requestHeaders, headers) {
   for (let i = 0; i < headers.length; i++) {
     const h = headers[i];
@@ -144,7 +142,13 @@ function headersMatch(requestHeaders, headers) {
     // This means that requestHeaders['FOO'] is equivalent to requestHeaders['foo'].
     let val = requestHeaders[kv[0]];
 
-    if (!val || val !== kv[1]) {
+    if (!val) {
+      return false;
+    }
+
+    // split on comma because nginx uses commas to delimit multiple header values
+    const values = val.split(',');
+    if (!values.includes(kv[1])) {
       return false;
     }
   }

--- a/internal/nginx/modules/test/httpmatches.test.js
+++ b/internal/nginx/modules/test/httpmatches.test.js
@@ -253,6 +253,14 @@ describe('headersMatch', () => {
       },
       expected: true,
     },
+    {
+      name: 'returns true if request has multiple values for a header name and one value matches ',
+      headers: ['multiValueHeader:val3'],
+      requestHeaders: {
+        multiValueHeader: 'val1,val2,val3,val4,val5',
+      },
+      expected: true,
+    },
   ];
 
   tests.forEach((test) => {


### PR DESCRIPTION
### Proposed changes

If an `HTTPHeaderMatch` contains entries with equivalent header names, we will only configure the first entry. We will ignore all other entries with that name. Header names are case-insensitive, so "Foo" is equivalent to "foo".

If an HTTP request has repeated headers, nginx will merge the values into a comma-delimited string.

For example, `-H "foo:bar" -H "foo:baz"` becomes `{"foo":"bar,baz"}` in the headersIn object. In this case, a request satisfies the header match `{"foo":"bar"}` if one of the values specified in the request header "foo" is "bar".


### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
