### PR TITLE
Add help for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,41 +10,47 @@ TARGET ?= local
 KIND_KUBE_CONFIG_FOLDER = $${HOME}/.kube/kind
 OUT_DIR=$(shell pwd)/build/.out
 
-export DOCKER_BUILDKIT = 1
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: Makefile ## Display this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "; printf "Usage:\n\n    make \033[36m<target>\033[0m\n\nTargets:\n\n"}; {printf "    \033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: container
-container: build
+container: build ## Build the container
+	@docker -v || (code=$$?; printf "\033[0;31mError\033[0m: there was a problem with Docker\n"; exit $$code)
 	docker build --build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg DATE=$(DATE) --target $(TARGET) -f build/Dockerfile -t $(PREFIX):$(TAG) .
 
 .PHONY: build
-build:
+build: ## Build the binary
 ifeq (${TARGET},local)
+	@go version || (code=$$?; printf "\033[0;31mError\033[0m: unable to build locally\n"; exit $$code)
 	CGO_ENABLED=0 GOOS=linux go build -trimpath -a -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${GIT_COMMIT} -X main.date=${DATE}" -o $(OUT_DIR)/gateway github.com/nginxinc/nginx-kubernetes-gateway/cmd/gateway
 endif
 
 .PHONY: generate
-generate:
+generate: ## Run go generate
 	go generate ./...
 
-.PHONY: out_dir
-out_dir:
-	mkdir -p $(OUT_DIR)
-
 .PHONY: clean
-clean: out_dir
-	rm -rf $(OUT_DIR)
+clean: ## Clean the build
+	-rm -r $(OUT_DIR)
+
+.PHONY: clean--go-cache
+clean-go-cache: ## Clean go cache
+	@go clean -modcache
 
 .PHONY: deps
-deps:
+deps: ## Add missing and remove unused modules, verify deps and download them to local cache
 	@go mod tidy && go mod verify && go mod download
 
 .PHONY: update-codegen
-update-codegen:
+update-codegen: ## Update codegen
 	# requires the root folder of the repo to be inside the GOPATH
 	./hack/update-codegen.sh
 
 .PHONY: verify-codegen
-verify-codegen:
+verify-codegen: ## Verify code generation
 	# requires the root folder of the repo to be inside the GOPATH
 	./hack/verify-codegen.sh
 
@@ -53,31 +59,31 @@ update-crds: ## Update CRDs
 	go run sigs.k8s.io/controller-tools/cmd/controller-gen crd:crdVersions=v1 schemapatch:manifests=./deploy/manifests/crds/ paths=./pkg/apis/... output:dir=./deploy/manifests/crds/
 
 .PHONY: create-kind-cluster
-create-kind-cluster:
+create-kind-cluster: ## Create a kind cluster
 	kind create cluster --image kindest/node:v1.24.2
 	kind export kubeconfig --kubeconfig $(KIND_KUBE_CONFIG_FOLDER)/config
 
 .PHONY: delete-kind-cluster
-delete-kind-cluster:
+delete-kind-cluster: ## Delete kind cluster
 	kind delete cluster
 
 .PHONY: fmt
-fmt: ## Run go fmt against code.
+fmt: ## Run go fmt against code
 	go fmt ./...
 
 .PHONY: njs-fmt
-njs-fmt: ## Run prettier against the njs httpmatches module.
+njs-fmt: ## Run prettier against the njs httpmatches module
 	docker run --rm -w /modules \
 		-v $(PWD)/internal/nginx/modules/:/modules/ \
 		node:18 \
 		/bin/bash -c "npm install && npm run format"
 
 .PHONY: vet
-vet: ## Run go vet against code.
+vet: ## Run go vet against code
 	go vet ./...
 
 .PHONY: lint
-lint: ## Run golangci-lint against code.
+lint: ## Run golangci-lint against code
 	docker run --pull always --rm -v $(shell pwd):/nginx-kubernetes-gateway -w /nginx-kubernetes-gateway -v $(shell go env GOCACHE):/cache/go -e GOCACHE=/cache/go -e GOLANGCI_LINT_CACHE=/cache/go -v $(shell go env GOPATH)/pkg:/go/pkg golangci/golangci-lint:latest golangci-lint --color always run
 
 .PHONY: unit-test
@@ -85,11 +91,11 @@ unit-test: ## Run unit tests for the go code
 	go test ./... -race -coverprofile cover.out
 	go tool cover -html=cover.out -o cover.html
 
-njs-unit-test: ## Run unit tests for the njs httpmatches module.
+njs-unit-test: ## Run unit tests for the njs httpmatches module
 	docker run --rm -w /modules \
 		-v $(PWD)/internal/nginx/modules:/modules/ \
 		node:18 \
 		/bin/bash -c "npm install && npm test && npm run clean"
 
 .PHONY: dev-all
-dev-all: deps fmt njs-fmt vet lint unit-test njs-unit-test
+dev-all: deps fmt njs-fmt vet lint unit-test njs-unit-test ## Run all the development checks


### PR DESCRIPTION
Adds help (as default target) in the Makefile:

```
❯ make help
Usage:

    make <target>

Targets:

    build                          Build the binary
    clean-go-cache                 Clean go cache
    clean                          Clean the build
    container                      Build the container
    create-kind-cluster            Create a kind cluster
    delete-kind-cluster            Delete kind cluster
    deps                           Add missing and remove unused modules, verify deps and download them to local cache
    dev-all                        Run all the development checks
    fmt                            Run go fmt against code
    generate                       Run go generate
    help                           Display this help
    lint                           Run golangci-lint against code
    njs-fmt                        Run prettier against the njs httpmatches module
    njs-unit-test                  Run unit tests for the njs httpmatches module
    unit-test                      Run unit tests for the go code
    update-codegen                 Update codegen
    update-crds                    Update CRDs
    verify-codegen                 Verify code generation
    vet                            Run go vet against code
```

Adds a couple of checks for `docker` and `go`