### PR TITLE
Remove workaround for CVE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-// temporary fix for CVE-2022-1996
-replace k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 => k8s.io/kube-openapi v0.0.0-20220803164354-a70c9af30aea


### PR DESCRIPTION
The package was updated upstream, so the `replace` is no longer needed.

