### PR TITLE
Allow nginx to bind to privileged ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The following table lists the software versions NGINX Kubernetes Gateway support
 
 | NGINX Kubernetes Gateway | Gateway API | Kubernetes | NGINX OSS |
 |-|-|-|-|
-| Edge | 0.6.0 | 1.21+ | 1.21.x *|
+| Edge | 0.6.0 | 1.22+ | 1.21.x *|
 | 0.2.0 | 0.5.1 | 1.21+ | 1.21.x *|
 | 0.1.0 | 0.5.0 | 1.19+ | 1.21.3 |
 

--- a/build/nginx-with-agent/Dockerfile
+++ b/build/nginx-with-agent/Dockerfile
@@ -28,20 +28,11 @@ RUN mkdir -p /etc/nginx/secrets /var/lib/nginx /var/log/nginx \
     && chown -R 101:101 /var/log/nginx-agent /etc/nginx-agent /var/log/nginx-agent /etc/nginx-agent\
     && chmod +x /nginx-with-agent/entrypoint.sh
 
-
-# The following instructions allow nginx and nginx-debug binaries to bind to privileged ports.
-# However, adding this capability prevents the agent from reading nginx's /proc/<pid>/exe symlink which is required by
-# the agent to determine the path to the nginx binary. While we wait for a more permanent fix, we will work around this
-# by having nginx bind to non-privileged ports. See this write-up for more details: https://dxuuu.xyz/filecaps.html
-
-#RUN setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug
-#RUN setcap -v 'cap_net_bind_service=+ep' /usr/sbin/nginx 'cap_net_bind_service=+ep' /usr/sbin/nginx-debug
-
 # Set user to 101 (nginx)
 USER 101:101
 
 STOPSIGNAL SIGTERM
 
-EXPOSE 8080 8443
+EXPOSE 80 443
 
 ENTRYPOINT ["/nginx-with-agent/entrypoint.sh"]

--- a/build/nginx-with-agent/nginx-with-agent.yaml
+++ b/build/nginx-with-agent/nginx-with-agent.yaml
@@ -15,6 +15,10 @@ spec:
     spec:
       serviceAccountName: default
       automountServiceAccountToken: false
+      securityContext:
+        sysctls:
+        - name: "net.ipv4.ip_unprivileged_port_start"
+          value: "0"
       containers:
       - image: docker.io/nginx-kubernetes-gateway/nginx-with-agent:edge
         imagePullPolicy: IfNotPresent
@@ -27,6 +31,6 @@ spec:
             - ALL
         ports:
         - name: http
-          containerPort: 8080
+          containerPort: 80
         - name: https
-          containerPort: 8443
+          containerPort: 443


### PR DESCRIPTION
Use sysctls to set unprivileged port start to 0. This allows nginx to bind to 80 and 443 without having to set the `cap_net_bind_service` capability. 