### PR TITLE
Fix Observed Generation for Gateway Status

### DIFF
--- a/internal/state/change_processor_test.go
+++ b/internal/state/change_processor_test.go
@@ -282,7 +282,8 @@ var _ = Describe("ChangeProcessor", func() {
 						expectedConf := state.Configuration{}
 						expectedStatuses := state.Statuses{
 							GatewayStatus: &state.GatewayStatus{
-								NsName: types.NamespacedName{Namespace: "test", Name: "gateway-1"},
+								NsName:             types.NamespacedName{Namespace: "test", Name: "gateway-1"},
+								ObservedGeneration: gw1.Generation,
 								ListenerStatuses: map[string]state.ListenerStatus{
 									"listener-80-1": {
 										Valid:          false,
@@ -386,7 +387,8 @@ var _ = Describe("ChangeProcessor", func() {
 							ObservedGeneration: gc.Generation,
 						},
 						GatewayStatus: &state.GatewayStatus{
-							NsName: types.NamespacedName{Namespace: "test", Name: "gateway-1"},
+							NsName:             types.NamespacedName{Namespace: "test", Name: "gateway-1"},
+							ObservedGeneration: gw1.Generation,
 							ListenerStatuses: map[string]state.ListenerStatus{
 								"listener-80-1": {
 									Valid:          true,
@@ -494,7 +496,8 @@ var _ = Describe("ChangeProcessor", func() {
 							ObservedGeneration: gc.Generation,
 						},
 						GatewayStatus: &state.GatewayStatus{
-							NsName: types.NamespacedName{Namespace: "test", Name: "gateway-1"},
+							NsName:             types.NamespacedName{Namespace: "test", Name: "gateway-1"},
+							ObservedGeneration: gw1.Generation,
 							ListenerStatuses: map[string]state.ListenerStatus{
 								"listener-80-1": {
 									Valid:          true,
@@ -603,7 +606,8 @@ var _ = Describe("ChangeProcessor", func() {
 							ObservedGeneration: gc.Generation,
 						},
 						GatewayStatus: &state.GatewayStatus{
-							NsName: types.NamespacedName{Namespace: "test", Name: "gateway-1"},
+							NsName:             types.NamespacedName{Namespace: "test", Name: "gateway-1"},
+							ObservedGeneration: gw1Updated.Generation,
 							ListenerStatuses: map[string]state.ListenerStatus{
 								"listener-80-1": {
 									Valid:          true,
@@ -711,7 +715,8 @@ var _ = Describe("ChangeProcessor", func() {
 							ObservedGeneration: gcUpdated.Generation,
 						},
 						GatewayStatus: &state.GatewayStatus{
-							NsName: types.NamespacedName{Namespace: "test", Name: "gateway-1"},
+							NsName:             types.NamespacedName{Namespace: "test", Name: "gateway-1"},
+							ObservedGeneration: gw1Updated.Generation,
 							ListenerStatuses: map[string]state.ListenerStatus{
 								"listener-80-1": {
 									Valid:          true,
@@ -818,7 +823,8 @@ var _ = Describe("ChangeProcessor", func() {
 							ObservedGeneration: gcUpdated.Generation,
 						},
 						GatewayStatus: &state.GatewayStatus{
-							NsName: types.NamespacedName{Namespace: "test", Name: "gateway-1"},
+							NsName:             types.NamespacedName{Namespace: "test", Name: "gateway-1"},
+							ObservedGeneration: gw1Updated.Generation,
 							ListenerStatuses: map[string]state.ListenerStatus{
 								"listener-80-1": {
 									Valid:          true,
@@ -918,7 +924,8 @@ var _ = Describe("ChangeProcessor", func() {
 							ObservedGeneration: gcUpdated.Generation,
 						},
 						GatewayStatus: &state.GatewayStatus{
-							NsName: types.NamespacedName{Namespace: "test", Name: "gateway-1"},
+							NsName:             types.NamespacedName{Namespace: "test", Name: "gateway-1"},
+							ObservedGeneration: gw1Updated.Generation,
 							ListenerStatuses: map[string]state.ListenerStatus{
 								"listener-80-1": {
 									Valid:          true,
@@ -1038,7 +1045,8 @@ var _ = Describe("ChangeProcessor", func() {
 							ObservedGeneration: gcUpdated.Generation,
 						},
 						GatewayStatus: &state.GatewayStatus{
-							NsName: types.NamespacedName{Namespace: "test", Name: "gateway-2"},
+							NsName:             types.NamespacedName{Namespace: "test", Name: "gateway-2"},
+							ObservedGeneration: gw2.Generation,
 							ListenerStatuses: map[string]state.ListenerStatus{
 								"listener-80-1": {
 									Valid:          true,
@@ -1101,7 +1109,8 @@ var _ = Describe("ChangeProcessor", func() {
 							ObservedGeneration: gcUpdated.Generation,
 						},
 						GatewayStatus: &state.GatewayStatus{
-							NsName: types.NamespacedName{Namespace: "test", Name: "gateway-2"},
+							NsName:             types.NamespacedName{Namespace: "test", Name: "gateway-2"},
+							ObservedGeneration: gw2.Generation,
 							ListenerStatuses: map[string]state.ListenerStatus{
 								"listener-80-1": {
 									Valid:          true,
@@ -1133,7 +1142,8 @@ var _ = Describe("ChangeProcessor", func() {
 					expectedConf := state.Configuration{}
 					expectedStatuses := state.Statuses{
 						GatewayStatus: &state.GatewayStatus{
-							NsName: types.NamespacedName{Namespace: "test", Name: "gateway-2"},
+							NsName:             types.NamespacedName{Namespace: "test", Name: "gateway-2"},
+							ObservedGeneration: gw2.Generation,
 							ListenerStatuses: map[string]state.ListenerStatus{
 								"listener-80-1": {
 									Valid:          false,

--- a/internal/state/statuses.go
+++ b/internal/state/statuses.go
@@ -23,8 +23,12 @@ type Statuses struct {
 
 // GatewayStatus holds the status of the winning Gateway resource.
 type GatewayStatus struct {
+	// ListenerStatuses holds the statuses of listeners defined on the Gateway.
 	ListenerStatuses ListenerStatuses
-	NsName           types.NamespacedName
+	// NsName is the namespaced name of the winning Gateway resource.
+	NsName types.NamespacedName
+	// ObservedGeneration is the generation of the resource that was processed.
+	ObservedGeneration int64
 }
 
 // IgnoredGatewayStatuses holds the statuses of the ignored Gateway resources.
@@ -98,8 +102,9 @@ func buildStatuses(graph *graph) Statuses {
 		}
 
 		statuses.GatewayStatus = &GatewayStatus{
-			NsName:           client.ObjectKeyFromObject(graph.Gateway.Source),
-			ListenerStatuses: listenerStatuses,
+			NsName:             client.ObjectKeyFromObject(graph.Gateway.Source),
+			ListenerStatuses:   listenerStatuses,
+			ObservedGeneration: graph.Gateway.Source.Generation,
 		}
 	}
 

--- a/internal/state/statuses_test.go
+++ b/internal/state/statuses_test.go
@@ -59,8 +59,9 @@ func TestBuildStatuses(t *testing.T) {
 
 	gw := &v1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "test",
-			Name:      "gateway",
+			Namespace:  "test",
+			Name:       "gateway",
+			Generation: 2,
 		},
 	}
 
@@ -107,6 +108,7 @@ func TestBuildStatuses(t *testing.T) {
 							AttachedRoutes: 1,
 						},
 					},
+					ObservedGeneration: 2,
 				},
 				IgnoredGatewayStatuses: map[types.NamespacedName]IgnoredGatewayStatus{
 					{Namespace: "test", Name: "ignored-gateway"}: {ObservedGeneration: 1},
@@ -152,6 +154,7 @@ func TestBuildStatuses(t *testing.T) {
 							AttachedRoutes: 1,
 						},
 					},
+					ObservedGeneration: 2,
 				},
 				IgnoredGatewayStatuses: map[types.NamespacedName]IgnoredGatewayStatus{
 					{Namespace: "test", Name: "ignored-gateway"}: {ObservedGeneration: 1},
@@ -211,6 +214,7 @@ func TestBuildStatuses(t *testing.T) {
 							AttachedRoutes: 1,
 						},
 					},
+					ObservedGeneration: 2,
 				},
 				IgnoredGatewayStatuses: map[types.NamespacedName]IgnoredGatewayStatus{
 					{Namespace: "test", Name: "ignored-gateway"}: {ObservedGeneration: 1},

--- a/internal/status/gateway.go
+++ b/internal/status/gateway.go
@@ -50,10 +50,9 @@ func prepareGatewayStatus(gatewayStatus state.GatewayStatus, transitionTime meta
 		}
 
 		cond := metav1.Condition{
-			Type:   string(v1beta1.ListenerConditionReady),
-			Status: status,
-			// FIXME(pleshakov) Set the observed generation to the last processed generation of the Gateway resource.
-			ObservedGeneration: 123,
+			Type:               string(v1beta1.ListenerConditionReady),
+			Status:             status,
+			ObservedGeneration: gatewayStatus.ObservedGeneration,
 			LastTransitionTime: transitionTime,
 			Reason:             string(reason),
 			Message:            "", // FIXME(pleshakov) Come up with a good message

--- a/internal/status/gateway_test.go
+++ b/internal/status/gateway_test.go
@@ -23,6 +23,7 @@ func TestPrepareGatewayStatus(t *testing.T) {
 				AttachedRoutes: 1,
 			},
 		},
+		ObservedGeneration: 1,
 	}
 
 	transitionTime := metav1.NewTime(time.Now())
@@ -41,7 +42,7 @@ func TestPrepareGatewayStatus(t *testing.T) {
 					{
 						Type:               string(v1beta1.ListenerConditionReady),
 						Status:             metav1.ConditionFalse,
-						ObservedGeneration: 123,
+						ObservedGeneration: 1,
 						LastTransitionTime: transitionTime,
 						Reason:             string(v1beta1.ListenerReasonInvalid),
 					},
@@ -59,7 +60,7 @@ func TestPrepareGatewayStatus(t *testing.T) {
 					{
 						Type:               string(v1beta1.ListenerConditionReady),
 						Status:             metav1.ConditionTrue,
-						ObservedGeneration: 123,
+						ObservedGeneration: 1,
 						LastTransitionTime: transitionTime,
 						Reason:             string(v1beta1.ListenerReasonReady),
 					},

--- a/internal/status/updater_test.go
+++ b/internal/status/updater_test.go
@@ -85,6 +85,7 @@ var _ = Describe("Updater", func() {
 								AttachedRoutes: 1,
 							},
 						},
+						ObservedGeneration: generation,
 					},
 					IgnoredGatewayStatuses: map[types.NamespacedName]state.IgnoredGatewayStatus{
 						{Namespace: "test", Name: "ignored-gateway"}: {
@@ -138,7 +139,7 @@ var _ = Describe("Updater", func() {
 				}
 			}
 
-			createExpectedGw = func(status metav1.ConditionStatus, reason string) *v1beta1.Gateway {
+			createExpectedGw = func(status metav1.ConditionStatus, generation int64, reason string) *v1beta1.Gateway {
 				return &v1beta1.Gateway{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "test",
@@ -162,7 +163,7 @@ var _ = Describe("Updater", func() {
 									{
 										Type:               string(v1beta1.ListenerConditionReady),
 										Status:             status,
-										ObservedGeneration: 0,
+										ObservedGeneration: generation,
 										LastTransitionTime: fakeClockTime,
 										Reason:             reason,
 									},
@@ -306,7 +307,7 @@ var _ = Describe("Updater", func() {
 
 		It("should have the updated status of Gateway in the API server", func() {
 			latestGw := &v1beta1.Gateway{}
-			expectedGw := createExpectedGw(metav1.ConditionTrue, string(v1beta1.ListenerReasonReady))
+			expectedGw := createExpectedGw(metav1.ConditionTrue, 1, string(v1beta1.ListenerReasonReady))
 
 			err := client.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "gateway"}, latestGw)
 			Expect(err).Should(Not(HaveOccurred()))
@@ -370,7 +371,7 @@ var _ = Describe("Updater", func() {
 
 			It("should have the updated status of Gateway in the API server", func() {
 				latestGw := &v1beta1.Gateway{}
-				expectedGw := createExpectedGw(metav1.ConditionFalse, string(v1beta1.ListenerReasonInvalid))
+				expectedGw := createExpectedGw(metav1.ConditionFalse, 2, string(v1beta1.ListenerReasonInvalid))
 
 				err := client.Get(
 					context.Background(),

--- a/internal/status/updater_test.go
+++ b/internal/status/updater_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Updater", func() {
 									{
 										Type:               string(v1beta1.ListenerConditionReady),
 										Status:             status,
-										ObservedGeneration: 123,
+										ObservedGeneration: 0,
 										LastTransitionTime: fakeClockTime,
 										Reason:             reason,
 									},


### PR DESCRIPTION
Use the Gateway's real generation in the Observed Generation field of the Gateway's status. 