### PR TITLE
Remove capabilizer steps and old pkg folder

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1.5
 FROM golang:1.20 as builder
 ARG VERSION
 ARG GIT_COMMIT
@@ -6,39 +6,23 @@ ARG DATE
 
 WORKDIR /go/src/github.com/nginxinc/nginx-kubernetes-gateway/cmd/gateway
 
-COPY go.mod go.sum /go/src/github.com/nginxinc/nginx-kubernetes-gateway
+COPY go.mod go.sum /go/src/github.com/nginxinc/nginx-kubernetes-gateway/
 RUN go mod download
 
 COPY cmd /go/src/github.com/nginxinc/nginx-kubernetes-gateway/cmd
 COPY internal /go/src/github.com/nginxinc/nginx-kubernetes-gateway/internal
-COPY pkg /go/src/github.com/nginxinc/nginx-kubernetes-gateway/pkg
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -a -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${GIT_COMMIT} -X main.date=${DATE}" -o gateway .
 
-FROM alpine:3.17 as capabilizer
-RUN apk add --no-cache libcap
-
-FROM capabilizer as local-capabilizer
-COPY ./build/.out/gateway /usr/bin/
-RUN setcap 'cap_kill=+ep' /usr/bin/gateway
-
-FROM capabilizer as container-capabilizer
-COPY --from=builder /go/src/github.com/nginxinc/nginx-kubernetes-gateway/cmd/gateway/gateway /usr/bin/
-RUN setcap 'cap_kill=+ep' /usr/bin/gateway
-
-FROM capabilizer as goreleaser-capabilizer
-ARG TARGETARCH
-COPY dist/gateway_linux_$TARGETARCH*/gateway /usr/bin/
-RUN setcap 'cap_kill=+ep' /usr/bin/gateway
 
 FROM scratch as common
 USER 1001:1001
 ENTRYPOINT [ "/usr/bin/gateway" ]
 
 FROM common as container
-COPY --from=container-capabilizer /usr/bin/gateway /usr/bin/
+COPY --from=builder /go/src/github.com/nginxinc/nginx-kubernetes-gateway/cmd/gateway/gateway /usr/bin/
 
 FROM common as local
-COPY --from=local-capabilizer /usr/bin/gateway /usr/bin/
+COPY ./build/.out/gateway /usr/bin/
 
 FROM common as goreleaser
-COPY --from=goreleaser-capabilizer /usr/bin/gateway /usr/bin/
+COPY dist/gateway_linux_$TARGETARCH*/gateway /usr/bin/


### PR DESCRIPTION
Removes `capabilizer` steps that are no longer needed and the `COPY` for `pkg` folder that doesn't exist anymore.
