### PR TITLE
Generate a default SSL server for select HTTPS listener hostname

### DIFF
--- a/internal/nginx/config/generator.go
+++ b/internal/nginx/config/generator.go
@@ -80,8 +80,22 @@ func generateDefaultHTTPServer() server {
 func generate(virtualServer state.VirtualServer, serviceStore state.ServiceStore) (server, Warnings) {
 	warnings := newWarnings()
 
-	locs := make([]location, 0, len(virtualServer.PathRules)) // FIXME(pleshakov): expand with rule.Routes
+	s := server{ServerName: virtualServer.Hostname}
 
+	if virtualServer.SSL != nil {
+		s.SSL = &ssl{
+			Certificate:    virtualServer.SSL.CertificatePath,
+			CertificateKey: virtualServer.SSL.CertificatePath,
+		}
+	}
+
+	if virtualServer.PathRules == nil {
+		// generate default "/" 404 location
+		s.Locations = []location{{Path: "/", Return: &returnVal{Code: statusNotFound}}}
+		return s, warnings
+	}
+
+	locs := make([]location, 0, len(virtualServer.PathRules)) // FIXME(pleshakov): expand with rule.Routes
 	for _, rule := range virtualServer.PathRules {
 		matches := make([]httpMatch, 0, len(rule.MatchRules))
 
@@ -125,16 +139,9 @@ func generate(virtualServer state.VirtualServer, serviceStore state.ServiceStore
 			locs = append(locs, pathLoc)
 		}
 	}
-	s := server{
-		ServerName: virtualServer.Hostname,
-		Locations:  locs,
-	}
-	if virtualServer.SSL != nil {
-		s.SSL = &ssl{
-			Certificate:    virtualServer.SSL.CertificatePath,
-			CertificateKey: virtualServer.SSL.CertificatePath,
-		}
-	}
+
+	s.Locations = locs
+
 	return s, warnings
 }
 

--- a/internal/nginx/config/generator.go
+++ b/internal/nginx/config/generator.go
@@ -89,7 +89,7 @@ func generate(virtualServer state.VirtualServer, serviceStore state.ServiceStore
 		}
 	}
 
-	if virtualServer.PathRules == nil {
+	if len(virtualServer.PathRules) == 0 {
 		// generate default "/" 404 location
 		s.Locations = []location{{Path: "/", Return: &returnVal{Code: statusNotFound}}}
 		return s, warnings

--- a/internal/nginx/config/http.go
+++ b/internal/nginx/config/http.go
@@ -5,21 +5,30 @@ type httpServers struct {
 }
 
 type server struct {
+	SSL           *ssl
+	ServerName    string
+	Locations     []location
 	IsDefaultHTTP bool
 	IsDefaultSSL  bool
-	ServerName    string
-	SSL           *ssl
-	Locations     []location
 }
 
 type location struct {
+	Return       *returnVal
 	Path         string
 	ProxyPass    string
 	HTTPMatchVar string
 	Internal     bool
 }
 
+type returnVal struct {
+	Code statusCode
+}
+
 type ssl struct {
 	Certificate    string
 	CertificateKey string
 }
+
+type statusCode int
+
+const statusNotFound statusCode = 404

--- a/internal/nginx/config/template.go
+++ b/internal/nginx/config/template.go
@@ -39,8 +39,10 @@ server {
 		{{ if $l.Internal }}
 		internal;
 		{{ end }}
-		
-		proxy_set_header Host $host;
+
+		{{ if $l.Return }}
+		return {{ $l.Return.Code }};
+		{{ end }}
 
 		{{ if $l.HTTPMatchVar }}
 		set $http_matches {{ $l.HTTPMatchVar | printf "%q" }};
@@ -48,6 +50,7 @@ server {
 		{{ end }}
 
 		{{ if $l.ProxyPass }}
+		proxy_set_header Host $host;
 		proxy_pass {{ $l.ProxyPass }}$request_uri;
 		{{ end }}
 	}

--- a/internal/state/change_processor_test.go
+++ b/internal/state/change_processor_test.go
@@ -246,6 +246,10 @@ var _ = Describe("ChangeProcessor", func() {
 								},
 							},
 						},
+						{
+							Hostname: "~^",
+							SSL:      &state.SSL{CertificatePath: certificatePath},
+						},
 					},
 				}
 
@@ -333,6 +337,10 @@ var _ = Describe("ChangeProcessor", func() {
 								},
 							},
 						},
+						{
+							Hostname: "~^",
+							SSL:      &state.SSL{CertificatePath: certificatePath},
+						},
 					},
 				}
 				expectedStatuses := state.Statuses{
@@ -418,6 +426,10 @@ var _ = Describe("ChangeProcessor", func() {
 									},
 								},
 							},
+						},
+						{
+							Hostname: "~^",
+							SSL:      &state.SSL{CertificatePath: certificatePath},
 						},
 					},
 				}
@@ -505,6 +517,10 @@ var _ = Describe("ChangeProcessor", func() {
 								},
 							},
 						},
+						{
+							Hostname: "~^",
+							SSL:      &state.SSL{CertificatePath: certificatePath},
+						},
 					},
 				}
 				expectedStatuses := state.Statuses{
@@ -590,6 +606,10 @@ var _ = Describe("ChangeProcessor", func() {
 								CertificatePath: certificatePath,
 							},
 						},
+						{
+							Hostname: "~^",
+							SSL:      &state.SSL{CertificatePath: certificatePath},
+						},
 					},
 				}
 				expectedStatuses := state.Statuses{
@@ -668,6 +688,10 @@ var _ = Describe("ChangeProcessor", func() {
 									},
 								},
 							},
+						},
+						{
+							Hostname: "~^",
+							SSL:      &state.SSL{CertificatePath: certificatePath},
 						},
 					},
 				}
@@ -754,6 +778,10 @@ var _ = Describe("ChangeProcessor", func() {
 								},
 							},
 						},
+						{
+							Hostname: "~^",
+							SSL:      &state.SSL{CertificatePath: certificatePath},
+						},
 					},
 				}
 				expectedStatuses := state.Statuses{
@@ -791,12 +819,17 @@ var _ = Describe("ChangeProcessor", func() {
 				Expect(helpers.Diff(expectedStatuses, statuses)).To(BeEmpty())
 			})
 
-			It("should return empty configuration and updated statuses after deleting the second HTTPRoute", func() {
+			It("should return configuration with default ssl server and updated statuses after deleting the second HTTPRoute", func() {
 				processor.CaptureDeleteChange(&v1alpha2.HTTPRoute{}, types.NamespacedName{Namespace: "test", Name: "hr-2"})
 
 				expectedConf := state.Configuration{
 					HTTPServers: []state.VirtualServer{},
-					SSLServers:  []state.VirtualServer{},
+					SSLServers: []state.VirtualServer{
+						{
+							Hostname: "~^",
+							SSL:      &state.SSL{CertificatePath: certificatePath},
+						},
+					},
 				}
 				expectedStatuses := state.Statuses{
 					GatewayClassStatus: &state.GatewayClassStatus{


### PR DESCRIPTION
This change fixes the following problems:

(1) If a valid HTTPS listener is configured but has no attached routes, a request to the listener's hostname will result in an SSL handshake error.

(2) If a valid HTTPS listener with a catch-all hostname is configured, a request to any hostname that does not match an existing route will result in an SSL handshake error.

After discussion, we decided that it doesn't make sense to reject the SSL handshake when there's a valid HTTPS listener configured for the hostname. The desired behavior is to return a 404.

Solution: Generate an SSL server block for each listener described above that terminates the TLS connection and returns a 404. 