### PR TITLE
Use 0.1.0 version in release-0.1 branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = edge
+VERSION = 0.1.0
 TAG = $(VERSION)
 PREFIX ?= nginx-kubernetes-gateway
 

--- a/deploy/manifests/nginx-gateway.yaml
+++ b/deploy/manifests/nginx-gateway.yaml
@@ -86,8 +86,8 @@ spec:
         - name: nginx-config
           mountPath: /etc/nginx
       containers:
-      - image: ghcr.io/nginxinc/nginx-kubernetes-gateway:edge
-        imagePullPolicy: Always
+      - image: ghcr.io/nginxinc/nginx-kubernetes-gateway:0.1.0
+        imagePullPolicy: IfNotPresent
         name: nginx-gateway
         volumeMounts:
         - name: nginx-config

--- a/docs/building-the-image.md
+++ b/docs/building-the-image.md
@@ -12,7 +12,7 @@ Before you can build the NGINX Kubernetes Gateway, make sure you have the follow
 1. Clone the repo and change into the `nginx-kubernetes-gateway` directory:
 
    ```
-   git clone https://github.com/nginxinc/nginx-kubernetes-gateway.git
+   git clone https://github.com/nginxinc/nginx-kubernetes-gateway.git --branch v0.1.0
    cd nginx-kubernetes-gateway
    ```
 
@@ -22,12 +22,12 @@ Before you can build the NGINX Kubernetes Gateway, make sure you have the follow
    make PREFIX=myregistry.example.com/nginx-kubernetes-gateway container
    ```
 
-   Set the `PREFIX` variable to the name of the registry you'd like to push the image to. By default, the image will be named `nginx-kubernetes-gateway:edge`.
+   Set the `PREFIX` variable to the name of the registry you'd like to push the image to. By default, the image will be named `nginx-kubernetes-gateway:0.1.0`.
 
 1. Push the image to your container registry:
 
    ```
-   docker push myregistry.example.com/nginx-kubernetes-gateway:edge
+   docker push myregistry.example.com/nginx-kubernetes-gateway:0.1.0
    ```
 
    Make sure to substitute `myregistry.example.com/nginx-kubernetes-gateway` with your registry.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,7 @@ This guide walks you through how to install NGINX Kubernetes Gateway on a generi
 1. Clone the repo and change into the `nginx-kubernetes-gateway` directory:
 
    ```
-   git clone https://github.com/nginxinc/nginx-kubernetes-gateway.git
+   git clone https://github.com/nginxinc/nginx-kubernetes-gateway.git --branch v0.1.0
    cd nginx-kubernetes-gateway
    ```
 


### PR DESCRIPTION
### Proposed changes

- Update the tag in the container image
- Update image pull policy to IfNotPresent (0.1.0 tag will not change)
- Update the version in the Makefile
- Checkout v0.1.0 tag in the git clone instructions