### PR TITLE
Fix status for parentRef with invalid listener

### DIFF
--- a/internal/state/conditions/httproute.go
+++ b/internal/state/conditions/httproute.go
@@ -8,7 +8,7 @@ import (
 )
 
 // RouteReasonInvalidListener is used with the "Accepted" condition when the route references an invalid listener.
-var RouteReasonInvalidListener v1beta1.RouteConditionReason = "InvalidListener"
+const RouteReasonInvalidListener v1beta1.RouteConditionReason = "InvalidListener"
 
 // RouteCondition defines a condition to be reported in the status of an HTTPRoute.
 type RouteCondition struct {

--- a/internal/state/conditions/httproute.go
+++ b/internal/state/conditions/httproute.go
@@ -7,6 +7,9 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
+// RouteReasonInvalidListener is used with the "Accepted" condition when the route references an invalid listener.
+var RouteReasonInvalidListener v1beta1.RouteConditionReason = "InvalidListener"
+
 // RouteCondition defines a condition to be reported in the status of an HTTPRoute.
 type RouteCondition struct {
 	Type    v1beta1.RouteConditionType
@@ -68,5 +71,16 @@ func NewRouteTODO(msg string) RouteCondition {
 		Status:  metav1.ConditionTrue,
 		Reason:  "TODO",
 		Message: fmt.Sprintf("The condition for this has not been implemented yet: %s", msg),
+	}
+}
+
+// NewRouteInvalidListener returns a RouteCondition that indicates that the HTTPRoute is not accepted because of an
+// invalid listener.
+func NewRouteInvalidListener() RouteCondition {
+	return RouteCondition{
+		Type:    v1beta1.RouteConditionAccepted,
+		Status:  metav1.ConditionFalse,
+		Reason:  RouteReasonInvalidListener,
+		Message: "The listener is invalid for this parent ref",
 	}
 }

--- a/internal/state/graph.go
+++ b/internal/state/graph.go
@@ -242,6 +242,11 @@ func bindHTTPRouteToListeners(
 				continue
 			}
 
+			if !l.Valid {
+				r.InvalidSectionNameRefs[name] = conditions.NewRouteInvalidListener()
+				continue
+			}
+
 			accepted := findAcceptedHostnames(l.Source.Hostname, ghr.Spec.Hostnames)
 
 			if len(accepted) > 0 {

--- a/internal/state/graph_test.go
+++ b/internal/state/graph_test.go
@@ -1020,6 +1020,30 @@ func TestBindRouteToListeners(t *testing.T) {
 			expectedListeners: nil,
 			msg:               "HTTPRoute when no gateway exists",
 		},
+		{
+			httpRoute:  hrFoo,
+			gw:         gw,
+			ignoredGws: nil,
+			listeners: map[string]*listener{
+				"listener-80-1": createModifiedListener(func(l *listener) {
+					l.Valid = false
+				}),
+			},
+			expectedIgnored: false,
+			expectedRoute: &route{
+				Source:               hrFoo,
+				ValidSectionNameRefs: map[string]struct{}{},
+				InvalidSectionNameRefs: map[string]conditions.RouteCondition{
+					"listener-80-1": conditions.NewRouteInvalidListener(),
+				},
+			},
+			expectedListeners: map[string]*listener{
+				"listener-80-1": createModifiedListener(func(l *listener) {
+					l.Valid = false
+				}),
+			},
+			msg: "HTTPRoute with invalid listener parentRef",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Problem: If an HTTPRoute references an invalid listener in a parentRef, the status is incorrectly reported as `Accepted:True`

Fix: Check if the listener associated with the parentRef is valid when binding HTTPRoutes to listeners. If not valid, mark the section name as invalid with a condition of `Accepted:False` and a Reason of `InvalidListener`

**Note**: The spec does not define a Reason that covers this case where the listener is invalid. This PR adds a new route Reason `InvalidListener` for this case. There's an open discussion about adding this Reason to the spec: https://github.com/kubernetes-sigs/gateway-api/discussions/1445
