### PR TITLE
Generate default http server if http listener exists

### DIFF
--- a/internal/nginx/config/generator_test.go
+++ b/internal/nginx/config/generator_test.go
@@ -25,12 +25,21 @@ func TestGenerate(t *testing.T) {
 	conf := state.Configuration{
 		HTTPServers: []state.VirtualServer{
 			{
+				IsDefault: true,
+			},
+			{
 				Hostname: "example.com",
 			},
 		},
 		SSLServers: []state.VirtualServer{
 			{
+				IsDefault: true,
+			},
+			{
 				Hostname: "example.com",
+				SSL: &state.SSL{
+					CertificatePath: "/etc/nginx/secrets/default",
+				},
 			},
 		},
 		Upstreams: []state.Upstream{
@@ -45,7 +54,7 @@ func TestGenerate(t *testing.T) {
 	cfg := string(generator.Generate(conf))
 
 	if !strings.Contains(cfg, "listen 80") {
-		t.Errorf("Generate() did not generate a config with an HTTP server; config: %s", cfg)
+		t.Errorf("Generate() did not generate a config with a default HTTP server; config: %s", cfg)
 	}
 
 	if !strings.Contains(cfg, "listen 443") {

--- a/internal/nginx/config/servers_test.go
+++ b/internal/nginx/config/servers_test.go
@@ -20,6 +20,9 @@ func TestExecuteServers(t *testing.T) {
 	conf := state.Configuration{
 		HTTPServers: []state.VirtualServer{
 			{
+				IsDefault: true,
+			},
+			{
 				Hostname: "example.com",
 			},
 			{
@@ -27,6 +30,9 @@ func TestExecuteServers(t *testing.T) {
 			},
 		},
 		SSLServers: []state.VirtualServer{
+			{
+				IsDefault: true,
+			},
 			{
 				Hostname: "example.com",
 				SSL: &state.SSL{
@@ -76,48 +82,48 @@ func TestExecuteForDefaultServers(t *testing.T) {
 			conf:        state.Configuration{},
 			httpDefault: false,
 			sslDefault:  false,
-			msg:         "no servers",
+			msg:         "no default servers",
 		},
 		{
 			conf: state.Configuration{
 				HTTPServers: []state.VirtualServer{
 					{
-						Hostname: "example.com",
+						IsDefault: true,
 					},
 				},
 			},
 			httpDefault: true,
 			sslDefault:  false,
-			msg:         "only HTTP servers",
+			msg:         "only HTTP default server",
 		},
 		{
 			conf: state.Configuration{
 				SSLServers: []state.VirtualServer{
 					{
-						Hostname: "example.com",
+						IsDefault: true,
 					},
 				},
 			},
 			httpDefault: false,
 			sslDefault:  true,
-			msg:         "only HTTPS servers",
+			msg:         "only HTTPS default server",
 		},
 		{
 			conf: state.Configuration{
 				HTTPServers: []state.VirtualServer{
 					{
-						Hostname: "example.com",
+						IsDefault: true,
 					},
 				},
 				SSLServers: []state.VirtualServer{
 					{
-						Hostname: "example.com",
+						IsDefault: true,
 					},
 				},
 			},
 			httpDefault: true,
 			sslDefault:  true,
-			msg:         "both HTTP and HTTPS servers",
+			msg:         "both HTTP and HTTPS default servers",
 		},
 	}
 
@@ -399,12 +405,18 @@ func TestCreateServers(t *testing.T) {
 
 	httpServers := []state.VirtualServer{
 		{
+			IsDefault: true,
+		},
+		{
 			Hostname:  "cafe.example.com",
 			PathRules: cafePathRules,
 		},
 	}
 
 	sslServers := []state.VirtualServer{
+		{
+			IsDefault: true,
+		},
 		{
 			Hostname:  "cafe.example.com",
 			SSL:       &state.SSL{CertificatePath: certPath},
@@ -495,11 +507,11 @@ func TestCreateServers(t *testing.T) {
 			IsDefaultHTTP: true,
 		},
 		{
-			IsDefaultSSL: true,
-		},
-		{
 			ServerName: "cafe.example.com",
 			Locations:  getExpectedLocations(false),
+		},
+		{
+			IsDefaultSSL: true,
 		},
 		{
 			ServerName: "cafe.example.com",

--- a/internal/state/change_processor_test.go
+++ b/internal/state/change_processor_test.go
@@ -330,6 +330,9 @@ var _ = Describe("ChangeProcessor", func() {
 					expectedConf := state.Configuration{
 						HTTPServers: []state.VirtualServer{
 							{
+								IsDefault: true,
+							},
+							{
 								Hostname: "foo.example.com",
 								PathRules: []state.PathRule{
 									{
@@ -347,6 +350,9 @@ var _ = Describe("ChangeProcessor", func() {
 							},
 						},
 						SSLServers: []state.VirtualServer{
+							{
+								IsDefault: true,
+							},
 							{
 								Hostname: "foo.example.com",
 								SSL:      &state.SSL{CertificatePath: certificatePath},
@@ -433,6 +439,9 @@ var _ = Describe("ChangeProcessor", func() {
 					expectedConf := state.Configuration{
 						HTTPServers: []state.VirtualServer{
 							{
+								IsDefault: true,
+							},
+							{
 								Hostname: "foo.example.com",
 								PathRules: []state.PathRule{
 									{
@@ -450,6 +459,9 @@ var _ = Describe("ChangeProcessor", func() {
 							},
 						},
 						SSLServers: []state.VirtualServer{
+							{
+								IsDefault: true,
+							},
 							{
 								Hostname: "foo.example.com",
 								SSL:      &state.SSL{CertificatePath: certificatePath},
@@ -536,6 +548,9 @@ var _ = Describe("ChangeProcessor", func() {
 					expectedConf := state.Configuration{
 						HTTPServers: []state.VirtualServer{
 							{
+								IsDefault: true,
+							},
+							{
 								Hostname: "foo.example.com",
 								PathRules: []state.PathRule{
 									{
@@ -553,6 +568,9 @@ var _ = Describe("ChangeProcessor", func() {
 							},
 						},
 						SSLServers: []state.VirtualServer{
+							{
+								IsDefault: true,
+							},
 							{
 								Hostname: "foo.example.com",
 								SSL:      &state.SSL{CertificatePath: certificatePath},
@@ -638,6 +656,9 @@ var _ = Describe("ChangeProcessor", func() {
 					expectedConf := state.Configuration{
 						HTTPServers: []state.VirtualServer{
 							{
+								IsDefault: true,
+							},
+							{
 								Hostname: "foo.example.com",
 								PathRules: []state.PathRule{
 									{
@@ -655,6 +676,9 @@ var _ = Describe("ChangeProcessor", func() {
 							},
 						},
 						SSLServers: []state.VirtualServer{
+							{
+								IsDefault: true,
+							},
 							{
 								Hostname: "foo.example.com",
 								SSL:      &state.SSL{CertificatePath: certificatePath},
@@ -737,6 +761,9 @@ var _ = Describe("ChangeProcessor", func() {
 					expectedConf := state.Configuration{
 						HTTPServers: []state.VirtualServer{
 							{
+								IsDefault: true,
+							},
+							{
 								Hostname: "foo.example.com",
 								PathRules: []state.PathRule{
 									{
@@ -754,6 +781,9 @@ var _ = Describe("ChangeProcessor", func() {
 							},
 						},
 						SSLServers: []state.VirtualServer{
+							{
+								IsDefault: true,
+							},
 							{
 								Hostname: "foo.example.com",
 								PathRules: []state.PathRule{
@@ -833,6 +863,9 @@ var _ = Describe("ChangeProcessor", func() {
 					expectedConf := state.Configuration{
 						HTTPServers: []state.VirtualServer{
 							{
+								IsDefault: true,
+							},
+							{
 								Hostname: "foo.example.com",
 								PathRules: []state.PathRule{
 									{
@@ -850,6 +883,9 @@ var _ = Describe("ChangeProcessor", func() {
 							},
 						},
 						SSLServers: []state.VirtualServer{
+							{
+								IsDefault: true,
+							},
 							{
 								Hostname: "foo.example.com",
 								SSL:      &state.SSL{CertificatePath: certificatePath},
@@ -947,6 +983,9 @@ var _ = Describe("ChangeProcessor", func() {
 					expectedConf := state.Configuration{
 						HTTPServers: []state.VirtualServer{
 							{
+								IsDefault: true,
+							},
+							{
 								Hostname: "bar.example.com",
 								PathRules: []state.PathRule{
 									{
@@ -964,6 +1003,9 @@ var _ = Describe("ChangeProcessor", func() {
 							},
 						},
 						SSLServers: []state.VirtualServer{
+							{
+								IsDefault: true,
+							},
 							{
 								Hostname: "bar.example.com",
 								SSL:      &state.SSL{CertificatePath: certificatePath},
@@ -1038,8 +1080,15 @@ var _ = Describe("ChangeProcessor", func() {
 					)
 
 					expectedConf := state.Configuration{
-						HTTPServers: []state.VirtualServer{},
+						HTTPServers: []state.VirtualServer{
+							{
+								IsDefault: true,
+							},
+						},
 						SSLServers: []state.VirtualServer{
+							{
+								IsDefault: true,
+							},
 							{
 								Hostname: "~^",
 								SSL:      &state.SSL{CertificatePath: certificatePath},

--- a/internal/state/configuration_test.go
+++ b/internal/state/configuration_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestBuildConfiguration(t *testing.T) {
-	createRoute := func(name string, hostname string, listenerName string, paths ...string) *v1beta1.HTTPRoute {
+	createRoute := func(name, hostname, listenerName string, paths ...string) *v1beta1.HTTPRoute {
 		rules := make([]v1beta1.HTTPRouteRule, 0, len(paths))
 		for _, p := range paths {
 			rules = append(rules, v1beta1.HTTPRouteRule{
@@ -282,8 +282,12 @@ func TestBuildConfiguration(t *testing.T) {
 				Routes: map[types.NamespacedName]*route{},
 			},
 			expConf: Configuration{
-				HTTPServers: []VirtualServer{},
-				SSLServers:  []VirtualServer{},
+				HTTPServers: []VirtualServer{
+					{
+						IsDefault: true,
+					},
+				},
+				SSLServers: []VirtualServer{},
 			},
 			msg: "http listener with no routes",
 		},
@@ -317,6 +321,9 @@ func TestBuildConfiguration(t *testing.T) {
 			expConf: Configuration{
 				HTTPServers: []VirtualServer{},
 				SSLServers: []VirtualServer{
+					{
+						IsDefault: true,
+					},
 					{
 						Hostname: string(hostname),
 						SSL:      &SSL{CertificatePath: secretPath},
@@ -398,6 +405,9 @@ func TestBuildConfiguration(t *testing.T) {
 			},
 			expConf: Configuration{
 				HTTPServers: []VirtualServer{
+					{
+						IsDefault: true,
+					},
 					{
 						Hostname: "bar.example.com",
 						PathRules: []PathRule{
@@ -481,6 +491,9 @@ func TestBuildConfiguration(t *testing.T) {
 			expConf: Configuration{
 				HTTPServers: []VirtualServer{},
 				SSLServers: []VirtualServer{
+					{
+						IsDefault: true,
+					},
 					{
 						Hostname: "bar.example.com",
 						PathRules: []PathRule{
@@ -592,6 +605,9 @@ func TestBuildConfiguration(t *testing.T) {
 			expConf: Configuration{
 				HTTPServers: []VirtualServer{
 					{
+						IsDefault: true,
+					},
+					{
 						Hostname: "foo.example.com",
 						PathRules: []PathRule{
 							{
@@ -637,6 +653,9 @@ func TestBuildConfiguration(t *testing.T) {
 					},
 				},
 				SSLServers: []VirtualServer{
+					{
+						IsDefault: true,
+					},
 					{
 						Hostname: "foo.example.com",
 						SSL: &SSL{
@@ -796,6 +815,9 @@ func TestBuildConfiguration(t *testing.T) {
 			},
 			expConf: Configuration{
 				HTTPServers: []VirtualServer{
+					{
+						IsDefault: true,
+					},
 					{
 						Hostname: "foo.example.com",
 						PathRules: []PathRule{


### PR DESCRIPTION
Problem: NKG does not generate an nginx server for an HTTP listener with no routes.

Fix: If an HTTP or HTTPS listener exists, we will generate an nginx default HTTP or SSL server block.

Fixes #316 