### PR TITLE
Remove deprecated linters, add gocyclo and gofumpt

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,14 +30,17 @@ linters-settings:
       - name: unused-parameter
       - name: var-declaration
       - name: var-naming
+  gocyclo:
+    min-complexity: 15
 
 linters:
     enable:
     - asciicheck
-    - deadcode
     - errcheck
     - errorlint
+    - gocyclo
     - gofmt
+    - gofumpt
     - goimports
     - gosec
     - gosimple
@@ -50,12 +53,10 @@ linters:
     - predeclared
     - revive
     - staticcheck
-    - structcheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - wastedassign
     disable-all: true
 issues:

--- a/cmd/gateway/gateway_suite_test.go
+++ b/cmd/gateway/gateway_suite_test.go
@@ -1,10 +1,10 @@
 package main_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestGateway(t *testing.T) {

--- a/cmd/gateway/setup.go
+++ b/cmd/gateway/setup.go
@@ -14,11 +14,13 @@ const (
 	errTmpl = "failed validation - flag: '--%s' reason: '%s'\n"
 )
 
-type Validator func(*flag.FlagSet) error
-type ValidatorContext struct {
-	Key string
-	V   Validator
-}
+type (
+	Validator        func(*flag.FlagSet) error
+	ValidatorContext struct {
+		Key string
+		V   Validator
+	}
+)
 
 func GatewayControllerParam(domain string, namespace string) ValidatorContext {
 	name := "gateway-ctlr-name"

--- a/internal/events/events_suit_test.go
+++ b/internal/events/events_suit_test.go
@@ -1,10 +1,10 @@
 package events_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestState(t *testing.T) {

--- a/internal/events/handler.go
+++ b/internal/events/handler.go
@@ -62,7 +62,6 @@ func NewEventHandlerImpl(cfg EventHandlerConfig) *EventHandlerImpl {
 }
 
 func (h *EventHandlerImpl) HandleEventBatch(ctx context.Context, batch EventBatch) {
-
 	for _, event := range batch {
 		switch e := event.(type) {
 		case *UpsertEvent:

--- a/internal/events/handler_test.go
+++ b/internal/events/handler_test.go
@@ -121,7 +121,6 @@ var _ = Describe("EventHandler", func() {
 
 				// Check that a reconfig happened
 				expectReconfig(fakeConf, fakeCfg, fakeStatuses)
-
 			},
 			Entry("HTTPRoute upsert", &events.UpsertEvent{Resource: &v1beta1.HTTPRoute{}}),
 			Entry("Gateway upsert", &events.UpsertEvent{Resource: &v1beta1.Gateway{}}),

--- a/internal/state/secrets_test.go
+++ b/internal/state/secrets_test.go
@@ -309,7 +309,6 @@ var _ = Describe("SecretStore", func() {
 
 		validToInvalidSecret = secret1.DeepCopy()
 		validToInvalidSecret.Data[apiv1.TLSCertKey] = invalidCert
-
 	})
 	Describe("handles CRUD events on secrets", Ordered, func() {
 		testUpsert := func(s *apiv1.Secret, valid bool) {

--- a/internal/state/services_test.go
+++ b/internal/state/services_test.go
@@ -57,7 +57,6 @@ var _ = Describe("ServiceStore", func() {
 
 			Expect(address).To(Equal("10.0.0.2"))
 			Expect(err).To(BeNil())
-
 		})
 
 		It("should delete the service", func() {

--- a/internal/status/clock.go
+++ b/internal/status/clock.go
@@ -12,8 +12,7 @@ type Clock interface {
 }
 
 // Real clock returns the current local time.
-type RealClock struct {
-}
+type RealClock struct{}
 
 // NewRealClock creates a new RealClock.
 func NewRealClock() *RealClock {

--- a/internal/status/status_suit_test.go
+++ b/internal/status/status_suit_test.go
@@ -1,10 +1,10 @@
 package status
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestState(t *testing.T) {


### PR DESCRIPTION
varcheck, deadcode, and structcheck have been deprecated https://github.com/golangci/golangci-lint/pull/3125
