### PR TITLE
Always generate a root "/" location block

### DIFF
--- a/internal/nginx/config/servers.go
+++ b/internal/nginx/config/servers.go
@@ -14,6 +14,8 @@ import (
 
 var serversTemplate = gotemplate.Must(gotemplate.New("servers").Parse(serversTemplateText))
 
+const rootPath = "/"
+
 func executeServers(conf state.Configuration) []byte {
 	servers := createServers(conf.HTTPServers, conf.SSLServers)
 
@@ -64,13 +66,19 @@ func createLocations(pathRules []state.PathRule, listenerPort int) []http.Locati
 	lenPathRules := len(pathRules)
 
 	if lenPathRules == 0 {
-		return []http.Location{{Path: "/", Return: &http.Return{Code: http.StatusNotFound}}}
+		return []http.Location{createDefaultRootLocation()}
 	}
 
 	locs := make([]http.Location, 0, lenPathRules) // FIXME(pleshakov): expand with rule.Routes
 
+	rootPathExists := false
+
 	for _, rule := range pathRules {
 		matches := make([]httpMatch, 0, len(rule.MatchRules))
+
+		if rule.Path == rootPath {
+			rootPathExists = true
+		}
 
 		for matchRuleIdx, r := range rule.MatchRules {
 			m := r.GetMatch()
@@ -128,6 +136,10 @@ func createLocations(pathRules []state.PathRule, listenerPort int) []http.Locati
 
 			locs = append(locs, pathLoc)
 		}
+	}
+
+	if !rootPathExists {
+		locs = append(locs, createDefaultRootLocation())
 	}
 
 	return locs
@@ -278,4 +290,11 @@ func createMatchLocation(path string) http.Location {
 
 func createPathForMatch(path string, routeIdx int) string {
 	return fmt.Sprintf("%s_route%d", path, routeIdx)
+}
+
+func createDefaultRootLocation() http.Location {
+	return http.Location{
+		Path:   "/",
+		Return: &http.Return{Code: http.StatusNotFound},
+	}
 }


### PR DESCRIPTION
If no root path ("/") is defined by the user for a server, generate a location block for the root path that returns 404.


