### PR TITLE
Configure NGINX error log

### DIFF
--- a/deploy/manifests/nginx-gateway.yaml
+++ b/deploy/manifests/nginx-gateway.yaml
@@ -90,7 +90,7 @@ spec:
       initContainers:
       - image: busybox:1.34 # FIXME(pleshakov): use gateway container to init the Config with proper main config
         name: nginx-config-initializer
-        command: [ 'sh', '-c', 'echo "load_module /usr/lib/nginx/modules/ngx_http_js_module.so; events {}  pid /etc/nginx/nginx.pid; http { include /etc/nginx/conf.d/*.conf; js_import /usr/lib/nginx/modules/njs/httpmatches.js; }" > /etc/nginx/nginx.conf && mkdir /etc/nginx/conf.d /etc/nginx/secrets && chown 1001:0 /etc/nginx/conf.d /etc/nginx/secrets' ]
+        command: [ 'sh', '-c', 'echo "load_module /usr/lib/nginx/modules/ngx_http_js_module.so; events {}  pid /etc/nginx/nginx.pid; error_log stderr debug; http { include /etc/nginx/conf.d/*.conf; js_import /usr/lib/nginx/modules/njs/httpmatches.js; }" > /etc/nginx/nginx.conf && mkdir /etc/nginx/conf.d /etc/nginx/secrets && chown 1001:0 /etc/nginx/conf.d /etc/nginx/secrets' ]
         volumeMounts:
         - name: nginx-config
           mountPath: /etc/nginx


### PR DESCRIPTION
### Proposed changes
Error log will help us understand when and how NGINX gets reloaded and also see any error messages.
The Debug level is useful while the project is still in the early stage of development.

Example of new logs:
```
2022/12/01 18:06:17 [notice] 37#37: signal 1 (SIGHUP) received from 21, reconfiguring
2022/12/01 18:06:17 [notice] 37#37: reconfiguring
2022/12/01 18:06:17 [notice] 37#37: using the "epoll" event method
2022/12/01 18:06:17 [notice] 37#37: start worker processes
2022/12/01 18:06:17 [notice] 37#37: start worker process 87
2022/12/01 18:06:17 [notice] 86#86: gracefully shutting down
2022/12/01 18:06:17 [notice] 86#86: exiting
2022/12/01 18:06:17 [notice] 86#86: exit
2022/12/01 18:06:17 [notice] 37#37: signal 17 (SIGCHLD) received from 86
2022/12/01 18:06:17 [notice] 37#37: worker process 86 exited with code 0
2022/12/01 18:06:17 [notice] 37#37: signal 29 (SIGIO) received
```
