### PR TITLE
Run CI on PRs to release branch, remove set-output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - main
+      - release-*
     types:
       - opened
       - reopened
@@ -32,7 +33,6 @@ jobs:
     name: Checks and variables
     runs-on: ubuntu-20.04
     outputs:
-      sha: ${{ steps.vars.outputs.sha }}
       go_path: ${{ steps.vars.outputs.go_path }}
     steps:
       - name: Checkout Repository
@@ -45,8 +45,7 @@ jobs:
       - name: Output Variables
         id: vars
         run: |
-          echo "::set-output name=sha::$(echo ${GITHUB_SHA} | cut -c1-7)"
-          echo "::set-output name=go_path::$(go env GOPATH)"
+          echo "go_path=$(go env GOPATH)" >> $GITHUB_OUTPUT
       - name: Check if go.mod and go.sum are up to date
         run: |
           go mod tidy && git diff --exit-code -- go.mod go.sum
@@ -68,7 +67,7 @@ jobs:
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v3
         with:
-          name: cover-${{ needs.vars.outputs.sha }}.html
+          name: cover-${{ github.run_id }}.html
           path: ${{ github.workspace }}/cover.html
         if: always()
 
@@ -129,6 +128,7 @@ jobs:
 
       - name: Download Syft
         uses: anchore/sbom-action/download-syft@v0.12.0
+        if: startsWith(github.ref, 'refs/tags/')
 
       - name: Build binary
         uses: goreleaser/goreleaser-action@v3


### PR DESCRIPTION
- Runs CI on PRs to release branches
- Uses [new format](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) for saving output
