### PR TITLE
Enforce that the SNI name matches the host name

### DIFF
--- a/internal/nginx/config/template.go
+++ b/internal/nginx/config/template.go
@@ -26,6 +26,10 @@ server {
 	listen 443 ssl;
 	ssl_certificate {{ $s.SSL.Certificate }};
 	ssl_certificate_key {{ $s.SSL.CertificateKey }};
+
+	if ($ssl_server_name != $host) {
+		return 421;
+	}
 		{{ end }}
 
 	server_name {{ $s.ServerName }};


### PR DESCRIPTION
Problem: Nginx does not enforce that the SNI name matches the host name for SSL
requests, which can lead to unexpected behavior and breaks the
recommendation of the gateway API spec.

Fix: in every SSL server block, we now check that the variables $ssl_server_name
and $host are equal. If they are not, we return a 421 misdirected request.
