### PR TITLE
Remove unnecessary HTTPRoute in cafe example

### DIFF
--- a/examples/cafe-example/cafe-routes.yaml
+++ b/examples/cafe-example/cafe-routes.yaml
@@ -1,21 +1,6 @@
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
-  name: cafe
-spec:
-  parentRefs:
-  - name: gateway
-    sectionName: http
-  hostnames:
-  - "cafe.example.com"
-  rules:
-  - backendRefs:
-    - name: main
-      port: 80
----
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: HTTPRoute
-metadata:
   name: coffee
 spec:
   parentRefs:


### PR DESCRIPTION
### Proposed changes
The cafe route with a rule for "/" routed traffic to a non-existing service. 
Thus PR removes the cafe route.