### PR TITLE
Always run pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
       - release-*
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
-    paths-ignore:
-      - '**.md'
   pull_request:
     branches:
       - main
@@ -16,8 +14,6 @@ on:
       - opened
       - reopened
       - synchronize
-    paths-ignore:
-      - '**.md'
 
 defaults:
   run:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,13 +4,9 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
     types:
       - opened
       - reopened


### PR DESCRIPTION
This removes the `path-ignore`s that would block a PR containing only docs

