### PR TITLE
Fix HTTPRoute section name related bugs

### DIFF
--- a/internal/state/change_processor_test.go
+++ b/internal/state/change_processor_test.go
@@ -335,14 +335,18 @@ var _ = Describe("ChangeProcessor", func() {
 							HTTPRouteStatuses: map[types.NamespacedName]state.HTTPRouteStatus{
 								{Namespace: "test", Name: "hr-1"}: {
 									ObservedGeneration: hr1.Generation,
-									ParentStatuses: map[string]state.ParentStatus{
-										"listener-80-1": {
+									ParentStatuses: []state.ParentStatus{
+										{
+											GatewayNsName: client.ObjectKeyFromObject(gw1),
+											SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-80-1"),
 											Conditions: append(
 												conditions.NewDefaultRouteConditions(),
 												conditions.NewTODO("GatewayClass is invalid or doesn't exist"),
 											),
 										},
-										"listener-443-1": {
+										{
+											GatewayNsName: client.ObjectKeyFromObject(gw1),
+											SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-443-1"),
 											Conditions: append(
 												conditions.NewDefaultRouteConditions(),
 												conditions.NewTODO("GatewayClass is invalid or doesn't exist"),
@@ -440,12 +444,16 @@ var _ = Describe("ChangeProcessor", func() {
 						HTTPRouteStatuses: map[types.NamespacedName]state.HTTPRouteStatus{
 							{Namespace: "test", Name: "hr-1"}: {
 								ObservedGeneration: hr1.Generation,
-								ParentStatuses: map[string]state.ParentStatus{
-									"listener-80-1": {
-										Conditions: conditions.NewDefaultRouteConditions(),
+								ParentStatuses: []state.ParentStatus{
+									{
+										GatewayNsName: client.ObjectKeyFromObject(gw1),
+										SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-80-1"),
+										Conditions:    conditions.NewDefaultRouteConditions(),
 									},
-									"listener-443-1": {
-										Conditions: conditions.NewDefaultRouteConditions(),
+									{
+										GatewayNsName: client.ObjectKeyFromObject(gw1),
+										SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-443-1"),
+										Conditions:    conditions.NewDefaultRouteConditions(),
 									},
 								},
 							},
@@ -549,12 +557,16 @@ var _ = Describe("ChangeProcessor", func() {
 						HTTPRouteStatuses: map[types.NamespacedName]state.HTTPRouteStatus{
 							{Namespace: "test", Name: "hr-1"}: {
 								ObservedGeneration: hr1Updated.Generation,
-								ParentStatuses: map[string]state.ParentStatus{
-									"listener-80-1": {
-										Conditions: conditions.NewDefaultRouteConditions(),
+								ParentStatuses: []state.ParentStatus{
+									{
+										GatewayNsName: client.ObjectKeyFromObject(gw1),
+										SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-80-1"),
+										Conditions:    conditions.NewDefaultRouteConditions(),
 									},
-									"listener-443-1": {
-										Conditions: conditions.NewDefaultRouteConditions(),
+									{
+										GatewayNsName: client.ObjectKeyFromObject(gw1),
+										SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-443-1"),
+										Conditions:    conditions.NewDefaultRouteConditions(),
 									},
 								},
 							},
@@ -659,12 +671,16 @@ var _ = Describe("ChangeProcessor", func() {
 						HTTPRouteStatuses: map[types.NamespacedName]state.HTTPRouteStatus{
 							{Namespace: "test", Name: "hr-1"}: {
 								ObservedGeneration: hr1Updated.Generation,
-								ParentStatuses: map[string]state.ParentStatus{
-									"listener-80-1": {
-										Conditions: conditions.NewDefaultRouteConditions(),
+								ParentStatuses: []state.ParentStatus{
+									{
+										GatewayNsName: client.ObjectKeyFromObject(gw1Updated),
+										SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-80-1"),
+										Conditions:    conditions.NewDefaultRouteConditions(),
 									},
-									"listener-443-1": {
-										Conditions: conditions.NewDefaultRouteConditions(),
+									{
+										GatewayNsName: client.ObjectKeyFromObject(gw1Updated),
+										SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-443-1"),
+										Conditions:    conditions.NewDefaultRouteConditions(),
 									},
 								},
 							},
@@ -768,12 +784,16 @@ var _ = Describe("ChangeProcessor", func() {
 						HTTPRouteStatuses: map[types.NamespacedName]state.HTTPRouteStatus{
 							{Namespace: "test", Name: "hr-1"}: {
 								ObservedGeneration: hr1Updated.Generation,
-								ParentStatuses: map[string]state.ParentStatus{
-									"listener-80-1": {
-										Conditions: conditions.NewDefaultRouteConditions(),
+								ParentStatuses: []state.ParentStatus{
+									{
+										GatewayNsName: client.ObjectKeyFromObject(gw1Updated),
+										SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-80-1"),
+										Conditions:    conditions.NewDefaultRouteConditions(),
 									},
-									"listener-443-1": {
-										Conditions: conditions.NewDefaultRouteConditions(),
+									{
+										GatewayNsName: client.ObjectKeyFromObject(gw1Updated),
+										SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-443-1"),
+										Conditions:    conditions.NewDefaultRouteConditions(),
 									},
 								},
 							},
@@ -880,12 +900,16 @@ var _ = Describe("ChangeProcessor", func() {
 						HTTPRouteStatuses: map[types.NamespacedName]state.HTTPRouteStatus{
 							{Namespace: "test", Name: "hr-1"}: {
 								ObservedGeneration: hr1Updated.Generation,
-								ParentStatuses: map[string]state.ParentStatus{
-									"listener-80-1": {
-										Conditions: conditions.NewDefaultRouteConditions(),
+								ParentStatuses: []state.ParentStatus{
+									{
+										GatewayNsName: client.ObjectKeyFromObject(gw1Updated),
+										SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-80-1"),
+										Conditions:    conditions.NewDefaultRouteConditions(),
 									},
-									"listener-443-1": {
-										Conditions: conditions.NewDefaultRouteConditions(),
+									{
+										GatewayNsName: client.ObjectKeyFromObject(gw1Updated),
+										SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-443-1"),
+										Conditions:    conditions.NewDefaultRouteConditions(),
 									},
 								},
 							},
@@ -981,25 +1005,33 @@ var _ = Describe("ChangeProcessor", func() {
 						HTTPRouteStatuses: map[types.NamespacedName]state.HTTPRouteStatus{
 							{Namespace: "test", Name: "hr-1"}: {
 								ObservedGeneration: hr1Updated.Generation,
-								ParentStatuses: map[string]state.ParentStatus{
-									"listener-80-1": {
-										Conditions: conditions.NewDefaultRouteConditions(),
+								ParentStatuses: []state.ParentStatus{
+									{
+										GatewayNsName: client.ObjectKeyFromObject(gw1Updated),
+										SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-80-1"),
+										Conditions:    conditions.NewDefaultRouteConditions(),
 									},
-									"listener-443-1": {
-										Conditions: conditions.NewDefaultRouteConditions(),
+									{
+										GatewayNsName: client.ObjectKeyFromObject(gw1Updated),
+										SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-443-1"),
+										Conditions:    conditions.NewDefaultRouteConditions(),
 									},
 								},
 							},
 							{Namespace: "test", Name: "hr-2"}: {
 								ObservedGeneration: hr2.Generation,
-								ParentStatuses: map[string]state.ParentStatus{
-									"listener-80-1": {
+								ParentStatuses: []state.ParentStatus{
+									{
+										GatewayNsName: client.ObjectKeyFromObject(gw2),
+										SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-80-1"),
 										Conditions: append(
 											conditions.NewDefaultRouteConditions(),
 											conditions.NewTODO("Gateway is ignored"),
 										),
 									},
-									"listener-443-1": {
+									{
+										GatewayNsName: client.ObjectKeyFromObject(gw2),
+										SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-443-1"),
 										Conditions: append(
 											conditions.NewDefaultRouteConditions(),
 											conditions.NewTODO("Gateway is ignored"),
@@ -1098,12 +1130,16 @@ var _ = Describe("ChangeProcessor", func() {
 						HTTPRouteStatuses: map[types.NamespacedName]state.HTTPRouteStatus{
 							{Namespace: "test", Name: "hr-2"}: {
 								ObservedGeneration: hr2.Generation,
-								ParentStatuses: map[string]state.ParentStatus{
-									"listener-80-1": {
-										Conditions: conditions.NewDefaultRouteConditions(),
+								ParentStatuses: []state.ParentStatus{
+									{
+										GatewayNsName: client.ObjectKeyFromObject(gw2),
+										SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-80-1"),
+										Conditions:    conditions.NewDefaultRouteConditions(),
 									},
-									"listener-443-1": {
-										Conditions: conditions.NewDefaultRouteConditions(),
+									{
+										GatewayNsName: client.ObjectKeyFromObject(gw2),
+										SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-443-1"),
+										Conditions:    conditions.NewDefaultRouteConditions(),
 									},
 								},
 							},
@@ -2102,9 +2138,11 @@ var _ = Describe("ChangeProcessor", func() {
 					HTTPRouteStatuses: map[types.NamespacedName]state.HTTPRouteStatus{
 						hrNsName: {
 							ObservedGeneration: hr.Generation,
-							ParentStatuses: map[string]state.ParentStatus{
-								"listener-80-1": {
-									Conditions: conditions.NewDefaultRouteConditions(),
+							ParentStatuses: []state.ParentStatus{
+								{
+									GatewayNsName: gwNsName,
+									SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-80-1"),
+									Conditions:    conditions.NewDefaultRouteConditions(),
 								},
 							},
 						},

--- a/internal/state/graph/backend_refs_test.go
+++ b/internal/state/graph/backend_refs_test.go
@@ -309,11 +309,11 @@ func TestAddBackendGroupsToRouteTest(t *testing.T) {
 		return rules
 	}
 
-	const sectionName = "test"
-	sectionNameRefs := map[string]ParentRef{
-		sectionName: {
-			Idx:     0,
-			Gateway: types.NamespacedName{Namespace: "test", Name: "gateway"},
+	sectionNameRefs := []ParentRef{
+		{
+			Idx:      0,
+			Gateway:  types.NamespacedName{Namespace: "test", Name: "gateway"},
+			Attached: true,
 		},
 	}
 
@@ -337,10 +337,10 @@ func TestAddBackendGroupsToRouteTest(t *testing.T) {
 	}{
 		{
 			route: &Route{
-				Source:          hrWithOneBackend,
-				SectionNameRefs: sectionNameRefs,
-				Valid:           true,
-				Rules:           createRules(hrWithOneBackend, allValid, allValid),
+				Source:     hrWithOneBackend,
+				ParentRefs: sectionNameRefs,
+				Valid:      true,
+				Rules:      createRules(hrWithOneBackend, allValid, allValid),
 			},
 			expectedBackendGroups: []BackendGroup{
 				{
@@ -362,10 +362,10 @@ func TestAddBackendGroupsToRouteTest(t *testing.T) {
 		},
 		{
 			route: &Route{
-				Source:          hrWithTwoBackends,
-				SectionNameRefs: sectionNameRefs,
-				Valid:           true,
-				Rules:           createRules(hrWithTwoBackends, allValid, allValid),
+				Source:     hrWithTwoBackends,
+				ParentRefs: sectionNameRefs,
+				Valid:      true,
+				Rules:      createRules(hrWithTwoBackends, allValid, allValid),
 			},
 			expectedBackendGroups: []BackendGroup{
 				{
@@ -394,9 +394,9 @@ func TestAddBackendGroupsToRouteTest(t *testing.T) {
 		},
 		{
 			route: &Route{
-				Source:          hrWithOneBackend,
-				SectionNameRefs: sectionNameRefs,
-				Valid:           false,
+				Source:     hrWithOneBackend,
+				ParentRefs: sectionNameRefs,
+				Valid:      false,
 			},
 			expectedBackendGroups: nil,
 			expectedConditions:    nil,
@@ -404,10 +404,10 @@ func TestAddBackendGroupsToRouteTest(t *testing.T) {
 		},
 		{
 			route: &Route{
-				Source:          hrWithOneBackend,
-				SectionNameRefs: sectionNameRefs,
-				Valid:           true,
-				Rules:           createRules(hrWithOneBackend, allInvalid, allValid),
+				Source:     hrWithOneBackend,
+				ParentRefs: sectionNameRefs,
+				Valid:      true,
+				Rules:      createRules(hrWithOneBackend, allInvalid, allValid),
 			},
 			expectedBackendGroups: nil,
 			expectedConditions:    nil,
@@ -415,10 +415,10 @@ func TestAddBackendGroupsToRouteTest(t *testing.T) {
 		},
 		{
 			route: &Route{
-				Source:          hrWithOneBackend,
-				SectionNameRefs: sectionNameRefs,
-				Valid:           true,
-				Rules:           createRules(hrWithOneBackend, allValid, allInvalid),
+				Source:     hrWithOneBackend,
+				ParentRefs: sectionNameRefs,
+				Valid:      true,
+				Rules:      createRules(hrWithOneBackend, allValid, allInvalid),
 			},
 			expectedBackendGroups: nil,
 			expectedConditions:    nil,
@@ -426,10 +426,10 @@ func TestAddBackendGroupsToRouteTest(t *testing.T) {
 		},
 		{
 			route: &Route{
-				Source:          hrWithInvalidRule,
-				SectionNameRefs: sectionNameRefs,
-				Valid:           true,
-				Rules:           createRules(hrWithInvalidRule, allValid, allValid),
+				Source:     hrWithInvalidRule,
+				ParentRefs: sectionNameRefs,
+				Valid:      true,
+				Rules:      createRules(hrWithInvalidRule, allValid, allValid),
 			},
 			expectedBackendGroups: []BackendGroup{
 				{
@@ -451,10 +451,10 @@ func TestAddBackendGroupsToRouteTest(t *testing.T) {
 		},
 		{
 			route: &Route{
-				Source:          hrWithZeroBackendRefs,
-				SectionNameRefs: sectionNameRefs,
-				Valid:           true,
-				Rules:           createRules(hrWithZeroBackendRefs, allValid, allValid),
+				Source:     hrWithZeroBackendRefs,
+				ParentRefs: sectionNameRefs,
+				Valid:      true,
+				Rules:      createRules(hrWithZeroBackendRefs, allValid, allValid),
 			},
 			expectedBackendGroups: []BackendGroup{
 				{
@@ -474,7 +474,7 @@ func TestAddBackendGroupsToRouteTest(t *testing.T) {
 			addBackendGroupsToRoute(test.route, services)
 
 			g.Expect(helpers.Diff(test.expectedBackendGroups, test.route.GetAllBackendGroups())).To(BeEmpty())
-			g.Expect(test.route.GetAllConditionsForSectionName(sectionName)).To(Equal(test.expectedConditions))
+			g.Expect(test.route.Conditions).To(Equal(test.expectedConditions))
 		})
 	}
 }

--- a/internal/state/graph/graph_test.go
+++ b/internal/state/graph/graph_test.go
@@ -12,7 +12,6 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/helpers"
-	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state/conditions"
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state/secrets/secretsfakes"
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state/validation"
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state/validation/validationfakes"
@@ -179,27 +178,27 @@ func TestBuildGraph(t *testing.T) {
 	routeHR1 := &Route{
 		Valid:  true,
 		Source: hr1,
-		SectionNameRefs: map[string]ParentRef{
-			"listener-80-1": {
-				Idx:     0,
-				Gateway: client.ObjectKeyFromObject(gw1),
+		ParentRefs: []ParentRef{
+			{
+				Idx:      0,
+				Gateway:  client.ObjectKeyFromObject(gw1),
+				Attached: true,
 			},
 		},
-		UnattachedSectionNameRefs: map[string]conditions.Condition{},
-		Rules:                     []Rule{createValidRuleWithBackendGroup(hr1Group)},
+		Rules: []Rule{createValidRuleWithBackendGroup(hr1Group)},
 	}
 
 	routeHR3 := &Route{
 		Valid:  true,
 		Source: hr3,
-		SectionNameRefs: map[string]ParentRef{
-			"listener-443-1": {
-				Idx:     0,
-				Gateway: client.ObjectKeyFromObject(gw1),
+		ParentRefs: []ParentRef{
+			{
+				Idx:      0,
+				Gateway:  client.ObjectKeyFromObject(gw1),
+				Attached: true,
 			},
 		},
-		UnattachedSectionNameRefs: map[string]conditions.Condition{},
-		Rules:                     []Rule{createValidRuleWithBackendGroup(hr3Group)},
+		Rules: []Rule{createValidRuleWithBackendGroup(hr3Group)},
 	}
 
 	secretMemoryMgr := &secretsfakes.FakeSecretDiskMemoryManager{}

--- a/internal/status/httproute.go
+++ b/internal/status/httproute.go
@@ -1,10 +1,7 @@
 package status
 
 import (
-	"sort"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state"
@@ -16,29 +13,17 @@ import (
 // Extend support to cover more cases.
 func prepareHTTPRouteStatus(
 	status state.HTTPRouteStatus,
-	gwNsName types.NamespacedName,
 	gatewayCtlrName string,
 	transitionTime metav1.Time,
 ) v1beta1.HTTPRouteStatus {
 	parents := make([]v1beta1.RouteParentStatus, 0, len(status.ParentStatuses))
 
-	// FIXME(pleshakov) Maintain the order from the HTTPRoute resource
-	names := make([]string, 0, len(status.ParentStatuses))
-	for name := range status.ParentStatuses {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	for _, name := range names {
-		ps := status.ParentStatuses[name]
-
-		sectionName := name
-
+	for _, ps := range status.ParentStatuses {
 		p := v1beta1.RouteParentStatus{
 			ParentRef: v1beta1.ParentReference{
-				Namespace:   (*v1beta1.Namespace)(&gwNsName.Namespace),
-				Name:        v1beta1.ObjectName(gwNsName.Name),
-				SectionName: (*v1beta1.SectionName)(&sectionName),
+				Namespace:   (*v1beta1.Namespace)(&ps.GatewayNsName.Namespace),
+				Name:        v1beta1.ObjectName(ps.GatewayNsName.Name),
+				SectionName: ps.SectionName,
 			},
 			ControllerName: v1beta1.GatewayController(gatewayCtlrName),
 			Conditions:     convertConditions(ps.Conditions, status.ObservedGeneration, transitionTime),

--- a/internal/status/updater.go
+++ b/internal/status/updater.go
@@ -130,7 +130,6 @@ func (upd *updaterImpl) Update(ctx context.Context, statuses state.Statuses) {
 			// statuses.GatewayStatus is never nil when len(statuses.HTTPRouteStatuses) > 0
 			hr.Status = prepareHTTPRouteStatus(
 				rs,
-				statuses.GatewayStatus.NsName,
 				upd.cfg.GatewayCtlrName,
 				upd.cfg.Clock.Now(),
 			)

--- a/internal/status/updater_test.go
+++ b/internal/status/updater_test.go
@@ -93,9 +93,11 @@ var _ = Describe("Updater", func() {
 					HTTPRouteStatuses: map[types.NamespacedName]state.HTTPRouteStatus{
 						{Namespace: "test", Name: "route1"}: {
 							ObservedGeneration: 5,
-							ParentStatuses: map[string]state.ParentStatus{
-								"http": {
-									Conditions: status.CreateTestConditions(),
+							ParentStatuses: []state.ParentStatus{
+								{
+									GatewayNsName: types.NamespacedName{Namespace: "test", Name: "gateway"},
+									SectionName:   helpers.GetPointer[v1beta1.SectionName]("http"),
+									Conditions:    status.CreateTestConditions(),
 								},
 							},
 						},


### PR DESCRIPTION
- Previously, NKG assumed section names in parentRefs of HTTPRoute were unique, even when they referenced different Gateways. This PR fixes that. Fixes https://github.com/nginxinc/nginx-kubernetes-gateway/issues/484
- Previously, when NKG reported status for a parentRef with an empty section name, it would give the ref the name "unattached" in the HTTPRoute status. This behavior is not Gateway API spec compliant -- the API prescribe to use empty section name in that case. Now NKG will use empty section name. See the corresponding FIXME in the code https://github.com/nginxinc/nginx-kubernetes-gateway/blob/b594695bb42a79653eb8217a6dfd00c6d9594d5b/internal/state/statuses.go#L151 Note: the FIXME advice is wrong.
- Previously, in case of multiple parentRefs in an HTTPRoute, when reporting their statuses in the HTTPRoute status, NKG could change the order of the refs in the status. This PR restores the order. See the corresponding FIXME in
the code https://github.com/nginxinc/nginx-kubernetes-gateway/blob/b594695bb42a79653eb8217a6dfd00c6d9594d5b/internal/status/httproute.go#L25