### PR TITLE
Panic for broken webhook validation assumption

### DIFF
--- a/internal/nginx/config/servers.go
+++ b/internal/nginx/config/servers.go
@@ -120,6 +120,10 @@ func createLocations(pathRules []dataplane.PathRule, listenerPort int) []http.Lo
 			// For example, type is v1beta1.HTTPRouteFilterRequestRedirect, but RequestRedirect field is nil.
 			// The imported Webhook validation webhook catches that.
 
+			// FIXME(pleshakov): Ensure dataplane.Configuration -related types don't include v1beta1 types, so that
+			// we don't need to make any assumptions like above here. After fixing this, ensure that there is a test
+			// for checking the imported Webhook validation catches the case above.
+
 			// RequestRedirect and proxying are mutually exclusive.
 			if r.Filters.RequestRedirect != nil {
 				loc.Return = createReturnValForRedirectFilter(r.Filters.RequestRedirect, listenerPort)

--- a/internal/state/graph/backend_refs.go
+++ b/internal/state/graph/backend_refs.go
@@ -167,9 +167,11 @@ func validateBackendRef(
 		return false, conditions.NewRouteBackendRefRefNotPermitted(valErr.Error())
 	}
 
-	// The imported Webhook validation ensures ref.Port is set
-	// any value is OK
-	// FIXME(pleshakov): Add a unit test for the imported Webhook validation code for this case.
+	if ref.Port == nil {
+		panicForBrokenWebhookAssumption(fmt.Errorf("port is nil for ref %q", ref.Name))
+	}
+
+	// any value of port is OK
 
 	if ref.Weight != nil {
 		if err := validateWeight(*ref.Weight); err != nil {

--- a/internal/state/graph/gateway.go
+++ b/internal/state/graph/gateway.go
@@ -321,8 +321,9 @@ func validateHTTPListener(listener v1beta1.Listener) []conditions.Condition {
 		conds = append(conds, conditions.NewListenerPortUnavailable(valErr.Error()))
 	}
 
-	// The imported Webhook validation ensures the tls field is not set for an HTTP listener.
-	// FIXME(pleshakov): Add a unit test for the imported Webhook validation code for this case.
+	if listener.TLS != nil {
+		panicForBrokenWebhookAssumption(fmt.Errorf("tls is not nil for HTTP listener %q", listener.Name))
+	}
 
 	return conds
 }
@@ -336,8 +337,9 @@ func validateHTTPSListener(listener v1beta1.Listener, gwNsName string) []conditi
 		conds = append(conds, conditions.NewListenerPortUnavailable(valErr.Error()))
 	}
 
-	// The imported Webhook validation ensures the tls field is not nil for an HTTPS listener.
-	// FIXME(pleshakov): Add a unit test for the imported Webhook validation code for this case.
+	if listener.TLS == nil {
+		panicForBrokenWebhookAssumption(fmt.Errorf("tls is nil for HTTPS listener %q", listener.Name))
+	}
 
 	tlsPath := field.NewPath("tls")
 
@@ -356,8 +358,9 @@ func validateHTTPSListener(listener v1beta1.Listener, gwNsName string) []conditi
 		conds = append(conds, conditions.NewListenerUnsupportedValue(valErr.Error()))
 	}
 
-	// The imported Webhook validation ensures len(listener.TLS.Certificates) is not 0.
-	// FIXME(pleshakov): Add a unit test for the imported Webhook validation code for this case.
+	if len(listener.TLS.CertificateRefs) == 0 {
+		panicForBrokenWebhookAssumption(fmt.Errorf("zero certificateRefs for HTTPS listener %q", listener.Name))
+	}
 
 	certRef := listener.TLS.CertificateRefs[0]
 

--- a/internal/state/graph/validation.go
+++ b/internal/state/graph/validation.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -23,4 +24,12 @@ func validateHostname(hostname string) error {
 	}
 
 	return nil
+}
+
+// panicForBrokenWebhookAssumption panics with the error message because an assumption about the webhook validation
+// (run by NKG) is broken.
+// Use it when you expect a validated Gateway API resource, but the actual resource breaks the validation constraints.
+// For example, a field that must not be nil is nil.
+func panicForBrokenWebhookAssumption(err error) {
+	panic(fmt.Errorf("webhook validation assumption was broken: %w", err))
 }


### PR DESCRIPTION
- Add panics for cases when an assumption about how webhook validation (run by NKG) validates a Gateway API resource is broken.
- Add unit tests for those cases to ensure that invalid resources don't reach the code that makes those assumptions. Note: panics are not unit tested as we considered it'd be redundant.

Fixes https://github.com/nginxinc/nginx-kubernetes-gateway/issues/515