### PR TITLE
Add check for go.mod and go.sum changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
           echo "::set-output name=version::$(grep "VERSION = " Makefile | cut -d " " -f 3)"
           echo "::set-output name=date::$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           echo "::set-output name=go_path::$(go env GOPATH)"
+      - name: Check if go.mod and go.sum are up to date
+        run: |
+          go mod tidy && git diff --exit-code -- go.mod go.sum
       - name: Check if CRDs changed
         run: |
           make update-crds && git diff --name-only --exit-code deploy/manifests/crds/*


### PR DESCRIPTION
Checks for changes in `go.mod` and `go.sum` that means that `go mod tidy` wasn't run.
