### PR TITLE
Support GatewayClass resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ You can deploy NGINX Kubernetes Gateway on an existing Kubernetes 1.16+ cluster.
     kubectl create configmap njs-modules --from-file=internal/nginx/modules/src/httpmatches.js -n nginx-gateway  
     ```
 
+1. Create the GatewayClass resource:
+
+    ```
+    kubectl apply -f deploy/manifests/gatewayclass.yaml
+    ```
+
 1. Deploy the NGINX Kubernetes Gateway:
 
    Before deploying, make sure to update the Deployment spec in `nginx-gateway.yaml` to reference the image you built.

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -28,6 +28,11 @@ var (
 		"",
 		fmt.Sprintf("The name of the Gateway controller. The controller name must be of the form: DOMAIN/NAMESPACE/NAME. The controller's domain is '%s'.", domain),
 	)
+
+	gatewayClassName = flag.String(
+		"gatewayclass",
+		"",
+		"The name of the GatewayClass resource. Every NGINX Gateway must have a unique corresponding GatewayClass resource")
 )
 
 func main() {
@@ -42,11 +47,13 @@ func main() {
 			Namespace: "nginx-gateway",
 			Name:      "gateway",
 		},
+		GatewayClassName: *gatewayClassName,
 	}
 
 	MustValidateArguments(
 		flag.CommandLine,
 		GatewayControllerParam(domain, "nginx-gateway" /* FIXME(f5yacobucci) dynamically set */),
+		GatewayClassParam(),
 	)
 
 	logger.Info("Starting NGINX Kubernetes Gateway",

--- a/cmd/gateway/setup.go
+++ b/cmd/gateway/setup.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	flag "github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 const (
@@ -58,6 +59,32 @@ func GatewayControllerParam(domain string, namespace string) ValidatorContext {
 						return errors.New("must provide a name")
 					}
 				}
+			}
+
+			return nil
+		},
+	}
+}
+
+func GatewayClassParam() ValidatorContext {
+	name := "gatewayclass"
+	return ValidatorContext{
+		name,
+		func(flagset *flag.FlagSet) error {
+			param, err := flagset.GetString(name)
+			if err != nil {
+				return err
+			}
+
+			if len(param) == 0 {
+				return errors.New("flag must be set")
+			}
+
+			// used by Kubernetes to validate resource names
+			messages := validation.IsDNS1123Subdomain(param)
+			if len(messages) > 0 {
+				msg := strings.Join(messages, "; ")
+				return fmt.Errorf("invalid format: %s", msg)
 			}
 
 			return nil

--- a/cmd/gateway/setup_test.go
+++ b/cmd/gateway/setup_test.go
@@ -10,8 +10,6 @@ import (
 	. "github.com/nginxinc/nginx-kubernetes-gateway/cmd/gateway"
 )
 
-var domain string
-
 func MockValidator(name string, called *int, succeed bool) ValidatorContext {
 	return ValidatorContext{
 		name,
@@ -122,22 +120,25 @@ var _ = Describe("Main", func() {
 
 	Describe("CLI argument validation", func() {
 		type testCase struct {
-			Param    string
-			Domain   string
-			ExpError bool
+			Flag             string
+			Value            string
+			ValidatorContext ValidatorContext
+			ExpError         bool
 		}
 
+		const (
+			expectError   = true
+			expectSuccess = false
+		)
+
 		var mockFlags *flag.FlagSet
-		var gatewayCtlrName string
 
 		tester := func(t testCase) {
-			err := mockFlags.Set(gatewayCtlrName, t.Param)
+			err := mockFlags.Set(t.Flag, t.Value)
 			Expect(err).ToNot(HaveOccurred())
 
-			v := GatewayControllerParam(domain, t.Domain)
-			Expect(v.V).ToNot(BeNil())
+			err = t.ValidatorContext.V(mockFlags)
 
-			err = v.V(mockFlags)
 			if t.ExpError {
 				Expect(err).To(HaveOccurred())
 			} else {
@@ -150,88 +151,122 @@ var _ = Describe("Main", func() {
 			}
 		}
 
-		BeforeEach(func() {
-			domain = "k8s-gateway.nginx.org"
-			gatewayCtlrName = "gateway-ctlr-name"
-
-			mockFlags = flag.NewFlagSet("mock", flag.PanicOnError)
-			_ = mockFlags.String("gateway-ctlr-name", "", "mock gateway-ctlr-name")
-			err := mockFlags.Parse([]string{})
-			Expect(err).ToNot(HaveOccurred())
-		})
-		AfterEach(func() {
-			mockFlags = nil
-		})
-		It("should parse full gateway-ctlr-name", func() {
-			t := testCase{
-				"k8s-gateway.nginx.org/nginx-gateway/my-gateway",
-				"nginx-gateway",
-				false,
-			}
-			tester(t)
-		}) // should parse full gateway-ctlr-name
-
-		It("should fail with too many path elements", func() {
-			t := testCase{
-				"k8s-gateway.nginx.org/nginx-gateway/my-gateway/broken",
-				"nginx-gateway",
-				true,
-			}
-			tester(t)
-		}) // should fail with too many path elements
-
-		It("should fail with too few path elements", func() {
-			table := []testCase{
-				{
-					Param:    "nginx-gateway/my-gateway",
-					Domain:   "nginx-gateway",
-					ExpError: true,
-				},
-				{
-					Param:    "my-gateway",
-					Domain:   "nginx-gateway",
-					ExpError: true,
-				},
+		Describe("gateway-ctlr-name validation", func() {
+			prepareTestCase := func(value string, expError bool) testCase {
+				return testCase{
+					Flag:             "gateway-ctlr-name",
+					Value:            value,
+					ValidatorContext: GatewayControllerParam("k8s-gateway.nginx.org", "nginx-gateway"),
+					ExpError:         expError,
+				}
 			}
 
-			runner(table)
-		}) // should fail with too few path elements
+			BeforeEach(func() {
+				mockFlags = flag.NewFlagSet("mock", flag.PanicOnError)
+				_ = mockFlags.String("gateway-ctlr-name", "", "mock gateway-ctlr-name")
+				err := mockFlags.Parse([]string{})
+				Expect(err).ToNot(HaveOccurred())
+			})
+			AfterEach(func() {
+				mockFlags = nil
+			})
 
-		It("should verify constraints", func() {
-			table := []testCase{
-				{
-					// bad domain
-					Param:    "invalid-domain/nginx-gateway/my-gateway",
-					Domain:   "nginx-gateway",
-					ExpError: true,
-				},
-				{
-					// bad domain
-					Param:    "/default/my-gateway",
-					Domain:   "nginx-gateway",
-					ExpError: true,
-				},
-				{
-					// bad namespace
-					Param:    "k8s-gateway.nginx.org/default/my-gateway",
-					Domain:   "nginx-gateway",
-					ExpError: true,
-				},
-				{
-					// bad namespace
-					Param:    "k8s-gateway.nginx.org//my-gateway",
-					Domain:   "nginx-gateway",
-					ExpError: true,
-				},
-				{
-					// bad name
-					Param:    "k8s-gateway.nginx.org/default/",
-					Domain:   "nginx-gateway",
-					ExpError: true,
-				},
+			It("should parse full gateway-ctlr-name", func() {
+				t := prepareTestCase(
+					"k8s-gateway.nginx.org/nginx-gateway/my-gateway",
+					expectSuccess,
+				)
+				tester(t)
+			}) // should parse full gateway-ctlr-name
+
+			It("should fail with too many path elements", func() {
+				t := prepareTestCase(
+					"k8s-gateway.nginx.org/nginx-gateway/my-gateway",
+					expectSuccess)
+				tester(t)
+			}) // should fail with too many path elements
+
+			It("should fail with too few path elements", func() {
+				table := []testCase{
+					prepareTestCase(
+						"nginx-gateway/my-gateway",
+						expectError,
+					),
+					prepareTestCase(
+						"my-gateway",
+						expectError,
+					),
+				}
+
+				runner(table)
+			}) // should fail with too few path elements
+
+			It("should verify constraints", func() {
+				table := []testCase{
+					prepareTestCase(
+						// bad domain
+						"invalid-domain/nginx-gateway/my-gateway",
+						expectError,
+					),
+					prepareTestCase(
+						// bad domain
+						"/default/my-gateway",
+						expectError,
+					),
+					prepareTestCase(
+						// bad namespace
+						"k8s-gateway.nginx.org/default/my-gateway",
+						expectError),
+					prepareTestCase(
+						// bad namespace
+						"k8s-gateway.nginx.org//my-gateway",
+						expectError,
+					),
+					prepareTestCase(
+						// bad name
+						"k8s-gateway.nginx.org/default/",
+						expectError,
+					),
+				}
+
+				runner(table)
+			}) // should verify constraints
+		}) // gateway-ctlr-name validation
+
+		Describe("gatewayclass validation", func() {
+			prepareTestCase := func(value string, expError bool) testCase {
+				return testCase{
+					Flag:             "gatewayclass",
+					Value:            value,
+					ValidatorContext: GatewayClassParam(),
+					ExpError:         expError,
+				}
 			}
 
-			runner(table)
-		}) // should verify constraints
+			BeforeEach(func() {
+				mockFlags = flag.NewFlagSet("mock", flag.PanicOnError)
+				_ = mockFlags.String("gatewayclass", "", "mock gatewayclass")
+				err := mockFlags.Parse([]string{})
+				Expect(err).ToNot(HaveOccurred())
+			})
+			AfterEach(func() {
+				mockFlags = nil
+			})
+
+			It("should succeed on valid name", func() {
+				t := prepareTestCase(
+					"nginx",
+					expectSuccess,
+				)
+				tester(t)
+			}) // should succeed on valid name
+
+			It("should fail with invalid name", func() {
+				t := prepareTestCase(
+					"$nginx",
+					expectError)
+				tester(t)
+			}) // should fail with invalid name"
+		}) // gatewayclass validation
 	}) // CLI argument validation
 }) // end Main

--- a/cmd/gateway/setup_test.go
+++ b/cmd/gateway/setup_test.go
@@ -181,8 +181,8 @@ var _ = Describe("Main", func() {
 
 			It("should fail with too many path elements", func() {
 				t := prepareTestCase(
-					"k8s-gateway.nginx.org/nginx-gateway/my-gateway",
-					expectSuccess)
+					"k8s-gateway.nginx.org/nginx-gateway/my-gateway/broken",
+					expectError)
 				tester(t)
 			}) // should fail with too many path elements
 

--- a/deploy/manifests/nginx-gateway.yaml
+++ b/deploy/manifests/nginx-gateway.yaml
@@ -37,6 +37,7 @@ rules:
   resources:
   - httproutes/status
   - gateways/status
+  - gatewayclasses/status
   verbs:
   - update
 ---
@@ -97,6 +98,7 @@ spec:
           # Note: CAP_KILL is needed for sending HUP signal to NGINX main process
         args:
         - --gateway-ctlr-name=k8s-gateway.nginx.org/nginx-gateway/gateway
+        - --gatewayclass=nginx
       - image: nginx:1.21.3
         imagePullPolicy: IfNotPresent
         name: nginx

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,4 +11,6 @@ type Config struct {
 	// GatewayNsName is the namespaced name of a Gateway resource that the Gateway will use.
 	// The Gateway will ignore all other Gateway resources.
 	GatewayNsName types.NamespacedName
+	// GatewayClassName is the name of the GatewayClass resource that the Gateway will use.
+	GatewayClassName string
 }

--- a/internal/events/loop.go
+++ b/internal/events/loop.go
@@ -118,6 +118,8 @@ func (el *EventLoop) updateNginx(ctx context.Context, conf state.Configuration) 
 
 func (el *EventLoop) propagateUpsert(e *UpsertEvent) {
 	switch r := e.Resource.(type) {
+	case *v1alpha2.GatewayClass:
+		el.processor.CaptureUpsertChange(r)
 	case *v1alpha2.Gateway:
 		el.processor.CaptureUpsertChange(r)
 	case *v1alpha2.HTTPRoute:
@@ -132,6 +134,8 @@ func (el *EventLoop) propagateUpsert(e *UpsertEvent) {
 
 func (el *EventLoop) propagateDelete(e *DeleteEvent) {
 	switch e.Type.(type) {
+	case *v1alpha2.GatewayClass:
+		el.processor.CaptureDeleteChange(e.Type, e.NamespacedName)
 	case *v1alpha2.Gateway:
 		el.processor.CaptureDeleteChange(e.Type, e.NamespacedName)
 	case *v1alpha2.HTTPRoute:

--- a/internal/events/loop_test.go
+++ b/internal/events/loop_test.go
@@ -112,6 +112,7 @@ var _ = Describe("EventLoop", func() {
 			},
 			Entry("HTTPRoute", &events.UpsertEvent{Resource: &v1alpha2.HTTPRoute{}}),
 			Entry("Gateway", &events.UpsertEvent{Resource: &v1alpha2.Gateway{}}),
+			Entry("GatewayClass", &events.UpsertEvent{Resource: &v1alpha2.GatewayClass{}}),
 		)
 
 		DescribeTable("Delete events",
@@ -141,6 +142,7 @@ var _ = Describe("EventLoop", func() {
 			},
 			Entry("HTTPRoute", &events.DeleteEvent{Type: &v1alpha2.HTTPRoute{}, NamespacedName: types.NamespacedName{Namespace: "test", Name: "route"}}),
 			Entry("Gateway", &events.DeleteEvent{Type: &v1alpha2.Gateway{}, NamespacedName: types.NamespacedName{Namespace: "test", Name: "gateway"}}),
+			Entry("GatewayClass", &events.DeleteEvent{Type: &v1alpha2.GatewayClass{}, NamespacedName: types.NamespacedName{Name: "class"}}),
 		)
 	})
 

--- a/internal/implementations/gatewayclass/gatewayclass.go
+++ b/internal/implementations/gatewayclass/gatewayclass.go
@@ -1,44 +1,64 @@
 package implementation
 
 import (
+	"fmt"
+
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/config"
+	"github.com/nginxinc/nginx-kubernetes-gateway/internal/events"
 	"github.com/nginxinc/nginx-kubernetes-gateway/pkg/sdk"
 )
 
 type gatewayClassImplementation struct {
-	conf config.Config
+	logger           logr.Logger
+	gatewayClassName string
+	eventCh          chan<- interface{}
 }
 
-func NewGatewayClassImplementation(conf config.Config) sdk.GatewayClassImpl {
+func NewGatewayClassImplementation(conf config.Config, eventCh chan<- interface{}) sdk.GatewayClassImpl {
 	return &gatewayClassImplementation{
-		conf: conf,
+		logger:           conf.Logger,
+		gatewayClassName: conf.GatewayClassName,
+		eventCh:          eventCh,
 	}
-}
-
-func (impl *gatewayClassImplementation) Logger() logr.Logger {
-	return impl.conf.Logger
-}
-
-func (impl *gatewayClassImplementation) ControllerName() string {
-	return impl.conf.GatewayCtlrName
 }
 
 func (impl *gatewayClassImplementation) Upsert(gc *v1alpha2.GatewayClass) {
-	if string(gc.Spec.ControllerName) != impl.ControllerName() {
-		impl.Logger().Info("Wrong ControllerName in the GatewayClass resource",
-			"expected", impl.ControllerName(),
-			"got", gc.Spec.ControllerName)
+	if gc.Name != impl.gatewayClassName {
+		msg := fmt.Sprintf("GatewayClass was upserted but ignored because this controller only supports the GatewayClass %s", impl.gatewayClassName)
+		impl.logger.Info(msg,
+			"name", gc.Name,
+		)
 		return
 	}
 
-	impl.Logger().Info("Processing GatewayClass resource",
+	impl.eventCh <- &events.UpsertEvent{
+		Resource: gc,
+	}
+
+	impl.logger.Info("GatewayClass was upserted",
 		"name", gc.Name)
 }
 
-func (impl *gatewayClassImplementation) Remove(key string) {
-	impl.Logger().Info("GatewayClass resource was removed",
-		"name", key)
+func (impl *gatewayClassImplementation) Remove(nsname types.NamespacedName) {
+	// GatewayClass is a cluster scoped resource - no namespace.
+
+	if nsname.Name != impl.gatewayClassName {
+		msg := fmt.Sprintf("GatewayClass was removed but ignored because this controller only supports the GatewayClass %s", impl.gatewayClassName)
+		impl.logger.Info(msg,
+			"name", nsname.Name,
+		)
+		return
+	}
+
+	impl.logger.Info("GatewayClass was removed",
+		"name", nsname.Name)
+
+	impl.eventCh <- &events.DeleteEvent{
+		NamespacedName: nsname,
+		Type:           &v1alpha2.GatewayClass{},
+	}
 }

--- a/internal/implementations/gatewayclass/gatewayclass_test.go
+++ b/internal/implementations/gatewayclass/gatewayclass_test.go
@@ -1,0 +1,88 @@
+package implementation_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/nginxinc/nginx-kubernetes-gateway/internal/config"
+	"github.com/nginxinc/nginx-kubernetes-gateway/internal/events"
+	implementation "github.com/nginxinc/nginx-kubernetes-gateway/internal/implementations/gatewayclass"
+	"github.com/nginxinc/nginx-kubernetes-gateway/pkg/sdk"
+)
+
+var _ = Describe("GatewayClassImplementation", func() {
+	var (
+		eventCh chan interface{}
+		impl    sdk.GatewayClassImpl
+	)
+
+	const (
+		className          = "my-class"
+		unrelatedClassName = "not-my-class"
+	)
+
+	BeforeEach(func() {
+		eventCh = make(chan interface{})
+
+		impl = implementation.NewGatewayClassImplementation(config.Config{
+			Logger:           zap.New(),
+			GatewayClassName: className,
+		}, eventCh)
+	})
+
+	Describe("Implementation processes GatewayClass", func() {
+		It("should process upsert", func() {
+			gc := &v1alpha2.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: className,
+				},
+			}
+
+			go func() {
+				impl.Upsert(gc)
+			}()
+
+			Eventually(eventCh).Should(Receive(Equal(&events.UpsertEvent{Resource: gc})))
+		})
+
+		It("should process remove", func() {
+			nsname := types.NamespacedName{Name: className}
+
+			go func() {
+				impl.Remove(nsname)
+			}()
+
+			Eventually(eventCh).Should(Receive(Equal(
+				&events.DeleteEvent{
+					NamespacedName: nsname,
+					Type:           &v1alpha2.GatewayClass{},
+				})))
+		})
+	})
+
+	Describe("Implementation ignores unrelated GatewayClass", func() {
+		It("should ignore upsert", func() {
+			gc := &v1alpha2.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: unrelatedClassName,
+				},
+			}
+
+			impl.Upsert(gc)
+
+			Expect(eventCh).ShouldNot(Receive())
+		})
+
+		It("should ignore remove", func() {
+			nsname := types.NamespacedName{Name: unrelatedClassName}
+
+			impl.Remove(nsname)
+
+			Expect(eventCh).ShouldNot(Receive())
+		})
+	})
+})

--- a/internal/implementations/gatewayclass/implementation_suit_test.go
+++ b/internal/implementations/gatewayclass/implementation_suit_test.go
@@ -1,0 +1,13 @@
+package implementation_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestState(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Implementation Suite")
+}

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -69,7 +69,11 @@ func Start(cfg config.Config) error {
 		return fmt.Errorf("cannot register service implementation: %w", err)
 	}
 
-	processor := state.NewChangeProcessorImpl(cfg.GatewayNsName, cfg.GatewayCtlrName, cfg.GatewayClassName)
+	processor := state.NewChangeProcessorImpl(state.ChangeProcessorConfig{
+		GatewayNsName:    cfg.GatewayNsName,
+		GatewayCtlrName:  cfg.GatewayCtlrName,
+		GatewayClassName: cfg.GatewayClassName,
+	})
 	serviceStore := state.NewServiceStore()
 	configGenerator := ngxcfg.NewGeneratorImpl(serviceStore)
 	nginxFileMgr := file.NewManagerImpl()

--- a/internal/state/change_processor.go
+++ b/internal/state/change_processor.go
@@ -29,23 +29,29 @@ type ChangeProcessor interface {
 	Process() (changed bool, conf Configuration, statuses Statuses)
 }
 
+// ChangeProcessorConfig holds configuration parameters for ChangeProcessorImpl.
+type ChangeProcessorConfig struct {
+	// GatewayNsName is the namespaced name of the Gateway resource.
+	GatewayNsName types.NamespacedName
+	// GatewayCtlrName is the name of the Gateway controller.
+	GatewayCtlrName string
+	// GatewayClassName is the name of the GatewayClass resource.
+	GatewayClassName string
+}
+
 type ChangeProcessorImpl struct {
-	store          *store
-	changed        bool
-	gwNsName       types.NamespacedName
-	controllerName string
-	gcName         string
+	store   *store
+	changed bool
+	cfg     ChangeProcessorConfig
 
 	lock sync.Mutex
 }
 
 // NewChangeProcessorImpl creates a new ChangeProcessorImpl for the Gateway resource with the configured namespace name.
-func NewChangeProcessorImpl(gwNsName types.NamespacedName, controllerName string, gcName string) *ChangeProcessorImpl {
+func NewChangeProcessorImpl(cfg ChangeProcessorConfig) *ChangeProcessorImpl {
 	return &ChangeProcessorImpl{
-		store:          newStore(),
-		gwNsName:       gwNsName,
-		controllerName: controllerName,
-		gcName:         gcName,
+		store: newStore(),
+		cfg:   cfg,
 	}
 }
 
@@ -57,8 +63,8 @@ func (c *ChangeProcessorImpl) CaptureUpsertChange(obj client.Object) {
 
 	switch o := obj.(type) {
 	case *v1alpha2.GatewayClass:
-		if o.Name != c.gcName {
-			panic(fmt.Errorf("gatewayclass resource must be %s, got %s", c.gcName, o.Name))
+		if o.Name != c.cfg.GatewayClassName {
+			panic(fmt.Errorf("gatewayclass resource must be %s, got %s", c.cfg.GatewayClassName, o.Name))
 		}
 		// if the resource spec hasn't changed (its generation is the same), ignore the upsert
 		if c.store.gc != nil && c.store.gc.Generation == o.Generation {
@@ -66,8 +72,8 @@ func (c *ChangeProcessorImpl) CaptureUpsertChange(obj client.Object) {
 		}
 		c.store.gc = o
 	case *v1alpha2.Gateway:
-		if o.Namespace != c.gwNsName.Namespace || o.Name != c.gwNsName.Name {
-			panic(fmt.Errorf("gateway resource must be %s/%s, got %s/%s", c.gwNsName.Namespace, c.gwNsName.Name, o.Namespace, o.Name))
+		if o.Namespace != c.cfg.GatewayNsName.Namespace || o.Name != c.cfg.GatewayNsName.Name {
+			panic(fmt.Errorf("gateway resource must be %s/%s, got %s/%s", c.cfg.GatewayNsName.Namespace, c.cfg.GatewayNsName.Name, o.Namespace, o.Name))
 		}
 		// if the resource spec hasn't changed (its generation is the same), ignore the upsert
 		if c.store.gw != nil && c.store.gw.Generation == o.Generation {
@@ -94,13 +100,13 @@ func (c *ChangeProcessorImpl) CaptureDeleteChange(resourceType client.Object, ns
 
 	switch o := resourceType.(type) {
 	case *v1alpha2.GatewayClass:
-		if nsname.Name != c.gcName {
-			panic(fmt.Errorf("gatewayclass resource must be %s, got %s", c.gcName, nsname.Name))
+		if nsname.Name != c.cfg.GatewayClassName {
+			panic(fmt.Errorf("gatewayclass resource must be %s, got %s", c.cfg.GatewayClassName, nsname.Name))
 		}
 		c.store.gc = nil
 	case *v1alpha2.Gateway:
-		if nsname != c.gwNsName {
-			panic(fmt.Errorf("gateway resource must be %s/%s, got %s/%s", c.gwNsName.Namespace, c.gwNsName.Name, o.Namespace, o.Name))
+		if nsname != c.cfg.GatewayNsName {
+			panic(fmt.Errorf("gateway resource must be %s/%s, got %s/%s", c.cfg.GatewayNsName.Namespace, c.cfg.GatewayNsName.Name, o.Namespace, o.Name))
 		}
 		c.store.gw = nil
 	case *v1alpha2.HTTPRoute:
@@ -120,7 +126,7 @@ func (c *ChangeProcessorImpl) Process() (changed bool, conf Configuration, statu
 
 	c.changed = false
 
-	graph := buildGraph(c.store, c.gwNsName, c.controllerName, c.gcName)
+	graph := buildGraph(c.store, c.cfg.GatewayNsName, c.cfg.GatewayCtlrName, c.cfg.GatewayClassName)
 
 	conf = buildConfiguration(graph)
 	statuses = buildStatuses(graph)

--- a/internal/state/change_processor_test.go
+++ b/internal/state/change_processor_test.go
@@ -102,7 +102,13 @@ var _ = Describe("ChangeProcessor", func() {
 			gwUpdated = gw.DeepCopy()
 			gwUpdated.Generation++
 
-			processor = state.NewChangeProcessorImpl(types.NamespacedName{Namespace: "test", Name: "gateway"}, controllerName, gcName)
+			cfg := state.ChangeProcessorConfig{
+				GatewayNsName:    types.NamespacedName{Namespace: "test", Name: "gateway"},
+				GatewayCtlrName:  controllerName,
+				GatewayClassName: gcName,
+			}
+
+			processor = state.NewChangeProcessorImpl(cfg)
 		})
 
 		Describe("Process resources", Ordered, func() {
@@ -583,7 +589,12 @@ var _ = Describe("ChangeProcessor", func() {
 		var processor state.ChangeProcessor
 
 		BeforeEach(func() {
-			processor = state.NewChangeProcessorImpl(types.NamespacedName{Namespace: "test", Name: "gateway"}, "test.controller", "my-class")
+			cfg := state.ChangeProcessorConfig{
+				GatewayNsName:    types.NamespacedName{Namespace: "test", Name: "gateway"},
+				GatewayCtlrName:  "test.controller",
+				GatewayClassName: "my-class",
+			}
+			processor = state.NewChangeProcessorImpl(cfg)
 		})
 
 		DescribeTable("CaptureUpsertChange must panic",

--- a/internal/state/configuration.go
+++ b/internal/state/configuration.go
@@ -50,6 +50,10 @@ func (r *MatchRule) GetMatch() v1alpha2.HTTPRouteMatch {
 
 // buildConfiguration builds the Configuration from the graph.
 func buildConfiguration(graph *graph) Configuration {
+	if graph.GatewayClass == nil || !graph.GatewayClass.Valid {
+		return Configuration{}
+	}
+
 	// FIXME(pleshakov) For now we only handle paths with prefix matches. Handle exact and regex matches
 	pathRulesForHosts := make(map[string]map[string]PathRule)
 

--- a/internal/state/configuration_test.go
+++ b/internal/state/configuration_test.go
@@ -96,16 +96,24 @@ func TestBuildConfiguration(t *testing.T) {
 	}{
 		{
 			graph: &graph{
+				GatewayClass: &gatewayClass{
+					Source: &v1alpha2.GatewayClass{},
+					Valid:  true,
+				},
 				Listeners: map[string]*listener{},
 				Routes:    map[types.NamespacedName]*route{},
 			},
 			expected: Configuration{
 				HTTPServers: []HTTPServer{},
 			},
-			msg: "empty graph",
+			msg: "no listeners and routes",
 		},
 		{
 			graph: &graph{
+				GatewayClass: &gatewayClass{
+					Source: &v1alpha2.GatewayClass{},
+					Valid:  true,
+				},
 				Listeners: map[string]*listener{
 					"listener-80-1": {
 						Valid:             true,
@@ -122,6 +130,10 @@ func TestBuildConfiguration(t *testing.T) {
 		},
 		{
 			graph: &graph{
+				GatewayClass: &gatewayClass{
+					Source: &v1alpha2.GatewayClass{},
+					Valid:  true,
+				},
 				Listeners: map[string]*listener{
 					"listener-80-1": {
 						Valid: true,
@@ -178,6 +190,10 @@ func TestBuildConfiguration(t *testing.T) {
 		},
 		{
 			graph: &graph{
+				GatewayClass: &gatewayClass{
+					Source: &v1alpha2.GatewayClass{},
+					Valid:  true,
+				},
 				Listeners: map[string]*listener{
 					"listener-80-1": {
 						Valid: true,
@@ -240,6 +256,52 @@ func TestBuildConfiguration(t *testing.T) {
 				},
 			},
 			msg: "one listener with two routes with the same hostname with and without collisions",
+		},
+		{
+			graph: &graph{
+				GatewayClass: &gatewayClass{
+					Source:   &v1alpha2.GatewayClass{},
+					Valid:    false,
+					ErrorMsg: "error",
+				},
+				Listeners: map[string]*listener{
+					"listener-80-1": {
+						Valid: true,
+						Routes: map[types.NamespacedName]*route{
+							{Namespace: "test", Name: "hr-1"}: routeHR1,
+						},
+						AcceptedHostnames: map[string]struct{}{
+							"foo.example.com": {},
+						},
+					},
+				},
+				Routes: map[types.NamespacedName]*route{
+					{Namespace: "test", Name: "hr-1"}: routeHR1,
+				},
+			},
+			expected: Configuration{},
+			msg:      "invalid gatewayclass",
+		},
+		{
+			graph: &graph{
+				GatewayClass: nil,
+				Listeners: map[string]*listener{
+					"listener-80-1": {
+						Valid: true,
+						Routes: map[types.NamespacedName]*route{
+							{Namespace: "test", Name: "hr-1"}: routeHR1,
+						},
+						AcceptedHostnames: map[string]struct{}{
+							"foo.example.com": {},
+						},
+					},
+				},
+				Routes: map[types.NamespacedName]*route{
+					{Namespace: "test", Name: "hr-1"}: routeHR1,
+				},
+			},
+			expected: Configuration{},
+			msg:      "missing gatewayclass",
 		},
 	}
 

--- a/internal/state/statuses_test.go
+++ b/internal/state/statuses_test.go
@@ -4,53 +4,146 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 func TestBuildStatuses(t *testing.T) {
-	g := &graph{
-		Listeners: map[string]*listener{
-			"listener-80-1": {
-				Valid: true,
-				Routes: map[types.NamespacedName]*route{
-					{Namespace: "test", Name: "hr-1"}: {}},
-			},
+	listeners := map[string]*listener{
+		"listener-80-1": {
+			Valid: true,
+			Routes: map[types.NamespacedName]*route{
+				{Namespace: "test", Name: "hr-1"}: {}},
 		},
-		Routes: map[types.NamespacedName]*route{
-			{Namespace: "test", Name: "hr-1"}: {
-				ValidSectionNameRefs: map[string]struct{}{
-					"listener-80-1": {},
-				},
-				InvalidSectionNameRefs: map[string]struct{}{
-					"listener-80-2": {},
-				},
+	}
+
+	routes := map[types.NamespacedName]*route{
+		{Namespace: "test", Name: "hr-1"}: {
+			ValidSectionNameRefs: map[string]struct{}{
+				"listener-80-1": {},
+			},
+			InvalidSectionNameRefs: map[string]struct{}{
+				"listener-80-2": {},
 			},
 		},
 	}
 
-	expected := Statuses{
-		ListenerStatuses: map[string]ListenerStatus{
-			"listener-80-1": {
-				Valid:          true,
-				AttachedRoutes: 1,
+	tests := []struct {
+		graph    *graph
+		expected Statuses
+		msg      string
+	}{
+		{
+			graph: &graph{
+				GatewayClass: &gatewayClass{
+					Source: &v1alpha2.GatewayClass{
+						ObjectMeta: metav1.ObjectMeta{Generation: 1},
+					},
+					Valid: true,
+				},
+				Listeners: listeners,
+				Routes:    routes,
 			},
-		},
-		HTTPRouteStatuses: map[types.NamespacedName]HTTPRouteStatus{
-			{Namespace: "test", Name: "hr-1"}: {
-				ParentStatuses: map[string]ParentStatus{
+			expected: Statuses{
+				GatewayClassStatus: &GatewayClassStatus{
+					Valid:              true,
+					ObservedGeneration: 1,
+				},
+				ListenerStatuses: map[string]ListenerStatus{
 					"listener-80-1": {
-						Attached: true,
+						Valid:          true,
+						AttachedRoutes: 1,
 					},
-					"listener-80-2": {
-						Attached: false,
+				},
+				HTTPRouteStatuses: map[types.NamespacedName]HTTPRouteStatus{
+					{Namespace: "test", Name: "hr-1"}: {
+						ParentStatuses: map[string]ParentStatus{
+							"listener-80-1": {
+								Attached: true,
+							},
+							"listener-80-2": {
+								Attached: false,
+							},
+						},
 					},
 				},
 			},
+			msg: "normal case",
+		},
+		{
+			graph: &graph{
+				GatewayClass: nil,
+				Listeners:    listeners,
+				Routes:       routes,
+			},
+			expected: Statuses{
+				ListenerStatuses: map[string]ListenerStatus{
+					"listener-80-1": {
+						Valid:          false,
+						AttachedRoutes: 1,
+					},
+				},
+				HTTPRouteStatuses: map[types.NamespacedName]HTTPRouteStatus{
+					{Namespace: "test", Name: "hr-1"}: {
+						ParentStatuses: map[string]ParentStatus{
+							"listener-80-1": {
+								Attached: false,
+							},
+							"listener-80-2": {
+								Attached: false,
+							},
+						},
+					},
+				},
+			},
+			msg: "gatewayclass doesn't exist",
+		},
+		{
+			graph: &graph{
+				GatewayClass: &gatewayClass{
+					Source: &v1alpha2.GatewayClass{
+						ObjectMeta: metav1.ObjectMeta{Generation: 1},
+					},
+					Valid:    false,
+					ErrorMsg: "error",
+				},
+				Listeners: listeners,
+				Routes:    routes,
+			},
+			expected: Statuses{
+				GatewayClassStatus: &GatewayClassStatus{
+					Valid:              false,
+					ErrorMsg:           "error",
+					ObservedGeneration: 1,
+				},
+				ListenerStatuses: map[string]ListenerStatus{
+					"listener-80-1": {
+						Valid:          false,
+						AttachedRoutes: 1,
+					},
+				},
+				HTTPRouteStatuses: map[types.NamespacedName]HTTPRouteStatus{
+					{Namespace: "test", Name: "hr-1"}: {
+						ParentStatuses: map[string]ParentStatus{
+							"listener-80-1": {
+								Attached: false,
+							},
+							"listener-80-2": {
+								Attached: false,
+							},
+						},
+					},
+				},
+			},
+			msg: "gatewayclass is not valid",
 		},
 	}
 
-	result := buildStatuses(g)
-	if diff := cmp.Diff(expected, result); diff != "" {
-		t.Errorf("buildStatuses() mismatch (-want +got):\n%s", diff)
+	for _, test := range tests {
+		result := buildStatuses(test.graph)
+		if diff := cmp.Diff(test.expected, result); diff != "" {
+			t.Errorf("buildStatuses() '%v' mismatch (-want +got):\n%s", test.msg, diff)
+		}
 	}
 }

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -7,6 +7,7 @@ import (
 
 // store contains the resources that represent the state of the Gateway.
 type store struct {
+	gc         *v1alpha2.GatewayClass
 	gw         *v1alpha2.Gateway
 	httpRoutes map[types.NamespacedName]*v1alpha2.HTTPRoute
 }

--- a/internal/status/gatewayclass.go
+++ b/internal/status/gatewayclass.go
@@ -1,0 +1,39 @@
+package status
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state"
+)
+
+// prepareGatewayClassStatus prepares the status for the GatewayClass resource.
+func prepareGatewayClassStatus(status state.GatewayClassStatus, transitionTime metav1.Time) v1alpha2.GatewayClassStatus {
+	var (
+		condStatus metav1.ConditionStatus
+		msg        string
+	)
+
+	if status.Valid {
+		condStatus = metav1.ConditionTrue
+		msg = "GatewayClass has been accepted"
+	} else {
+		condStatus = metav1.ConditionFalse
+		msg = fmt.Sprintf("GatewayClass has been rejected: %s", status.ErrorMsg)
+	}
+
+	cond := metav1.Condition{
+		Type:               string(v1alpha2.GatewayClassConditionStatusAccepted),
+		Status:             condStatus,
+		ObservedGeneration: status.ObservedGeneration,
+		LastTransitionTime: transitionTime,
+		Reason:             string(v1alpha2.GatewayClassReasonAccepted),
+		Message:            msg,
+	}
+
+	return v1alpha2.GatewayClassStatus{
+		Conditions: []metav1.Condition{cond},
+	}
+}

--- a/internal/status/gatewayclass_test.go
+++ b/internal/status/gatewayclass_test.go
@@ -1,0 +1,69 @@
+package status
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state"
+)
+
+func TestPrepareGatewayClassStatus(t *testing.T) {
+	transitionTime := metav1.NewTime(time.Now())
+
+	tests := []struct {
+		status   state.GatewayClassStatus
+		expected v1alpha2.GatewayClassStatus
+		msg      string
+	}{
+		{
+			status: state.GatewayClassStatus{
+				Valid:              true,
+				ObservedGeneration: 1,
+			},
+			expected: v1alpha2.GatewayClassStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(v1alpha2.GatewayClassConditionStatusAccepted),
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: 1,
+						LastTransitionTime: transitionTime,
+						Reason:             string(v1alpha2.GatewayClassReasonAccepted),
+						Message:            "GatewayClass has been accepted",
+					},
+				},
+			},
+			msg: "valid GatewayClass",
+		},
+		{
+			status: state.GatewayClassStatus{
+				Valid:              false,
+				ErrorMsg:           "error",
+				ObservedGeneration: 2,
+			},
+			expected: v1alpha2.GatewayClassStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(v1alpha2.GatewayClassConditionStatusAccepted),
+						Status:             metav1.ConditionFalse,
+						ObservedGeneration: 2,
+						LastTransitionTime: transitionTime,
+						Reason:             string(v1alpha2.GatewayClassReasonAccepted),
+						Message:            "GatewayClass has been rejected: error",
+					},
+				},
+			},
+			msg: "invalid GatewayClass",
+		},
+	}
+
+	for _, test := range tests {
+		result := prepareGatewayClassStatus(test.status, transitionTime)
+		if diff := cmp.Diff(test.expected, result); diff != "" {
+			t.Errorf("prepareGatewayClassStatus() '%s' mismatch (-want +got):\n%s", test.msg, diff)
+		}
+	}
+}

--- a/internal/status/updater.go
+++ b/internal/status/updater.go
@@ -20,6 +20,22 @@ type Updater interface {
 	Update(context.Context, state.Statuses)
 }
 
+// UpdaterConfig holds configuration parameters for Updater.
+type UpdaterConfig struct {
+	// GatewayNsName is the namespaced name of the Gateway resource.
+	GatewayNsName types.NamespacedName
+	// GatewayCtlrName is the name of the Gateway controller.
+	GatewayCtlrName string
+	// GatewayClassName is the name of the GatewayClass resource.
+	GatewayClassName string
+	// Client is a Kubernetes API client.
+	Client client.Client
+	// Logger holds a logger to be used.
+	Logger logr.Logger
+	// Clock is used as a source of time for the LastTransitionTime field in Conditions in resource statuses.
+	Clock Clock
+}
+
 // updaterImpl updates statuses of the Gateway API resources.
 //
 // It has the following limitations:
@@ -58,30 +74,13 @@ type Updater interface {
 // goes along the Open-closed principle.
 // FIXME(pleshakov): address limitation (7)
 type updaterImpl struct {
-	gatewayCtlrName string
-	gwNsName        types.NamespacedName
-	gcName          string
-	client          client.Client
-	logger          logr.Logger
-	clock           Clock
+	cfg UpdaterConfig
 }
 
 // NewUpdater creates a new Updater.
-func NewUpdater(
-	gatewayCtlrName string,
-	gwNsName types.NamespacedName,
-	gcName string,
-	client client.Client,
-	logger logr.Logger,
-	clock Clock,
-) Updater {
+func NewUpdater(cfg UpdaterConfig) Updater {
 	return &updaterImpl{
-		gatewayCtlrName: gatewayCtlrName,
-		gwNsName:        gwNsName,
-		gcName:          gcName,
-		client:          client,
-		logger:          logger.WithName("statusUpdater"),
-		clock:           clock,
+		cfg: cfg,
 	}
 }
 
@@ -90,15 +89,15 @@ func (upd *updaterImpl) Update(ctx context.Context, statuses state.Statuses) {
 	// FIXME(pleshakov) Skip the status update (API call) if the status hasn't changed.
 
 	if statuses.GatewayClassStatus != nil {
-		upd.update(ctx, types.NamespacedName{Name: upd.gcName}, &v1alpha2.GatewayClass{}, func(object client.Object) {
+		upd.update(ctx, types.NamespacedName{Name: upd.cfg.GatewayClassName}, &v1alpha2.GatewayClass{}, func(object client.Object) {
 			gc := object.(*v1alpha2.GatewayClass)
-			gc.Status = prepareGatewayClassStatus(*statuses.GatewayClassStatus, upd.clock.Now())
+			gc.Status = prepareGatewayClassStatus(*statuses.GatewayClassStatus, upd.cfg.Clock.Now())
 		})
 	}
 
-	upd.update(ctx, upd.gwNsName, &v1alpha2.Gateway{}, func(object client.Object) {
+	upd.update(ctx, upd.cfg.GatewayNsName, &v1alpha2.Gateway{}, func(object client.Object) {
 		gw := object.(*v1alpha2.Gateway)
-		gw.Status = prepareGatewayStatus(statuses.ListenerStatuses, upd.clock.Now())
+		gw.Status = prepareGatewayStatus(statuses.ListenerStatuses, upd.cfg.Clock.Now())
 	})
 
 	for nsname, rs := range statuses.HTTPRouteStatuses {
@@ -110,7 +109,7 @@ func (upd *updaterImpl) Update(ctx context.Context, statuses state.Statuses) {
 
 		upd.update(ctx, nsname, &v1alpha2.HTTPRoute{}, func(object client.Object) {
 			hr := object.(*v1alpha2.HTTPRoute)
-			hr.Status = prepareHTTPRouteStatus(rs, upd.gwNsName, upd.gatewayCtlrName, upd.clock.Now())
+			hr.Status = prepareHTTPRouteStatus(rs, upd.cfg.GatewayNsName, upd.cfg.GatewayCtlrName, upd.cfg.Clock.Now())
 		})
 	}
 }
@@ -123,10 +122,10 @@ func (upd *updaterImpl) update(ctx context.Context, nsname types.NamespacedName,
 	// Otherwise, the Update status API call can fail.
 	// Note: the default client uses a cache for reads, so we're not making an unnecessary API call here.
 	// the default is configurable in the Manager options.
-	err := upd.client.Get(ctx, nsname, obj)
+	err := upd.cfg.Client.Get(ctx, nsname, obj)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			upd.logger.Error(err, "Failed to get the recent version the resource when updating status",
+			upd.cfg.Logger.Error(err, "Failed to get the recent version the resource when updating status",
 				"namespace", nsname.Namespace,
 				"name", nsname.Name,
 				"kind", obj.GetObjectKind().GroupVersionKind().Kind)
@@ -136,9 +135,9 @@ func (upd *updaterImpl) update(ctx context.Context, nsname types.NamespacedName,
 
 	statusSetter(obj)
 
-	err = upd.client.Status().Update(ctx, obj)
+	err = upd.cfg.Client.Status().Update(ctx, obj)
 	if err != nil {
-		upd.logger.Error(err, "Failed to update status",
+		upd.cfg.Logger.Error(err, "Failed to update status",
 			"namespace", nsname.Namespace,
 			"name", nsname.Name,
 			"kind", obj.GetObjectKind().GroupVersionKind().Kind)

--- a/internal/status/updater_test.go
+++ b/internal/status/updater_test.go
@@ -51,7 +51,14 @@ var _ = Describe("Updater", func() {
 		gatewayCtrlName = "test.example.com"
 		gwNsName = types.NamespacedName{Namespace: "test", Name: "gateway"}
 
-		updater = status.NewUpdater(gatewayCtrlName, gwNsName, gcName, client, zap.New(), fakeClock)
+		updater = status.NewUpdater(status.UpdaterConfig{
+			GatewayNsName:    gwNsName,
+			GatewayCtlrName:  gatewayCtrlName,
+			GatewayClassName: gcName,
+			Client:           client,
+			Logger:           zap.New(),
+			Clock:            fakeClock,
+		})
 	})
 
 	Describe("Process status updates", Ordered, func() {

--- a/internal/status/updater_test.go
+++ b/internal/status/updater_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 var _ = Describe("Updater", func() {
+	const gcName = "my-class"
+
 	var (
 		updater         status.Updater
 		client          client.Client
@@ -49,27 +51,28 @@ var _ = Describe("Updater", func() {
 		gatewayCtrlName = "test.example.com"
 		gwNsName = types.NamespacedName{Namespace: "test", Name: "gateway"}
 
-		updater = status.NewUpdater(gatewayCtrlName, gwNsName, client, zap.New(), fakeClock)
+		updater = status.NewUpdater(gatewayCtrlName, gwNsName, gcName, client, zap.New(), fakeClock)
 	})
 
 	Describe("Process status updates", Ordered, func() {
 		var (
-			hr *v1alpha2.HTTPRoute
+			gc *v1alpha2.GatewayClass
 			gw *v1alpha2.Gateway
+			hr *v1alpha2.HTTPRoute
 
-			createStatuses   func(bool, bool) state.Statuses
-			createExpectedHR func() *v1alpha2.HTTPRoute
+			createStatuses   func(bool) state.Statuses
+			createExpectedGc func(metav1.ConditionStatus, string, string) *v1alpha2.GatewayClass
 			createExpectedGw func(metav1.ConditionStatus, string) *v1alpha2.Gateway
+			createExpectedHR func() *v1alpha2.HTTPRoute
 		)
 
 		BeforeAll(func() {
-			hr = &v1alpha2.HTTPRoute{
+			gc = &v1alpha2.GatewayClass{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test",
-					Name:      "route1",
+					Name: gcName,
 				},
 				TypeMeta: metav1.TypeMeta{
-					Kind:       "HTTPRoute",
+					Kind:       "GatewayClass",
 					APIVersion: "gateway.networking.k8s.io/v1alpha2",
 				},
 			}
@@ -83,12 +86,32 @@ var _ = Describe("Updater", func() {
 					APIVersion: "gateway.networking.k8s.io/v1alpha2",
 				},
 			}
+			hr = &v1alpha2.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "route1",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "HTTPRoute",
+					APIVersion: "gateway.networking.k8s.io/v1alpha2",
+				},
+			}
 
-			createStatuses = func(listenerValid, routeAttached bool) state.Statuses {
+			createStatuses = func(valid bool) state.Statuses {
+				var gcErrorMsg string
+				if !valid {
+					gcErrorMsg = "error"
+				}
+
 				return state.Statuses{
+					GatewayClassStatus: &state.GatewayClassStatus{
+						Valid:              valid,
+						ErrorMsg:           gcErrorMsg,
+						ObservedGeneration: 1,
+					},
 					ListenerStatuses: map[string]state.ListenerStatus{
 						"http": {
-							Valid:          listenerValid,
+							Valid:          valid,
 							AttachedRoutes: 1,
 						},
 					},
@@ -96,7 +119,7 @@ var _ = Describe("Updater", func() {
 						{Namespace: "test", Name: "route1"}: {
 							ParentStatuses: map[string]state.ParentStatus{
 								"http": {
-									Attached: routeAttached,
+									Attached: valid,
 								},
 							},
 						},
@@ -104,71 +127,24 @@ var _ = Describe("Updater", func() {
 				}
 			}
 
-			createExpectedHR = func() *v1alpha2.HTTPRoute {
-				return &v1alpha2.HTTPRoute{
+			createExpectedGc = func(status metav1.ConditionStatus, reason string, msg string) *v1alpha2.GatewayClass {
+				return &v1alpha2.GatewayClass{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test",
-						Name:      "route1",
+						Name: gcName,
 					},
 					TypeMeta: metav1.TypeMeta{
-						Kind:       "HTTPRoute",
+						Kind:       "GatewayClass",
 						APIVersion: "gateway.networking.k8s.io/v1alpha2",
 					},
-					Status: gatewayv1alpha2.HTTPRouteStatus{
-						RouteStatus: gatewayv1alpha2.RouteStatus{
-							Parents: []gatewayv1alpha2.RouteParentStatus{
-								{
-									ControllerName: gatewayv1alpha2.GatewayController(gatewayCtrlName),
-									ParentRef: gatewayv1alpha2.ParentRef{
-										Namespace:   (*v1alpha2.Namespace)(helpers.GetStringPointer("test")),
-										Name:        "gateway",
-										SectionName: (*v1alpha2.SectionName)(helpers.GetStringPointer("http")),
-									},
-									Conditions: []metav1.Condition{
-										{
-											Type:               string(gatewayv1alpha2.ConditionRouteAccepted),
-											Status:             metav1.ConditionTrue,
-											ObservedGeneration: 123,
-											LastTransitionTime: fakeClockTime,
-											Reason:             "Accepted",
-										},
-									},
-								},
-							},
-						},
-					},
-				}
-			}
-
-			createExpectedGw = func(status metav1.ConditionStatus, reason string) *v1alpha2.Gateway {
-				return &v1alpha2.Gateway{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test",
-						Name:      "gateway",
-					},
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "Gateway",
-						APIVersion: "gateway.networking.k8s.io/v1alpha2",
-					},
-					Status: v1alpha2.GatewayStatus{
-						Listeners: []gatewayv1alpha2.ListenerStatus{
+					Status: v1alpha2.GatewayClassStatus{
+						Conditions: []metav1.Condition{
 							{
-								Name: "http",
-								SupportedKinds: []v1alpha2.RouteGroupKind{
-									{
-										Kind: "HTTPRoute",
-									},
-								},
-								AttachedRoutes: 1,
-								Conditions: []metav1.Condition{
-									{
-										Type:               string(v1alpha2.ListenerConditionReady),
-										Status:             status,
-										ObservedGeneration: 123,
-										LastTransitionTime: fakeClockTime,
-										Reason:             reason,
-									},
-								},
+								Type:               string(v1alpha2.GatewayClassConditionStatusAccepted),
+								Status:             status,
+								ObservedGeneration: 1,
+								LastTransitionTime: fakeClockTime,
+								Reason:             string(v1alpha2.GatewayClassReasonAccepted),
+								Message:            msg,
 							},
 						},
 					},
@@ -176,25 +152,97 @@ var _ = Describe("Updater", func() {
 			}
 		})
 
+		createExpectedGw = func(status metav1.ConditionStatus, reason string) *v1alpha2.Gateway {
+			return &v1alpha2.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "gateway",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Gateway",
+					APIVersion: "gateway.networking.k8s.io/v1alpha2",
+				},
+				Status: v1alpha2.GatewayStatus{
+					Listeners: []gatewayv1alpha2.ListenerStatus{
+						{
+							Name: "http",
+							SupportedKinds: []v1alpha2.RouteGroupKind{
+								{
+									Kind: "HTTPRoute",
+								},
+							},
+							AttachedRoutes: 1,
+							Conditions: []metav1.Condition{
+								{
+									Type:               string(v1alpha2.ListenerConditionReady),
+									Status:             status,
+									ObservedGeneration: 123,
+									LastTransitionTime: fakeClockTime,
+									Reason:             reason,
+								},
+							},
+						},
+					},
+				},
+			}
+		}
+
+		createExpectedHR = func() *v1alpha2.HTTPRoute {
+			return &v1alpha2.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "route1",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "HTTPRoute",
+					APIVersion: "gateway.networking.k8s.io/v1alpha2",
+				},
+				Status: gatewayv1alpha2.HTTPRouteStatus{
+					RouteStatus: gatewayv1alpha2.RouteStatus{
+						Parents: []gatewayv1alpha2.RouteParentStatus{
+							{
+								ControllerName: gatewayv1alpha2.GatewayController(gatewayCtrlName),
+								ParentRef: gatewayv1alpha2.ParentRef{
+									Namespace:   (*v1alpha2.Namespace)(helpers.GetStringPointer("test")),
+									Name:        "gateway",
+									SectionName: (*v1alpha2.SectionName)(helpers.GetStringPointer("http")),
+								},
+								Conditions: []metav1.Condition{
+									{
+										Type:               string(gatewayv1alpha2.ConditionRouteAccepted),
+										Status:             metav1.ConditionTrue,
+										ObservedGeneration: 123,
+										LastTransitionTime: fakeClockTime,
+										Reason:             "Accepted",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+		}
+
 		It("should create resources in the API server", func() {
-			Expect(client.Create(context.Background(), hr)).Should(Succeed())
+			Expect(client.Create(context.Background(), gc)).Should(Succeed())
 			Expect(client.Create(context.Background(), gw)).Should(Succeed())
+			Expect(client.Create(context.Background(), hr)).Should(Succeed())
 		})
 
 		It("should update statuses", func() {
-			updater.Update(context.Background(), createStatuses(true, true))
+			updater.Update(context.Background(), createStatuses(true))
 		})
 
-		It("should have the updated status of HTTPRoute in the API server", func() {
-			latestHR := &v1alpha2.HTTPRoute{}
-			expectedHR := createExpectedHR()
+		It("should have the updated status of GatewayClass in the API server", func() {
+			latestGc := &v1alpha2.GatewayClass{}
+			expectedGc := createExpectedGc(metav1.ConditionTrue, string(v1alpha2.GatewayClassConditionStatusAccepted), "GatewayClass has been accepted")
 
-			err := client.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "route1"}, latestHR)
+			err := client.Get(context.Background(), types.NamespacedName{Name: gcName}, latestGc)
 			Expect(err).Should(Not(HaveOccurred()))
 
-			expectedHR.ResourceVersion = latestHR.ResourceVersion // updating the status changes the ResourceVersion
+			expectedGc.ResourceVersion = latestGc.ResourceVersion // updating the status changes the ResourceVersion
 
-			Expect(helpers.Diff(expectedHR, latestHR)).To(BeEmpty())
+			Expect(helpers.Diff(expectedGc, latestGc)).To(BeEmpty())
 		})
 
 		It("should have the updated status of Gateway in the API server", func() {
@@ -209,13 +257,7 @@ var _ = Describe("Updater", func() {
 			Expect(helpers.Diff(expectedGw, latestGw)).To(BeEmpty())
 		})
 
-		It("should update statuses with canceled context - function normally returns", func() {
-			ctx, cancel := context.WithCancel(context.Background())
-			cancel()
-			updater.Update(ctx, createStatuses(false, false))
-		})
-
-		It("should not have the updated status of HTTPRoute in the API server after updating with canceled context", func() {
+		It("should have the updated status of HTTPRoute in the API server", func() {
 			latestHR := &v1alpha2.HTTPRoute{}
 			expectedHR := createExpectedHR()
 
@@ -225,6 +267,24 @@ var _ = Describe("Updater", func() {
 			expectedHR.ResourceVersion = latestHR.ResourceVersion
 
 			Expect(helpers.Diff(expectedHR, latestHR)).To(BeEmpty())
+		})
+
+		It("should update statuses with canceled context - function normally returns", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			updater.Update(ctx, createStatuses(false))
+		})
+
+		It("should have the updated status of GatewayClass in the API server after updating with canceled context", func() {
+			latestGc := &v1alpha2.GatewayClass{}
+			expectedGc := createExpectedGc(metav1.ConditionFalse, string(v1alpha2.GatewayClassConditionStatusAccepted), "GatewayClass has been rejected: error")
+
+			err := client.Get(context.Background(), types.NamespacedName{Name: gcName}, latestGc)
+			Expect(err).Should(Not(HaveOccurred()))
+
+			expectedGc.ResourceVersion = latestGc.ResourceVersion
+
+			Expect(helpers.Diff(expectedGc, latestGc)).To(BeEmpty())
 		})
 
 		It("should have the updated status of Gateway in the API server after updating with canceled context", func() {
@@ -237,6 +297,19 @@ var _ = Describe("Updater", func() {
 			expectedGw.ResourceVersion = latestGw.ResourceVersion
 
 			Expect(helpers.Diff(expectedGw, latestGw)).To(BeEmpty())
+		})
+
+		It("should not have the updated status of HTTPRoute in the API server after updating with canceled context", func() {
+			latestHR := &v1alpha2.HTTPRoute{}
+			expectedHR := createExpectedHR()
+
+			err := client.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "route1"}, latestHR)
+			Expect(err).Should(Not(HaveOccurred()))
+
+			expectedHR.ResourceVersion = latestHR.ResourceVersion
+
+			// if the status was updated, we would see the route rejected (Accepted = false)
+			Expect(helpers.Diff(expectedHR, latestHR)).To(BeEmpty())
 		})
 	})
 })

--- a/pkg/sdk/gatewayclass_controller.go
+++ b/pkg/sdk/gatewayclass_controller.go
@@ -37,9 +37,6 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req reconcile.Re
 	var gc v1alpha2.GatewayClass
 	found := true
 
-	// we assume that the reconcile will only be called with the GatewayClass of the known name (like 'nginx')
-	// this is something that has to be configured on the Manager
-
 	err := r.Get(ctx, req.NamespacedName, &gc)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -50,7 +47,7 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req reconcile.Re
 	}
 
 	if !found {
-		r.impl.Remove(req.Name)
+		r.impl.Remove(req.NamespacedName)
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/sdk/interfaces.go
+++ b/pkg/sdk/interfaces.go
@@ -10,7 +10,7 @@ import (
 
 type GatewayClassImpl interface {
 	Upsert(gc *v1alpha2.GatewayClass)
-	Remove(key string)
+	Remove(nsname types.NamespacedName)
 }
 
 type GatewayImpl interface {
@@ -31,5 +31,5 @@ type HTTPRouteImpl interface {
 
 type ServiceImpl interface {
 	Upsert(svc *apiv1.Service)
-	Remove(name types.NamespacedName)
+	Remove(nsname types.NamespacedName)
 }


### PR DESCRIPTION
This PR brings support for a GatewayClass resource.

NGINX Gateway supports a single GatewayClass resource that must be configured via a new cli argument - gatewayclass.

The GatewayClass resource is required - no traffic will go through NGINX if the GatewayClass is missing.