### PR TITLE
Add release branches to CodeQL analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,14 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - release-*
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches:
+      - main
+      - release-*
   schedule:
     - cron: '39 13 * * 6'
 


### PR DESCRIPTION
With this change the workflow will run for all the commits and PR against the release branches.
