### PR TITLE
Dynamic Upstreams

### DIFF
--- a/deploy/manifests/nginx-gateway.yaml
+++ b/deploy/manifests/nginx-gateway.yaml
@@ -18,6 +18,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - gateway.networking.k8s.io
   resources:
   - gatewayclasses

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -46,3 +46,8 @@ func GetQueryParamMatchTypePointer(t v1alpha2.QueryParamMatchType) *v1alpha2.Que
 func GetTLSModePointer(t v1alpha2.TLSModeType) *v1alpha2.TLSModeType {
 	return &t
 }
+
+// GetBoolPointer takes a bool and returns a pointer to it. Useful in unit tests when initializing structs.
+func GetBoolPointer(b bool) *bool {
+	return &b
+}

--- a/internal/implementations/endpointslice/endpointslice.go
+++ b/internal/implementations/endpointslice/endpointslice.go
@@ -1,0 +1,48 @@
+package implementation
+
+import (
+	"github.com/go-logr/logr"
+	discoveryV1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/nginxinc/nginx-kubernetes-gateway/internal/config"
+	"github.com/nginxinc/nginx-kubernetes-gateway/internal/events"
+)
+
+type endpointSliceImplementation struct {
+	conf    config.Config
+	eventCh chan<- interface{}
+}
+
+// NewEndpointSliceImplementation creates a new EndpointSliceImplementation.
+func NewEndpointSliceImplementation(cfg config.Config, eventCh chan<- interface{}) *endpointSliceImplementation {
+	return &endpointSliceImplementation{
+		conf:    cfg,
+		eventCh: eventCh,
+	}
+}
+
+func (impl *endpointSliceImplementation) Logger() logr.Logger {
+	return impl.conf.Logger
+}
+
+func (impl *endpointSliceImplementation) Upsert(endpSlice *discoveryV1.EndpointSlice) {
+	impl.Logger().Info("Endpoint Slice was upserted",
+		"namespace", endpSlice.Namespace, "name", endpSlice.Name,
+	)
+
+	impl.eventCh <- &events.UpsertEvent{
+		Resource: endpSlice,
+	}
+}
+
+func (impl *endpointSliceImplementation) Remove(nsname types.NamespacedName) {
+	impl.Logger().Info("Endpoint Slice resource was removed",
+		"namespace", nsname.Namespace, "name", nsname.Name,
+	)
+
+	impl.eventCh <- &events.DeleteEvent{
+		NamespacedName: nsname,
+		Type:           &discoveryV1.EndpointSlice{},
+	}
+}

--- a/internal/implementations/endpointslice/endpointslice_test.go
+++ b/internal/implementations/endpointslice/endpointslice_test.go
@@ -1,0 +1,64 @@
+package implementation_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	discoveryV1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/nginxinc/nginx-kubernetes-gateway/internal/config"
+	"github.com/nginxinc/nginx-kubernetes-gateway/internal/events"
+	implementation "github.com/nginxinc/nginx-kubernetes-gateway/internal/implementations/endpointslice"
+	"github.com/nginxinc/nginx-kubernetes-gateway/pkg/sdk"
+)
+
+var _ = Describe("EndpointSliceImplementation", func() {
+	var (
+		eventCh chan interface{}
+		impl    sdk.EndpointSliceImpl
+	)
+
+	BeforeEach(func() {
+		eventCh = make(chan interface{})
+
+		impl = implementation.NewEndpointSliceImplementation(config.Config{
+			Logger: zap.New(),
+		}, eventCh)
+	})
+
+	const endpointSliceName = "my-endpoint-slice"
+	const endpointSliceNamespace = "test"
+
+	Describe("Implementation processes Endpoint Slices", func() {
+		It("should process upsert", func() {
+			endpointSlice := &discoveryV1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      endpointSliceName,
+					Namespace: endpointSliceNamespace,
+				},
+			}
+
+			go func() {
+				impl.Upsert(endpointSlice)
+			}()
+
+			Eventually(eventCh).Should(Receive(Equal(&events.UpsertEvent{Resource: endpointSlice})))
+		})
+
+		It("should process remove", func() {
+			nsname := types.NamespacedName{Name: endpointSliceName, Namespace: endpointSliceNamespace}
+
+			go func() {
+				impl.Remove(nsname)
+			}()
+
+			Eventually(eventCh).Should(Receive(Equal(
+				&events.DeleteEvent{
+					NamespacedName: nsname,
+					Type:           &discoveryV1.EndpointSlice{},
+				})))
+		})
+	})
+})

--- a/internal/implementations/endpointslice/implementation_suite_test.go
+++ b/internal/implementations/endpointslice/implementation_suite_test.go
@@ -1,0 +1,13 @@
+package implementation_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpointSliceImplementation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Endpoint Slice Implementation Suite")
+}

--- a/internal/nginx/config/http.go
+++ b/internal/nginx/config/http.go
@@ -1,7 +1,8 @@
 package config
 
-type httpServers struct {
-	Servers []server
+type http struct {
+	Servers   []server
+	Upstreams []upstream
 }
 
 type server struct {
@@ -22,4 +23,13 @@ type location struct {
 type ssl struct {
 	Certificate    string
 	CertificateKey string
+}
+
+type upstream struct {
+	Name    string
+	Servers []upstreamServer
+}
+
+type upstreamServer struct {
+	Address string
 }

--- a/internal/nginx/file/filefakes/fake_manager.go
+++ b/internal/nginx/file/filefakes/fake_manager.go
@@ -8,38 +8,38 @@ import (
 )
 
 type FakeManager struct {
-	WriteHTTPServersConfigStub        func(string, []byte) error
-	writeHTTPServersConfigMutex       sync.RWMutex
-	writeHTTPServersConfigArgsForCall []struct {
+	WriteHTTPConfigStub        func(string, []byte) error
+	writeHTTPConfigMutex       sync.RWMutex
+	writeHTTPConfigArgsForCall []struct {
 		arg1 string
 		arg2 []byte
 	}
-	writeHTTPServersConfigReturns struct {
+	writeHTTPConfigReturns struct {
 		result1 error
 	}
-	writeHTTPServersConfigReturnsOnCall map[int]struct {
+	writeHTTPConfigReturnsOnCall map[int]struct {
 		result1 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeManager) WriteHTTPServersConfig(arg1 string, arg2 []byte) error {
+func (fake *FakeManager) WriteHTTPConfig(arg1 string, arg2 []byte) error {
 	var arg2Copy []byte
 	if arg2 != nil {
 		arg2Copy = make([]byte, len(arg2))
 		copy(arg2Copy, arg2)
 	}
-	fake.writeHTTPServersConfigMutex.Lock()
-	ret, specificReturn := fake.writeHTTPServersConfigReturnsOnCall[len(fake.writeHTTPServersConfigArgsForCall)]
-	fake.writeHTTPServersConfigArgsForCall = append(fake.writeHTTPServersConfigArgsForCall, struct {
+	fake.writeHTTPConfigMutex.Lock()
+	ret, specificReturn := fake.writeHTTPConfigReturnsOnCall[len(fake.writeHTTPConfigArgsForCall)]
+	fake.writeHTTPConfigArgsForCall = append(fake.writeHTTPConfigArgsForCall, struct {
 		arg1 string
 		arg2 []byte
 	}{arg1, arg2Copy})
-	stub := fake.WriteHTTPServersConfigStub
-	fakeReturns := fake.writeHTTPServersConfigReturns
-	fake.recordInvocation("WriteHTTPServersConfig", []interface{}{arg1, arg2Copy})
-	fake.writeHTTPServersConfigMutex.Unlock()
+	stub := fake.WriteHTTPConfigStub
+	fakeReturns := fake.writeHTTPConfigReturns
+	fake.recordInvocation("WriteHTTPConfig", []interface{}{arg1, arg2Copy})
+	fake.writeHTTPConfigMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
 	}
@@ -49,44 +49,44 @@ func (fake *FakeManager) WriteHTTPServersConfig(arg1 string, arg2 []byte) error 
 	return fakeReturns.result1
 }
 
-func (fake *FakeManager) WriteHTTPServersConfigCallCount() int {
-	fake.writeHTTPServersConfigMutex.RLock()
-	defer fake.writeHTTPServersConfigMutex.RUnlock()
-	return len(fake.writeHTTPServersConfigArgsForCall)
+func (fake *FakeManager) WriteHTTPConfigCallCount() int {
+	fake.writeHTTPConfigMutex.RLock()
+	defer fake.writeHTTPConfigMutex.RUnlock()
+	return len(fake.writeHTTPConfigArgsForCall)
 }
 
-func (fake *FakeManager) WriteHTTPServersConfigCalls(stub func(string, []byte) error) {
-	fake.writeHTTPServersConfigMutex.Lock()
-	defer fake.writeHTTPServersConfigMutex.Unlock()
-	fake.WriteHTTPServersConfigStub = stub
+func (fake *FakeManager) WriteHTTPConfigCalls(stub func(string, []byte) error) {
+	fake.writeHTTPConfigMutex.Lock()
+	defer fake.writeHTTPConfigMutex.Unlock()
+	fake.WriteHTTPConfigStub = stub
 }
 
-func (fake *FakeManager) WriteHTTPServersConfigArgsForCall(i int) (string, []byte) {
-	fake.writeHTTPServersConfigMutex.RLock()
-	defer fake.writeHTTPServersConfigMutex.RUnlock()
-	argsForCall := fake.writeHTTPServersConfigArgsForCall[i]
+func (fake *FakeManager) WriteHTTPConfigArgsForCall(i int) (string, []byte) {
+	fake.writeHTTPConfigMutex.RLock()
+	defer fake.writeHTTPConfigMutex.RUnlock()
+	argsForCall := fake.writeHTTPConfigArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeManager) WriteHTTPServersConfigReturns(result1 error) {
-	fake.writeHTTPServersConfigMutex.Lock()
-	defer fake.writeHTTPServersConfigMutex.Unlock()
-	fake.WriteHTTPServersConfigStub = nil
-	fake.writeHTTPServersConfigReturns = struct {
+func (fake *FakeManager) WriteHTTPConfigReturns(result1 error) {
+	fake.writeHTTPConfigMutex.Lock()
+	defer fake.writeHTTPConfigMutex.Unlock()
+	fake.WriteHTTPConfigStub = nil
+	fake.writeHTTPConfigReturns = struct {
 		result1 error
 	}{result1}
 }
 
-func (fake *FakeManager) WriteHTTPServersConfigReturnsOnCall(i int, result1 error) {
-	fake.writeHTTPServersConfigMutex.Lock()
-	defer fake.writeHTTPServersConfigMutex.Unlock()
-	fake.WriteHTTPServersConfigStub = nil
-	if fake.writeHTTPServersConfigReturnsOnCall == nil {
-		fake.writeHTTPServersConfigReturnsOnCall = make(map[int]struct {
+func (fake *FakeManager) WriteHTTPConfigReturnsOnCall(i int, result1 error) {
+	fake.writeHTTPConfigMutex.Lock()
+	defer fake.writeHTTPConfigMutex.Unlock()
+	fake.WriteHTTPConfigStub = nil
+	if fake.writeHTTPConfigReturnsOnCall == nil {
+		fake.writeHTTPConfigReturnsOnCall = make(map[int]struct {
 			result1 error
 		})
 	}
-	fake.writeHTTPServersConfigReturnsOnCall[i] = struct {
+	fake.writeHTTPConfigReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -94,8 +94,8 @@ func (fake *FakeManager) WriteHTTPServersConfigReturnsOnCall(i int, result1 erro
 func (fake *FakeManager) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.writeHTTPServersConfigMutex.RLock()
-	defer fake.writeHTTPServersConfigMutex.RUnlock()
+	fake.writeHTTPConfigMutex.RLock()
+	defer fake.writeHTTPConfigMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/internal/nginx/file/manager.go
+++ b/internal/nginx/file/manager.go
@@ -12,10 +12,10 @@ const confdFolder = "/etc/nginx/conf.d"
 
 // Manager manages NGINX configuration files.
 type Manager interface {
-	// WriteHTTPServersConfig writes the http servers config on the file system.
+	// WriteHTTPConfig writes the http config on the file system.
 	// The name distinguishes this config among all other configs. For that, it must be unique.
 	// Note that name is not the name of the corresponding configuration file.
-	WriteHTTPServersConfig(name string, cfg []byte) error
+	WriteHTTPConfig(name string, cfg []byte) error
 }
 
 // ManagerImpl is an implementation of Manager.
@@ -26,8 +26,8 @@ func NewManagerImpl() *ManagerImpl {
 	return &ManagerImpl{}
 }
 
-func (m *ManagerImpl) WriteHTTPServersConfig(name string, cfg []byte) error {
-	path := getPathForServerConfig(name)
+func (m *ManagerImpl) WriteHTTPConfig(name string, cfg []byte) error {
+	path := getPathForConfig(name)
 
 	file, err := os.Create(path)
 	if err != nil {
@@ -44,6 +44,6 @@ func (m *ManagerImpl) WriteHTTPServersConfig(name string, cfg []byte) error {
 	return nil
 }
 
-func getPathForServerConfig(name string) string {
+func getPathForConfig(name string) string {
 	return filepath.Join(confdFolder, name+".conf")
 }

--- a/internal/nginx/file/manager_test.go
+++ b/internal/nginx/file/manager_test.go
@@ -5,8 +5,8 @@ import "testing"
 func TestGetPathForServerConfig(t *testing.T) {
 	expected := "/etc/nginx/conf.d/test.example.com.conf"
 
-	result := getPathForServerConfig("test.example.com")
+	result := getPathForConfig("test.example.com")
 	if result != expected {
-		t.Errorf("getPathForServerConfig() returned %q but expected %q", result, expected)
+		t.Errorf("getPathForConfig() returned %q but expected %q", result, expected)
 	}
 }

--- a/internal/state/change_processor_test.go
+++ b/internal/state/change_processor_test.go
@@ -3,6 +3,8 @@ package state_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apiv1 "k8s.io/api/core/v1"
+	discoveryV1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -13,24 +15,133 @@ import (
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state/statefakes"
 )
 
+const (
+	controllerName  = "my.controller"
+	gcName          = "test-class"
+	certificatePath = "path/to/cert"
+)
+
+func createRoute(name string, gateway string, hostname string, backendRefs ...v1alpha2.HTTPBackendRef) *v1alpha2.HTTPRoute {
+	return &v1alpha2.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      name,
+		},
+		Spec: v1alpha2.HTTPRouteSpec{
+			CommonRouteSpec: v1alpha2.CommonRouteSpec{
+				ParentRefs: []v1alpha2.ParentRef{
+					{
+						Namespace:   (*v1alpha2.Namespace)(helpers.GetStringPointer("test")),
+						Name:        v1alpha2.ObjectName(gateway),
+						SectionName: (*v1alpha2.SectionName)(helpers.GetStringPointer("listener-80-1")),
+					},
+					{
+						Namespace:   (*v1alpha2.Namespace)(helpers.GetStringPointer("test")),
+						Name:        v1alpha2.ObjectName(gateway),
+						SectionName: (*v1alpha2.SectionName)(helpers.GetStringPointer("listener-443-1")),
+					},
+				},
+			},
+			Hostnames: []v1alpha2.Hostname{
+				v1alpha2.Hostname(hostname),
+			},
+			Rules: []v1alpha2.HTTPRouteRule{
+				{
+					Matches: []v1alpha2.HTTPRouteMatch{
+						{
+							Path: &v1alpha2.HTTPPathMatch{
+								Value: helpers.GetStringPointer("/"),
+							},
+						},
+					},
+					BackendRefs: backendRefs,
+				},
+			},
+		},
+	}
+}
+
+func createGateway(name string) *v1alpha2.Gateway {
+	return &v1alpha2.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "test",
+			Name:       name,
+			Generation: 1,
+		},
+		Spec: v1alpha2.GatewaySpec{
+			GatewayClassName: gcName,
+			Listeners: []v1alpha2.Listener{
+				{
+					Name:     "listener-80-1",
+					Hostname: nil,
+					Port:     80,
+					Protocol: v1alpha2.HTTPProtocolType,
+				},
+			},
+		},
+	}
+}
+
+func createGatewayWithTLSListener(name string) *v1alpha2.Gateway {
+	gw := createGateway(name)
+
+	l := v1alpha2.Listener{
+		Name:     "listener-443-1",
+		Hostname: nil,
+		Port:     443,
+		Protocol: v1alpha2.HTTPSProtocolType,
+		TLS: &v1alpha2.GatewayTLSConfig{
+			Mode: helpers.GetTLSModePointer(v1alpha2.TLSModeTerminate),
+			CertificateRefs: []*v1alpha2.SecretObjectReference{
+				{
+					Kind:      (*v1alpha2.Kind)(helpers.GetStringPointer("Secret")),
+					Name:      "secret",
+					Namespace: (*v1alpha2.Namespace)(helpers.GetStringPointer("test")),
+				},
+			},
+		},
+	}
+	gw.Spec.Listeners = append(gw.Spec.Listeners, l)
+
+	return gw
+}
+
+func createRouteWithMultipleRules(name, gateway, hostname string, rules []v1alpha2.HTTPRouteRule) *v1alpha2.HTTPRoute {
+	hr := createRoute(name, gateway, hostname)
+	hr.Spec.Rules = rules
+
+	return hr
+}
+
+func createHTTPRule(path string, backendRefs ...v1alpha2.HTTPBackendRef) v1alpha2.HTTPRouteRule {
+	return v1alpha2.HTTPRouteRule{
+		Matches: []v1alpha2.HTTPRouteMatch{
+			{
+				Path: &v1alpha2.HTTPPathMatch{
+					Value: &path,
+				},
+			},
+		},
+		BackendRefs: backendRefs,
+	}
+}
+
+func createBackendRef(kind *v1alpha2.Kind, name v1alpha2.ObjectName, namespace *v1alpha2.Namespace) v1alpha2.HTTPBackendRef {
+	return v1alpha2.HTTPBackendRef{
+		BackendRef: v1alpha2.BackendRef{
+			BackendObjectReference: v1alpha2.BackendObjectReference{
+				Kind:      kind,
+				Name:      name,
+				Namespace: namespace,
+			},
+		},
+	}
+}
+
 // FIXME(kate-osborn): Consider refactoring these tests to reduce code duplication.
 var _ = Describe("ChangeProcessor", func() {
 	Describe("Normal cases of processing changes", func() {
-		const (
-			controllerName  = "my.controller"
-			gcName          = "test-class"
-			certificatePath = "path/to/cert"
-		)
-
 		var (
-			gc, gcUpdated        *v1alpha2.GatewayClass
-			hr1, hr1Updated, hr2 *v1alpha2.HTTPRoute
-			gw1, gw1Updated, gw2 *v1alpha2.Gateway
-			processor            state.ChangeProcessor
-			fakeSecretMemoryMgr  *statefakes.FakeSecretDiskMemoryManager
-		)
-
-		BeforeEach(OncePerOrdered, func() {
 			gc = &v1alpha2.GatewayClass{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       gcName,
@@ -40,100 +151,11 @@ var _ = Describe("ChangeProcessor", func() {
 					ControllerName: controllerName,
 				},
 			}
+			processor           state.ChangeProcessor
+			fakeSecretMemoryMgr *statefakes.FakeSecretDiskMemoryManager
+		)
 
-			gcUpdated = gc.DeepCopy()
-			gcUpdated.Generation++
-
-			createRoute := func(name string, gateway string, hostname string) *v1alpha2.HTTPRoute {
-				return &v1alpha2.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test",
-						Name:      name,
-					},
-					Spec: v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: v1alpha2.CommonRouteSpec{
-							ParentRefs: []v1alpha2.ParentRef{
-								{
-									Namespace:   (*v1alpha2.Namespace)(helpers.GetStringPointer("test")),
-									Name:        v1alpha2.ObjectName(gateway),
-									SectionName: (*v1alpha2.SectionName)(helpers.GetStringPointer("listener-80-1")),
-								},
-								{
-									Namespace:   (*v1alpha2.Namespace)(helpers.GetStringPointer("test")),
-									Name:        v1alpha2.ObjectName(gateway),
-									SectionName: (*v1alpha2.SectionName)(helpers.GetStringPointer("listener-443-1")),
-								},
-							},
-						},
-						Hostnames: []v1alpha2.Hostname{
-							v1alpha2.Hostname(hostname),
-						},
-						Rules: []v1alpha2.HTTPRouteRule{
-							{
-								Matches: []v1alpha2.HTTPRouteMatch{
-									{
-										Path: &v1alpha2.HTTPPathMatch{
-											Value: helpers.GetStringPointer("/"),
-										},
-									},
-								},
-							},
-						},
-					},
-				}
-			}
-
-			hr1 = createRoute("hr-1", "gateway-1", "foo.example.com")
-
-			hr1Updated = hr1.DeepCopy()
-			hr1Updated.Generation++
-
-			hr2 = createRoute("hr-2", "gateway-2", "bar.example.com")
-
-			createGateway := func(name string) *v1alpha2.Gateway {
-				return &v1alpha2.Gateway{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace:  "test",
-						Name:       name,
-						Generation: 1,
-					},
-					Spec: v1alpha2.GatewaySpec{
-						GatewayClassName: gcName,
-						Listeners: []v1alpha2.Listener{
-							{
-								Name:     "listener-80-1",
-								Hostname: nil,
-								Port:     80,
-								Protocol: v1alpha2.HTTPProtocolType,
-							},
-							{
-								Name:     "listener-443-1",
-								Hostname: nil,
-								Port:     443,
-								Protocol: v1alpha2.HTTPSProtocolType,
-								TLS: &v1alpha2.GatewayTLSConfig{
-									Mode: helpers.GetTLSModePointer(v1alpha2.TLSModeTerminate),
-									CertificateRefs: []*v1alpha2.SecretObjectReference{
-										{
-											Kind:      (*v1alpha2.Kind)(helpers.GetStringPointer("Secret")),
-											Name:      "secret",
-											Namespace: (*v1alpha2.Namespace)(helpers.GetStringPointer("test")),
-										},
-									},
-								},
-							},
-						},
-					},
-				}
-			}
-
-			gw1 = createGateway("gateway-1")
-
-			gw1Updated = gw1.DeepCopy()
-			gw1Updated.Generation++
-
-			gw2 = createGateway("gateway-2")
-
+		BeforeEach(OncePerOrdered, func() {
 			fakeSecretMemoryMgr = &statefakes.FakeSecretDiskMemoryManager{}
 
 			processor = state.NewChangeProcessorImpl(state.ChangeProcessorConfig{
@@ -145,7 +167,30 @@ var _ = Describe("ChangeProcessor", func() {
 			fakeSecretMemoryMgr.RequestReturns(certificatePath, nil)
 		})
 
-		Describe("Process resources", Ordered, func() {
+		Describe("Process gateway resources", Ordered, func() {
+			var (
+				gcUpdated            *v1alpha2.GatewayClass
+				hr1, hr1Updated, hr2 *v1alpha2.HTTPRoute
+				gw1, gw1Updated, gw2 *v1alpha2.Gateway
+			)
+			BeforeAll(func() {
+				gcUpdated = gc.DeepCopy()
+				gcUpdated.Generation++
+
+				hr1 = createRoute("hr-1", "gateway-1", "foo.example.com")
+
+				hr1Updated = hr1.DeepCopy()
+				hr1Updated.Generation++
+
+				hr2 = createRoute("hr-2", "gateway-2", "bar.example.com")
+
+				gw1 = createGatewayWithTLSListener("gateway-1")
+
+				gw1Updated = gw1.DeepCopy()
+				gw1Updated.Generation++
+
+				gw2 = createGatewayWithTLSListener("gateway-2")
+			})
 			When("no upsert has occurred", func() {
 				It("should return empty configuration and statuses", func() {
 					changed, conf, statuses := processor.Process()
@@ -882,6 +927,215 @@ var _ = Describe("ChangeProcessor", func() {
 				Expect(changed).To(BeTrue())
 				Expect(helpers.Diff(expectedConf, conf)).To(BeEmpty())
 				Expect(helpers.Diff(expectedStatuses, statuses)).To(BeEmpty())
+			})
+		})
+		Describe("Process services and endpoints", Ordered, func() {
+			var (
+				hr1, hr2, hr3, hrInvalidBackendRef, hrMultipleRules                                       *v1alpha2.HTTPRoute
+				hr1svc, sharedSvc, bazSvc1, bazSvc2, bazSvc3, invalidSvc, notRefSvc                       *apiv1.Service
+				hr1SvcEndpointSlice1, hr1SvcEndpointSlice2, notRefEndpointSlice, invalidKindEndpointSlice *discoveryV1.EndpointSlice
+			)
+
+			createSvc := func(name string) *apiv1.Service {
+				return &apiv1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:  "test",
+						Name:       name,
+						Generation: 1,
+					},
+				}
+			}
+
+			createEndpointSlice := func(name string, owners ...metav1.OwnerReference) *discoveryV1.EndpointSlice {
+				return &discoveryV1.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       "test",
+						Name:            name,
+						OwnerReferences: owners,
+					},
+				}
+			}
+
+			svcToOwnerRef := func(svc *apiv1.Service) metav1.OwnerReference {
+				return metav1.OwnerReference{
+					Kind: "Service",
+					Name: svc.Name,
+				}
+			}
+
+			BeforeAll(func() {
+				testNamespace := v1alpha2.Namespace("test")
+				kindService := v1alpha2.Kind("Service")
+				kindInvalid := v1alpha2.Kind("Invalid")
+				// backend Refs
+				fooRef := createBackendRef(&kindService, "foo-svc", &testNamespace)
+				barRef := createBackendRef(&kindService, "bar-svc", nil) // nil namespace should inherit namespace from route
+				baz1Ref := createBackendRef(&kindService, "baz-svc-v1", &testNamespace)
+				baz2Ref := createBackendRef(&kindService, "baz-svc-v2", &testNamespace)
+				baz3Ref := createBackendRef(&kindService, "baz-svc-v3", &testNamespace)
+				invalidRef := createBackendRef(&kindInvalid, "bar-svc", &testNamespace) // invalid kind
+
+				// httproutes
+				hr1 = createRoute("hr1", "gw", "foo.example.com", fooRef)
+				hr2 = createRoute("hr2", "gw", "bar.example.com", barRef)
+				hr3 = createRoute("hr3", "gw", "bar.2.example.com", barRef) // shares backend ref with hr2
+				hrInvalidBackendRef = createRoute("hr-invalid", "gw", "invalid.example.com", invalidRef)
+				hrMultipleRules = createRouteWithMultipleRules(
+					"hr-multiple-rules",
+					"gw",
+					"mutli.example.com",
+					[]v1alpha2.HTTPRouteRule{
+						createHTTPRule("/baz-v1", baz1Ref),
+						createHTTPRule("/baz-v2", baz2Ref),
+						createHTTPRule("/baz-v3", baz3Ref),
+					},
+				)
+
+				// services
+				hr1svc = createSvc("foo-svc")
+				sharedSvc = createSvc("bar-svc")  // shared between hr2 and hr3
+				invalidSvc = createSvc("invalid") // nsname matches invalid BackendRef
+				notRefSvc = createSvc("not-ref")
+				bazSvc1 = createSvc("baz-svc-v1")
+				bazSvc2 = createSvc("baz-svc-v2")
+				bazSvc3 = createSvc("baz-svc-v3")
+
+				// endpoint slices
+				hr1SvcEndpointSlice1 = createEndpointSlice("hr1-1", metav1.OwnerReference{Kind: "Service", Name: "not-ref"}, svcToOwnerRef(hr1svc))
+				hr1SvcEndpointSlice2 = createEndpointSlice("hr1-2", svcToOwnerRef(hr1svc))
+				invalidKindEndpointSlice = createEndpointSlice("invalid-kind", metav1.OwnerReference{Kind: "Invalid", Name: "foo-svc"}) // same name as hr1svc but invalid Kind.
+				notRefEndpointSlice = createEndpointSlice(
+					"not-ref",
+					metav1.OwnerReference{Kind: "Service", Name: "not-ref"},
+					metav1.OwnerReference{Kind: "Service", Name: "another-not-ref"},
+				)
+
+			})
+
+			testProcessChangedVal := func(expChanged bool) {
+				changed, _, _ := processor.Process()
+				Expect(changed).To(Equal(expChanged))
+			}
+
+			testUpsertTriggersChange := func(obj client.Object, expChanged bool) {
+				processor.CaptureUpsertChange(obj)
+				testProcessChangedVal(expChanged)
+			}
+
+			testDeleteTriggersChange := func(obj client.Object, nsname types.NamespacedName, expChanged bool) {
+				processor.CaptureDeleteChange(obj, nsname)
+				testProcessChangedVal(expChanged)
+			}
+
+			It("add hr1", func() {
+				testUpsertTriggersChange(hr1, true)
+			})
+			It("add service for hr1", func() {
+				testUpsertTriggersChange(hr1svc, true)
+			})
+			It("add endpoint slice for hr1", func() {
+				testUpsertTriggersChange(hr1SvcEndpointSlice1, true)
+			})
+			It("update for service for hr1", func() {
+				testUpsertTriggersChange(hr1svc, true)
+			})
+			It("add second endpoint slice for hr1", func() {
+				testUpsertTriggersChange(hr1SvcEndpointSlice2, true)
+			})
+			It("add endpoint slice with invalid kind", func() {
+				testUpsertTriggersChange(invalidKindEndpointSlice, false)
+			})
+			It("delete one endpoint slice for hr1", func() {
+				testDeleteTriggersChange(hr1SvcEndpointSlice1, types.NamespacedName{Namespace: hr1SvcEndpointSlice1.Namespace, Name: hr1SvcEndpointSlice1.Name}, true)
+			})
+			It("delete second endpoint slice for hr1", func() {
+				testDeleteTriggersChange(hr1SvcEndpointSlice2, types.NamespacedName{Namespace: hr1SvcEndpointSlice2.Namespace, Name: hr1SvcEndpointSlice2.Name}, true)
+			})
+			It("recreate second endpoint slice for hr1", func() {
+				testUpsertTriggersChange(hr1SvcEndpointSlice2, true)
+			})
+			It("delete hr1", func() {
+				testDeleteTriggersChange(hr1, types.NamespacedName{Namespace: hr1.Namespace, Name: hr1.Name}, true)
+			})
+			It("delete service for hr1", func() {
+				testDeleteTriggersChange(hr1svc, types.NamespacedName{Namespace: hr1svc.Namespace, Name: hr1svc.Name}, false)
+			})
+			It("delete second endpoint slice for hr1", func() {
+				testDeleteTriggersChange(hr1SvcEndpointSlice2, types.NamespacedName{Namespace: hr1SvcEndpointSlice2.Namespace, Name: hr1SvcEndpointSlice2.Name}, false)
+			})
+			It("add hr2", func() {
+				testUpsertTriggersChange(hr2, true)
+			})
+			It("add hr3 -- a route that shares a backend service with hr2", func() {
+				testUpsertTriggersChange(hr3, true)
+			})
+			It("add service referenced by both hr2 and hr3", func() {
+				testUpsertTriggersChange(sharedSvc, true)
+			})
+			It("delete hr2", func() {
+				testDeleteTriggersChange(hr2, types.NamespacedName{Namespace: hr2.Namespace, Name: hr2.Name}, true)
+			})
+			It("delete shared service", func() {
+				testDeleteTriggersChange(sharedSvc, types.NamespacedName{Namespace: sharedSvc.Namespace, Name: sharedSvc.Name}, true)
+			})
+			It("recreate shared service", func() {
+				testUpsertTriggersChange(sharedSvc, true)
+			})
+			It("delete hr3", func() {
+				testDeleteTriggersChange(hr3, types.NamespacedName{Namespace: hr3.Namespace, Name: hr3.Name}, true)
+			})
+			It("delete shared service", func() {
+				testDeleteTriggersChange(sharedSvc, types.NamespacedName{Namespace: sharedSvc.Namespace, Name: sharedSvc.Name}, false)
+			})
+			It("add service that is not referenced by any route", func() {
+				testUpsertTriggersChange(notRefSvc, false)
+			})
+			It("add route with an invalid backend ref type", func() {
+				testUpsertTriggersChange(hrInvalidBackendRef, true)
+			})
+			It("add service with a namespace name that matches invalid backend ref (should be ignored)", func() {
+				testUpsertTriggersChange(invalidSvc, false)
+			})
+			It("add endpoint slice that is not owned by a referenced service", func() {
+				testUpsertTriggersChange(notRefEndpointSlice, false)
+			})
+			It("delete endpoint slice that is not owned by a referenced service", func() {
+				testDeleteTriggersChange(notRefEndpointSlice, types.NamespacedName{Namespace: notRefEndpointSlice.Namespace, Name: notRefEndpointSlice.Name}, false)
+			})
+			When("processing a route with multiple rules and three unique backend services", func() {
+				It("adds route", func() {
+					testUpsertTriggersChange(hrMultipleRules, true)
+				})
+				It("adds one referenced service", func() {
+					testUpsertTriggersChange(bazSvc1, true)
+				})
+				It("adds second referenced service", func() {
+					testUpsertTriggersChange(bazSvc2, true)
+				})
+				It("deletes first referenced service", func() {
+					testDeleteTriggersChange(bazSvc1, types.NamespacedName{Namespace: bazSvc1.Namespace, Name: bazSvc1.Name}, true)
+				})
+				It("recreates first referenced service", func() {
+					testUpsertTriggersChange(bazSvc1, true)
+				})
+				It("adds third referenced service", func() {
+					testUpsertTriggersChange(bazSvc3, true)
+				})
+				It("updates third referenced service", func() {
+					testUpsertTriggersChange(bazSvc3, true)
+				})
+				It("deletes route with multiple services", func() {
+					testDeleteTriggersChange(hrMultipleRules, types.NamespacedName{Namespace: hrMultipleRules.Namespace, Name: hrMultipleRules.Name}, true)
+				})
+				It("deletes first service", func() {
+					testDeleteTriggersChange(bazSvc1, types.NamespacedName{Namespace: bazSvc1.Namespace, Name: bazSvc1.Name}, false)
+				})
+				It("deletes second service", func() {
+					testDeleteTriggersChange(bazSvc2, types.NamespacedName{Namespace: bazSvc2.Namespace, Name: bazSvc2.Name}, false)
+				})
+				It("deletes final service", func() {
+					testDeleteTriggersChange(bazSvc3, types.NamespacedName{Namespace: bazSvc3.Namespace, Name: bazSvc3.Name}, false)
+				})
 			})
 		})
 	})

--- a/internal/state/services.go
+++ b/internal/state/services.go
@@ -1,36 +1,51 @@
 package state
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	discoveryV1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . ServiceStore
 
-// ServiceStore stores services and can be queried for the cluster IP of a service.
+// k8sServiceNameLabel is a Kubernetes label that holds the service name that owns the endpoint slice.
+// Used to lookup endpoint slices for a given service.
+const k8sServiceNameLabel = "kubernetes.io/service-name"
+
+// Endpoint is the internal representation of a Kubernetes endpoint.
+type Endpoint struct {
+	Address string
+	Port    int32
+}
+
+// ServiceStore stores services and can be queried for the endpoints of a service.
 type ServiceStore interface {
 	// Upsert upserts the service into the store.
 	Upsert(svc *v1.Service)
 	// Delete deletes the service from the store.
 	Delete(nsname types.NamespacedName)
-	// Resolve returns the cluster IP  the service specified by its namespace and name.
-	// If the service doesn't have a cluster IP or it doesn't exist, resolve will return an error.
-	// FIXME(pleshakov): later, we will start using the Endpoints rather than cluster IPs.
-	Resolve(nsname types.NamespacedName) (string, error)
+	// Resolve returns the endpoints for the service specified by its nsname and port.
+	// If the service doesn't have endpoints, or it doesn't exist, resolve will return an error.
+	Resolve(nsname types.NamespacedName, port int32) ([]Endpoint, error)
 }
 
 // NewServiceStore creates a new ServiceStore.
-func NewServiceStore() ServiceStore {
+func NewServiceStore(k8sClient client.Client) *serviceStoreImpl {
 	return &serviceStoreImpl{
-		services: make(map[string]*v1.Service),
+		services:  make(map[string]*v1.Service),
+		k8sClient: k8sClient,
 	}
 }
 
 type serviceStoreImpl struct {
-	services map[string]*v1.Service
+	services  map[string]*v1.Service
+	k8sClient client.Client
 }
 
 func (s *serviceStoreImpl) Upsert(svc *v1.Service) {
@@ -41,17 +56,119 @@ func (s *serviceStoreImpl) Delete(nsname types.NamespacedName) {
 	delete(s.services, nsname.String())
 }
 
-func (s *serviceStoreImpl) Resolve(nsname types.NamespacedName) (string, error) {
+func (s *serviceStoreImpl) Resolve(nsname types.NamespacedName, port int32) ([]Endpoint, error) {
 	svc, exist := s.services[nsname.String()]
 	if !exist {
-		return "", fmt.Errorf("service %s doesn't exist", nsname.String())
+		return nil, fmt.Errorf("service %s doesn't exist", nsname)
 	}
 
-	if svc.Spec.ClusterIP == "" || svc.Spec.ClusterIP == "None" {
-		return "", fmt.Errorf("service %s doesn't have ClusterIP", nsname.String())
+	targetPort := getTargetPort(svc, port)
+	if targetPort == 0 {
+		return nil, fmt.Errorf("no matching target port for service %s and port %d", nsname, port)
 	}
 
-	return svc.Spec.ClusterIP, nil
+	endpoints, err := s.resolveEndpoints(svc, targetPort)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve endpoints for service %s: %w", nsname, err)
+	}
+
+	return endpoints, nil
+}
+
+func getTargetPort(svc *v1.Service, svcPort int32) int32 {
+	for _, port := range svc.Spec.Ports {
+		if port.Port == svcPort {
+			return int32(port.TargetPort.IntValue())
+		}
+	}
+
+	return 0
+}
+
+func (s *serviceStoreImpl) resolveEndpoints(svc *v1.Service, targetPort int32) ([]Endpoint, error) {
+	var endpointSliceList discoveryV1.EndpointSliceList
+
+	err := s.k8sClient.List(context.TODO(), &endpointSliceList, client.MatchingLabels{k8sServiceNameLabel: svc.Name})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(endpointSliceList.Items) == 0 {
+		return nil, errors.New("no endpoints found")
+	}
+
+	capacity := calculateEndpointSliceCapacity(endpointSliceList.Items, targetPort)
+
+	if capacity == 0 {
+		return nil, errors.New("no valid endpoints found")
+	}
+
+	endpoints := make([]Endpoint, 0, capacity)
+
+	for _, eps := range endpointSliceList.Items {
+		// FIXME(kate-osborn): only handling ipv4 addresses right now
+		if eps.AddressType != discoveryV1.AddressTypeIPv4 {
+			continue
+		}
+
+		if !targetPortExists(eps.Ports, targetPort) {
+			continue
+		}
+
+		for _, endpoint := range eps.Endpoints {
+
+			if !endpointReady(endpoint) {
+				continue
+			}
+
+			for _, address := range endpoint.Addresses {
+				ep := Endpoint{Address: address, Port: targetPort}
+				endpoints = append(endpoints, ep)
+			}
+		}
+	}
+
+	return endpoints, nil
+}
+
+func calculateEndpointSliceCapacity(endpointSlices []discoveryV1.EndpointSlice, targetPort int32) (capacity int) {
+	for _, es := range endpointSlices {
+		if es.AddressType != discoveryV1.AddressTypeIPv4 {
+			continue
+		}
+
+		if !targetPortExists(es.Ports, targetPort) {
+			continue
+		}
+
+		for _, e := range es.Endpoints {
+			if !endpointReady(e) {
+				continue
+			}
+			capacity += len(e.Addresses)
+		}
+	}
+
+	return
+}
+
+func endpointReady(endpoint discoveryV1.Endpoint) bool {
+	ready := endpoint.Conditions.Ready
+	return ready != nil && *ready
+}
+
+func targetPortExists(ports []discoveryV1.EndpointPort, targetPort int32) bool {
+	for _, port := range ports {
+		if port.Port == nil {
+			continue
+		}
+
+		if *port.Port == targetPort {
+			return true
+		}
+	}
+
+	return false
 }
 
 func getResourceKey(meta *metav1.ObjectMeta) string {

--- a/internal/state/services_test.go
+++ b/internal/state/services_test.go
@@ -1,104 +1,361 @@
 package state
 
 import (
+	"context"
+	"testing"
+
 	. "github.com/onsi/ginkgo/v2"
 	apiv1 "k8s.io/api/core/v1"
+	discoveryV1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	. "github.com/onsi/gomega"
+
+	"github.com/nginxinc/nginx-kubernetes-gateway/internal/helpers"
 )
 
+func createEndpointSlice(name, serviceName string, addresses []string, ports []int32, addressType discoveryV1.AddressType) *discoveryV1.EndpointSlice {
+	es := &discoveryV1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "test",
+			Labels: map[string]string{
+				"kubernetes.io/service-name": serviceName,
+			},
+		},
+		AddressType: addressType,
+		Endpoints: []discoveryV1.Endpoint{
+			{
+				Addresses: addresses,
+				Conditions: discoveryV1.EndpointConditions{
+					Ready: helpers.GetBoolPointer(true),
+				},
+			},
+			{
+				Addresses: []string{"1.0.0.1", "1.0.0.2", "1.0.0.3"},
+				Conditions: discoveryV1.EndpointConditions{
+					Serving:     helpers.GetBoolPointer(true),
+					Terminating: helpers.GetBoolPointer(true),
+				},
+			},
+			{
+				Addresses:  []string{"2.0.0.1", "2.0.0.2", "2.0.0.3"},
+				Conditions: discoveryV1.EndpointConditions{
+					// nil conditions should be treated as not ready
+				},
+			},
+		},
+		Ports: make([]discoveryV1.EndpointPort, len(ports)),
+	}
+
+	for i, p := range ports {
+		port := p
+		es.Ports[i] = discoveryV1.EndpointPort{Port: &port}
+	}
+
+	return es
+}
+
+func createService(name string) *apiv1.Service {
+	return &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      name,
+		},
+		Spec: apiv1.ServiceSpec{
+			Ports: []apiv1.ServicePort{
+				{
+					Port: 80,
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 8080,
+					},
+				},
+				{
+					Port: 443,
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: "8443",
+					},
+				},
+			},
+		},
+	}
+}
+
+func createExpectedEndpoints(addresses []string, port int32) []Endpoint {
+	expEndpoints := make([]Endpoint, len(addresses))
+	for idx, addr := range addresses {
+		expEndpoints[idx] = Endpoint{Address: addr, Port: port}
+	}
+
+	return expEndpoints
+}
+
 var _ = Describe("ServiceStore", func() {
-	var store ServiceStore
+	var (
+		store         ServiceStore
+		fakeK8sClient client.Client
+	)
 
-	BeforeEach(OncePerOrdered, func() {
-		store = NewServiceStore()
-	})
+	var (
+		fooAddresses1    = []string{"9.0.0.1", "9.0.0.2", "9.0.0.3"}
+		fooAddresses2    = []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}
+		fooIPV6Addresses = []string{"FE80:CD00:0:CDE:1257:0:211E:729C"}
 
-	Describe("Resolve Service", Ordered, func() {
-		var svc *apiv1.Service
-		var svcUpdated *apiv1.Service
+		barAddresses     = []string{"13.0.0.1", "13.0.0.2"}
+		bar8081Addresses = []string{"12.0.0.1", "12.0.0.2"}
 
+		ports    = []int32{8080, 8443}
+		port8081 = []int32{8081}
+
+		fooSvc        = createService("foo")
+		barSvc        = createService("bar")
+		noEndpointSvc = createService("no-endpoints")
+
+		// foo endpoints
+		fooEndpointSlice1    = createEndpointSlice("foo-1", "foo", fooAddresses1, ports, discoveryV1.AddressTypeIPv4)
+		fooEndpointSlice2    = createEndpointSlice("foo-2", "foo", fooAddresses2, ports, discoveryV1.AddressTypeIPv4)
+		fooEndpointSliceIPV6 = createEndpointSlice("foo-ipv6", "foo", fooIPV6Addresses, port8081, discoveryV1.AddressTypeIPv6)
+
+		// bar endpoints
+		barEndpointSlice1        = createEndpointSlice("bar", "bar", barAddresses, ports, discoveryV1.AddressTypeIPv4)
+		fooEndpointSlicePort8081 = createEndpointSlice("bar-diff-ports", "bar", bar8081Addresses, port8081, discoveryV1.AddressTypeIPv4)
+
+		fooExpectedAddresses = append(fooAddresses1, fooAddresses2...)
+	)
+
+	Describe("Resolve", Ordered, func() {
 		BeforeAll(func() {
-			svc = &apiv1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test",
-					Name:      "service1",
-				},
-				Spec: apiv1.ServiceSpec{
-					ClusterIP: "10.0.0.1",
-				},
-			}
+			scheme := runtime.NewScheme()
+			err := discoveryV1.AddToScheme(scheme)
+			Expect(err).ToNot(HaveOccurred())
 
-			svcUpdated = svc.DeepCopy()
-			// In reality, ClusterIP cannot change for a regular service.
-			// However, it is ok to use this change to test the Upsert function.
-			svcUpdated.Spec.ClusterIP = "10.0.0.2"
+			fakeK8sClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(fooEndpointSlice1, fooEndpointSlice2, fooEndpointSlicePort8081, fooEndpointSliceIPV6, barEndpointSlice1).
+				Build()
+
+			store = NewServiceStore(fakeK8sClient)
 		})
 
+		testResolve := func(svcName string, svcPort int32, expEndpoints []Endpoint) {
+			endpoints, err := store.Resolve(types.NamespacedName{Namespace: "test", Name: svcName}, svcPort)
+			Expect(err).To(BeNil())
+
+			Expect(endpoints).To(ConsistOf(expEndpoints))
+		}
+
 		It("should add a service", func() {
-			store.Upsert(svc)
+			store.Upsert(fooSvc)
 		})
 
 		It("should resolve the service", func() {
-			address, err := store.Resolve(types.NamespacedName{Namespace: "test", Name: "service1"})
+			testResolve("foo", 80, createExpectedEndpoints(fooExpectedAddresses, 8080))
+			testResolve("foo", 443, createExpectedEndpoints(fooExpectedAddresses, 8443))
+		})
 
-			Expect(address).To(Equal("10.0.0.1"))
-			Expect(err).To(BeNil())
+		It("should add a new service", func() {
+			store.Upsert(barSvc)
+		})
+
+		It("should resolve the service", func() {
+			testResolve("bar", 80, createExpectedEndpoints(barAddresses, 8080))
+			testResolve("bar", 443, createExpectedEndpoints(barAddresses, 8443))
+		})
+		When("port does not exist in service spec", func() {
+			It("should return an error", func() {
+				endpoints, err := store.Resolve(types.NamespacedName{Namespace: "test", Name: "bar"}, 8080)
+				Expect(err).ToNot(BeNil())
+				Expect(endpoints).To(BeNil())
+			})
 		})
 
 		It("should update the service", func() {
-			store.Upsert(svcUpdated)
+			barSvcUpdated := barSvc.DeepCopy()
+			barSvcUpdated.Spec.Ports[0].TargetPort.IntVal = 8081
+
+			store.Upsert(barSvcUpdated)
 		})
-
 		It("should resolve the updated service", func() {
-			address, err := store.Resolve(types.NamespacedName{Namespace: "test", Name: "service1"})
-
-			Expect(address).To(Equal("10.0.0.2"))
-			Expect(err).To(BeNil())
-
+			testResolve("bar", 80, createExpectedEndpoints(bar8081Addresses, 8081))
 		})
 
 		It("should delete the service", func() {
-			store.Delete(types.NamespacedName{Namespace: "test", Name: "service1"})
+			store.Delete(types.NamespacedName{Namespace: "test", Name: "bar"})
 		})
 
 		It("should fail to resolve the service", func() {
-			_, err := store.Resolve(types.NamespacedName{Namespace: "test", Name: "service1"})
+			endpoints, err := store.Resolve(types.NamespacedName{Namespace: "test", Name: "bar"}, 80)
 
 			Expect(err).To(HaveOccurred())
+			Expect(endpoints).To(BeNil())
 		})
-	})
-
-	Describe("Edge cases", func() {
-		BeforeEach(func() {
-			store.Upsert(&apiv1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test",
-					Name:      "empty-ip",
-				},
-			})
-
-			store.Upsert(&apiv1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test",
-					Name:      "none-ip",
-				},
-				Spec: apiv1.ServiceSpec{
-					ClusterIP: "None",
-				},
-			})
+		It("should still resolve remaining service", func() {
+			testResolve("foo", 80, createExpectedEndpoints(fooExpectedAddresses, 8080))
+			testResolve("foo", 443, createExpectedEndpoints(fooExpectedAddresses, 8443))
 		})
-		DescribeTable("Resolve returns error",
-			func(nsname types.NamespacedName) {
-				_, err := store.Resolve(nsname)
+		When("resolving a service has no valid endpoints", func() {
+			It("should return an error", func() {
+				// Delete all valid foo endpoints
+				Expect(fakeK8sClient.Delete(context.TODO(), fooEndpointSlice1)).To(Succeed())
+				Expect(fakeK8sClient.Delete(context.TODO(), fooEndpointSlice2)).To(Succeed())
+
+				endpoints, err := store.Resolve(types.NamespacedName{Namespace: "test", Name: "foo"}, 80)
 
 				Expect(err).To(HaveOccurred())
-			},
-			Entry("cluster ip is empty", types.NamespacedName{Namespace: "test", Name: "empty-ip"}),
-			Entry("cluster ip is none", types.NamespacedName{Namespace: "test", Name: "none-ip"}),
-			Entry("service doesn't exist", types.NamespacedName{Namespace: "test", Name: "service"}),
-		)
+				Expect(err.Error()).To(ContainSubstring("no valid endpoints found"))
+				Expect(endpoints).To(BeNil())
+			})
+		})
+		It("should add a service with no endpoints", func() {
+			store.Upsert(noEndpointSvc)
+		})
+		When("resolving a service with no endpoints", func() {
+			It("should return an error", func() {
+				endpoints, err := store.Resolve(types.NamespacedName{Namespace: "test", Name: "no-endpoints"}, 80)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("no endpoints found"))
+				Expect(endpoints).To(BeNil())
+			})
+		})
+		When("resolving a service with no ready endpoints", func() {
+			It("should return an error", func() {
+				endpoints, err := store.Resolve(types.NamespacedName{Namespace: "test", Name: "no-endpoints"}, 80)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("no endpoints found"))
+				Expect(endpoints).To(BeNil())
+			})
+		})
 	})
 })
+
+func TestCalculateEndpointSliceCapacity(t *testing.T) {
+
+	addresses := []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}
+
+	readyEndpoint1 := discoveryV1.Endpoint{
+		Addresses:  addresses,
+		Conditions: discoveryV1.EndpointConditions{Ready: helpers.GetBoolPointer(true)},
+	}
+
+	notReadyEndpoint := discoveryV1.Endpoint{
+		Addresses:  addresses,
+		Conditions: discoveryV1.EndpointConditions{Ready: helpers.GetBoolPointer(false)},
+	}
+
+	validEndpointSlice := discoveryV1.EndpointSlice{
+		AddressType: discoveryV1.AddressTypeIPv4,
+		Endpoints:   []discoveryV1.Endpoint{readyEndpoint1, readyEndpoint1, readyEndpoint1}, // in reality these endpoints would be different but for this test it doesn't matter
+		Ports: []discoveryV1.EndpointPort{
+			{
+				Port: helpers.GetInt32Pointer(80),
+			},
+			{
+				Port: helpers.GetInt32Pointer(443),
+			},
+		},
+	}
+
+	invalidAddressTypeEndpointSlice := discoveryV1.EndpointSlice{
+		AddressType: discoveryV1.AddressTypeIPv6,
+		Endpoints:   []discoveryV1.Endpoint{readyEndpoint1},
+		Ports: []discoveryV1.EndpointPort{
+			{
+				Port: helpers.GetInt32Pointer(80),
+			},
+		},
+	}
+
+	invalidPortEndpointSlice := discoveryV1.EndpointSlice{
+		AddressType: discoveryV1.AddressTypeIPv4,
+		Endpoints:   []discoveryV1.Endpoint{readyEndpoint1},
+		Ports: []discoveryV1.EndpointPort{
+			{
+				Port: helpers.GetInt32Pointer(8080),
+			},
+		},
+	}
+
+	notReadyEndpointSlice := discoveryV1.EndpointSlice{
+		AddressType: discoveryV1.AddressTypeIPv4,
+		Endpoints:   []discoveryV1.Endpoint{notReadyEndpoint, notReadyEndpoint}, // in reality these endpoints would be different but for this test it doesn't matter
+		Ports: []discoveryV1.EndpointPort{
+			{
+				Port: helpers.GetInt32Pointer(80),
+			},
+			{
+				Port: helpers.GetInt32Pointer(443),
+			},
+		},
+	}
+
+	mixedValidityEndpointSlice := discoveryV1.EndpointSlice{
+		AddressType: discoveryV1.AddressTypeIPv4,
+		Endpoints:   []discoveryV1.Endpoint{readyEndpoint1, notReadyEndpoint, readyEndpoint1}, // 6 valid endpoints
+		Ports: []discoveryV1.EndpointPort{
+			{
+				Port: helpers.GetInt32Pointer(80),
+			},
+		},
+	}
+
+	testcases := []struct {
+		msg            string
+		endpointSlices []discoveryV1.EndpointSlice
+		targetPort     int32
+		expCapacity    int
+	}{
+		{
+			msg: "multiple endpoint slices - multiple valid endpoints",
+			endpointSlices: []discoveryV1.EndpointSlice{
+				validEndpointSlice,
+				validEndpointSlice}, // in reality these endpoints would be different but for this test it doesn't matter
+			targetPort:  80,
+			expCapacity: 18,
+		},
+		{
+			msg: "multiple endpoint slices - some valid ",
+			endpointSlices: []discoveryV1.EndpointSlice{
+				validEndpointSlice,
+				invalidAddressTypeEndpointSlice,
+				validEndpointSlice,
+				invalidPortEndpointSlice,
+			},
+			targetPort:  80,
+			expCapacity: 18,
+		},
+		{
+			msg:            "multiple endpoints - some valid ",
+			endpointSlices: []discoveryV1.EndpointSlice{mixedValidityEndpointSlice},
+			targetPort:     80,
+			expCapacity:    6,
+		},
+		{
+			msg:            "multiple endpoint slices - all invalid ",
+			endpointSlices: []discoveryV1.EndpointSlice{invalidAddressTypeEndpointSlice, invalidPortEndpointSlice},
+			targetPort:     80,
+			expCapacity:    0,
+		},
+		{
+			msg:            "multiple endpoints - all invalid ",
+			endpointSlices: []discoveryV1.EndpointSlice{notReadyEndpointSlice},
+			targetPort:     80,
+			expCapacity:    0,
+		},
+	}
+
+	for _, tc := range testcases {
+		capacity := calculateEndpointSliceCapacity(tc.endpointSlices, tc.targetPort)
+		if capacity != tc.expCapacity {
+			t.Errorf("calculateEndpointSliceCapacity() returned %d but expected %d for test: %q", capacity, tc.expCapacity, tc.msg)
+		}
+	}
+}

--- a/internal/state/statefakes/fake_service_store.go
+++ b/internal/state/statefakes/fake_service_store.go
@@ -15,17 +15,18 @@ type FakeServiceStore struct {
 	deleteArgsForCall []struct {
 		arg1 types.NamespacedName
 	}
-	ResolveStub        func(types.NamespacedName) (string, error)
+	ResolveStub        func(types.NamespacedName, int32) ([]state.Endpoint, error)
 	resolveMutex       sync.RWMutex
 	resolveArgsForCall []struct {
 		arg1 types.NamespacedName
+		arg2 int32
 	}
 	resolveReturns struct {
-		result1 string
+		result1 []state.Endpoint
 		result2 error
 	}
 	resolveReturnsOnCall map[int]struct {
-		result1 string
+		result1 []state.Endpoint
 		result2 error
 	}
 	UpsertStub        func(*v1.Service)
@@ -69,18 +70,19 @@ func (fake *FakeServiceStore) DeleteArgsForCall(i int) types.NamespacedName {
 	return argsForCall.arg1
 }
 
-func (fake *FakeServiceStore) Resolve(arg1 types.NamespacedName) (string, error) {
+func (fake *FakeServiceStore) Resolve(arg1 types.NamespacedName, arg2 int32) ([]state.Endpoint, error) {
 	fake.resolveMutex.Lock()
 	ret, specificReturn := fake.resolveReturnsOnCall[len(fake.resolveArgsForCall)]
 	fake.resolveArgsForCall = append(fake.resolveArgsForCall, struct {
 		arg1 types.NamespacedName
-	}{arg1})
+		arg2 int32
+	}{arg1, arg2})
 	stub := fake.ResolveStub
 	fakeReturns := fake.resolveReturns
-	fake.recordInvocation("Resolve", []interface{}{arg1})
+	fake.recordInvocation("Resolve", []interface{}{arg1, arg2})
 	fake.resolveMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -94,41 +96,41 @@ func (fake *FakeServiceStore) ResolveCallCount() int {
 	return len(fake.resolveArgsForCall)
 }
 
-func (fake *FakeServiceStore) ResolveCalls(stub func(types.NamespacedName) (string, error)) {
+func (fake *FakeServiceStore) ResolveCalls(stub func(types.NamespacedName, int32) ([]state.Endpoint, error)) {
 	fake.resolveMutex.Lock()
 	defer fake.resolveMutex.Unlock()
 	fake.ResolveStub = stub
 }
 
-func (fake *FakeServiceStore) ResolveArgsForCall(i int) types.NamespacedName {
+func (fake *FakeServiceStore) ResolveArgsForCall(i int) (types.NamespacedName, int32) {
 	fake.resolveMutex.RLock()
 	defer fake.resolveMutex.RUnlock()
 	argsForCall := fake.resolveArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeServiceStore) ResolveReturns(result1 string, result2 error) {
+func (fake *FakeServiceStore) ResolveReturns(result1 []state.Endpoint, result2 error) {
 	fake.resolveMutex.Lock()
 	defer fake.resolveMutex.Unlock()
 	fake.ResolveStub = nil
 	fake.resolveReturns = struct {
-		result1 string
+		result1 []state.Endpoint
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeServiceStore) ResolveReturnsOnCall(i int, result1 string, result2 error) {
+func (fake *FakeServiceStore) ResolveReturnsOnCall(i int, result1 []state.Endpoint, result2 error) {
 	fake.resolveMutex.Lock()
 	defer fake.resolveMutex.Unlock()
 	fake.ResolveStub = nil
 	if fake.resolveReturnsOnCall == nil {
 		fake.resolveReturnsOnCall = make(map[int]struct {
-			result1 string
+			result1 []state.Endpoint
 			result2 error
 		})
 	}
 	fake.resolveReturnsOnCall[i] = struct {
-		result1 string
+		result1 []state.Endpoint
 		result2 error
 	}{result1, result2}
 }

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	discoveryV1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
@@ -10,11 +11,18 @@ type store struct {
 	gc         *v1alpha2.GatewayClass
 	gateways   map[types.NamespacedName]*v1alpha2.Gateway
 	httpRoutes map[types.NamespacedName]*v1alpha2.HTTPRoute
+
+	// services maps services to the set of http routes that reference the service.
+	services map[types.NamespacedName]map[types.NamespacedName]struct{}
+	// endpointSlices is the set of endpoint slices that belong to the services we are tracking.
+	endpointSlices map[types.NamespacedName]*discoveryV1.EndpointSlice
 }
 
 func newStore() *store {
 	return &store{
-		gateways:   make(map[types.NamespacedName]*v1alpha2.Gateway),
-		httpRoutes: make(map[types.NamespacedName]*v1alpha2.HTTPRoute),
+		gateways:       make(map[types.NamespacedName]*v1alpha2.Gateway),
+		httpRoutes:     make(map[types.NamespacedName]*v1alpha2.HTTPRoute),
+		services:       make(map[types.NamespacedName]map[types.NamespacedName]struct{}),
+		endpointSlices: make(map[types.NamespacedName]*discoveryV1.EndpointSlice),
 	}
 }

--- a/pkg/sdk/endpointslice_controller.go
+++ b/pkg/sdk/endpointslice_controller.go
@@ -1,0 +1,62 @@
+package sdk
+
+import (
+	"context"
+
+	discoveryV1 "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctlr "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type endpointSliceReconciler struct {
+	client.Client
+	scheme *runtime.Scheme
+	impl   EndpointSliceImpl
+}
+
+// RegisterEndpointSliceController registers the EndpointSliceController in the manager.
+func RegisterEndpointSliceController(mgr manager.Manager, impl EndpointSliceImpl) error {
+	r := &endpointSliceReconciler{
+		Client: mgr.GetClient(),
+		scheme: mgr.GetScheme(),
+		impl:   impl,
+	}
+
+	return ctlr.NewControllerManagedBy(mgr).
+		For(&discoveryV1.EndpointSlice{}).
+		Complete(r)
+}
+
+func (r *endpointSliceReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := log.FromContext(ctx).WithValues("endpointslice", req.NamespacedName)
+
+	log.V(3).Info("Reconciling Endpoint Slice")
+
+	found := true
+	var endpSlice discoveryV1.EndpointSlice
+	err := r.Get(ctx, req.NamespacedName, &endpSlice)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "Failed to get Endpoint Slice")
+			return reconcile.Result{}, err
+		}
+		found = false
+	}
+
+	if !found {
+		log.V(3).Info("Removing Endpoint Slice")
+
+		r.impl.Remove(req.NamespacedName)
+		return reconcile.Result{}, nil
+	}
+
+	log.V(3).Info("Upserting Endpoint Slice")
+
+	r.impl.Upsert(&endpSlice)
+	return reconcile.Result{}, nil
+}

--- a/pkg/sdk/interfaces.go
+++ b/pkg/sdk/interfaces.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 
@@ -37,4 +38,9 @@ type ServiceImpl interface {
 type SecretImpl interface {
 	Upsert(secret *apiv1.Secret)
 	Remove(name types.NamespacedName)
+}
+
+type EndpointSliceImpl interface {
+	Upsert(endpSlice *v1.EndpointSlice)
+	Remove(nsname types.NamespacedName)
 }


### PR DESCRIPTION
Adds endpoint slice reconciler and support for dynamic upstreams.

Watches endpoint slices and reconfigures nginx when endpoints that are needed by http routes are upserted or deleted. I verified that all of our examples work and that relevant endpoint updates trigger nginx re-config. 

Targeting commit e06fb3f3f4485acce68a3862653048487c8f0d2f to avoid rebasing. 