### PR TITLE
Report proper conditions when GatewayClass is invalid or doesn't exist 

### DIFF
--- a/internal/state/change_processor_test.go
+++ b/internal/state/change_processor_test.go
@@ -316,18 +316,20 @@ var _ = Describe("ChangeProcessor", func() {
 								ObservedGeneration: gw1.Generation,
 								ListenerStatuses: map[string]state.ListenerStatus{
 									"listener-80-1": {
-										AttachedRoutes: 1,
-										Conditions: append(
-											conditions.NewDefaultListenerConditions(),
-											conditions.NewTODO("GatewayClass is invalid or doesn't exist"),
-										),
+										AttachedRoutes: 0,
+										Conditions: []conditions.Condition{
+											conditions.NewListenerResolvedRefs(),
+											conditions.NewListenerNoConflicts(),
+											conditions.NewListenerNoValidGatewayClass("GatewayClass doesn't exist"),
+										},
 									},
 									"listener-443-1": {
-										AttachedRoutes: 1,
-										Conditions: append(
-											conditions.NewDefaultListenerConditions(),
-											conditions.NewTODO("GatewayClass is invalid or doesn't exist"),
-										),
+										AttachedRoutes: 0,
+										Conditions: []conditions.Condition{
+											conditions.NewListenerResolvedRefs(),
+											conditions.NewListenerNoConflicts(),
+											conditions.NewListenerNoValidGatewayClass("GatewayClass doesn't exist"),
+										},
 									},
 								},
 							},
@@ -339,18 +341,16 @@ var _ = Describe("ChangeProcessor", func() {
 										{
 											GatewayNsName: client.ObjectKeyFromObject(gw1),
 											SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-80-1"),
-											Conditions: append(
-												conditions.NewDefaultRouteConditions(),
-												conditions.NewTODO("GatewayClass is invalid or doesn't exist"),
-											),
+											Conditions: []conditions.Condition{
+												conditions.NewRouteInvalidListener(),
+											},
 										},
 										{
 											GatewayNsName: client.ObjectKeyFromObject(gw1),
 											SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-443-1"),
-											Conditions: append(
-												conditions.NewDefaultRouteConditions(),
-												conditions.NewTODO("GatewayClass is invalid or doesn't exist"),
-											),
+											Conditions: []conditions.Condition{
+												conditions.NewRouteInvalidListener(),
+											},
 										},
 									},
 								},
@@ -1219,17 +1219,19 @@ var _ = Describe("ChangeProcessor", func() {
 							ListenerStatuses: map[string]state.ListenerStatus{
 								"listener-80-1": {
 									AttachedRoutes: 0,
-									Conditions: append(
-										conditions.NewDefaultListenerConditions(),
-										conditions.NewTODO("GatewayClass is invalid or doesn't exist"),
-									),
+									Conditions: []conditions.Condition{
+										conditions.NewListenerResolvedRefs(),
+										conditions.NewListenerNoConflicts(),
+										conditions.NewListenerNoValidGatewayClass("GatewayClass doesn't exist"),
+									},
 								},
 								"listener-443-1": {
 									AttachedRoutes: 0,
-									Conditions: append(
-										conditions.NewDefaultListenerConditions(),
-										conditions.NewTODO("GatewayClass is invalid or doesn't exist"),
-									),
+									Conditions: []conditions.Condition{
+										conditions.NewListenerResolvedRefs(),
+										conditions.NewListenerNoConflicts(),
+										conditions.NewListenerNoValidGatewayClass("GatewayClass doesn't exist"),
+									},
 								},
 							},
 						},

--- a/internal/state/conditions/conditions.go
+++ b/internal/state/conditions/conditions.go
@@ -15,6 +15,10 @@ const (
 	// is invalid or not supported.
 	ListenerReasonUnsupportedValue v1beta1.ListenerConditionReason = "UnsupportedValue"
 
+	// ListenerReasonNoValidGatewayClass is used with the "Accepted" condition when there is no valid GatewayClass
+	// in the cluster.
+	ListenerReasonNoValidGatewayClass v1beta1.ListenerConditionReason = "NoValidGatewayClass"
+
 	// RouteReasonBackendRefUnsupportedValue is used with the "ResolvedRefs" condition when one of the
 	// Route rules has a backendRef with an unsupported value.
 	RouteReasonBackendRefUnsupportedValue = "UnsupportedValue"
@@ -129,27 +133,42 @@ func NewListenerPortUnavailable(msg string) Condition {
 	}
 }
 
+// NewListenerAccepted returns a Condition that indicates that the Listener is accepted.
+func NewListenerAccepted() Condition {
+	return Condition{
+		Type:    string(v1beta1.ListenerConditionAccepted),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(v1beta1.ListenerReasonAccepted),
+		Message: "Listener is accepted",
+	}
+}
+
+// NewListenerResolvedRefs returns a Condition that indicates that all references in a Listener are resolved.
+func NewListenerResolvedRefs() Condition {
+	return Condition{
+		Type:    string(v1beta1.ListenerConditionResolvedRefs),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(v1beta1.ListenerReasonResolvedRefs),
+		Message: "All references are resolved",
+	}
+}
+
+// NewListenerNoConflicts returns a Condition that indicates that there are no conflicts in a Listener.
+func NewListenerNoConflicts() Condition {
+	return Condition{
+		Type:    string(v1beta1.ListenerConditionConflicted),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(v1beta1.ListenerReasonNoConflicts),
+		Message: "No conflicts",
+	}
+}
+
 // NewDefaultListenerConditions returns the default Conditions that must be present in the status of a Listener.
 func NewDefaultListenerConditions() []Condition {
 	return []Condition{
-		{
-			Type:    string(v1beta1.ListenerConditionAccepted),
-			Status:  metav1.ConditionTrue,
-			Reason:  string(v1beta1.ListenerReasonAccepted),
-			Message: "Listener is accepted",
-		},
-		{
-			Type:    string(v1beta1.ListenerReasonResolvedRefs),
-			Status:  metav1.ConditionTrue,
-			Reason:  string(v1beta1.ListenerReasonResolvedRefs),
-			Message: "All references are resolved",
-		},
-		{
-			Type:    string(v1beta1.ListenerConditionConflicted),
-			Status:  metav1.ConditionFalse,
-			Reason:  string(v1beta1.ListenerReasonNoConflicts),
-			Message: "No conflicts",
-		},
+		NewListenerAccepted(),
+		NewListenerResolvedRefs(),
+		NewListenerNoConflicts(),
 	}
 }
 
@@ -216,6 +235,17 @@ func NewListenerUnsupportedProtocol(msg string) Condition {
 		Type:    string(v1beta1.ListenerConditionAccepted),
 		Status:  metav1.ConditionFalse,
 		Reason:  string(v1beta1.ListenerReasonUnsupportedProtocol),
+		Message: msg,
+	}
+}
+
+// NewListenerNoValidGatewayClass returns a Condition that indicates that the Listener is not accepted because
+// there is no valid GatewayClass.
+func NewListenerNoValidGatewayClass(msg string) Condition {
+	return Condition{
+		Type:    string(v1beta1.ListenerConditionAccepted),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(ListenerReasonNoValidGatewayClass),
 		Message: msg,
 	}
 }

--- a/internal/state/graph/gateway.go
+++ b/internal/state/graph/gateway.go
@@ -134,23 +134,18 @@ func buildListeners(
 	return listeners
 }
 
-type listenerConfigurator interface {
-	configure(listener v1beta1.Listener) *Listener
-}
-
 type listenerConfiguratorFactory struct {
-	https *httpListenerConfigurator
-	http  *httpListenerConfigurator
+	http, https, unsupportedProtocol *listenerConfigurator
 }
 
-func (f *listenerConfiguratorFactory) getConfiguratorForListener(l v1beta1.Listener) listenerConfigurator {
+func (f *listenerConfiguratorFactory) getConfiguratorForListener(l v1beta1.Listener) *listenerConfigurator {
 	switch l.Protocol {
 	case v1beta1.HTTPProtocolType:
 		return f.http
 	case v1beta1.HTTPSProtocolType:
 		return f.https
 	default:
-		return newInvalidProtocolListenerConfigurator()
+		return f.unsupportedProtocol
 	}
 }
 
@@ -159,253 +154,267 @@ func newListenerConfiguratorFactory(
 	secretMemoryMgr secrets.SecretDiskMemoryManager,
 ) *listenerConfiguratorFactory {
 	return &listenerConfiguratorFactory{
-		https: newHTTPSListenerConfigurator(gw, secretMemoryMgr),
-		http:  newHTTPListenerConfigurator(gw),
-	}
-}
-
-type httpListenerConfigurator struct {
-	gateway         *v1beta1.Gateway
-	secretMemoryMgr secrets.SecretDiskMemoryManager
-	usedHostnames   map[string]*Listener
-	validate        func(gl v1beta1.Listener) []conditions.Condition
-}
-
-func newHTTPListenerConfigurator(gw *v1beta1.Gateway) *httpListenerConfigurator {
-	return &httpListenerConfigurator{
-		usedHostnames: make(map[string]*Listener),
-		gateway:       gw,
-		validate:      validateHTTPListener,
-	}
-}
-
-func newHTTPSListenerConfigurator(
-	gateway *v1beta1.Gateway,
-	secretMemoryMgr secrets.SecretDiskMemoryManager,
-) *httpListenerConfigurator {
-	return &httpListenerConfigurator{
-		gateway:         gateway,
-		secretMemoryMgr: secretMemoryMgr,
-		usedHostnames:   make(map[string]*Listener),
-		validate: func(gl v1beta1.Listener) []conditions.Condition {
-			return validateHTTPSListener(gl, gateway.Namespace)
+		unsupportedProtocol: &listenerConfigurator{
+			validators: []listenerValidator{
+				func(listener v1beta1.Listener) []conditions.Condition {
+					valErr := field.NotSupported(
+						field.NewPath("protocol"),
+						listener.Protocol,
+						[]string{string(v1beta1.HTTPProtocolType), string(v1beta1.HTTPSProtocolType)},
+					)
+					return []conditions.Condition{conditions.NewListenerUnsupportedProtocol(valErr.Error())}
+				},
+			},
+		},
+		http: &listenerConfigurator{
+			validators: []listenerValidator{
+				validateListenerHostname,
+				createAddressesValidator(gw),
+				validateHTTPListener,
+			},
+			conflictResolvers: []listenerConflictResolver{
+				createHostnameConflictResolver(),
+			},
+		},
+		https: &listenerConfigurator{
+			validators: []listenerValidator{
+				validateListenerHostname,
+				createAddressesValidator(gw),
+				createHTTPSListenerValidator(gw.Namespace),
+			},
+			conflictResolvers: []listenerConflictResolver{
+				createHostnameConflictResolver(),
+			},
+			externalReferenceResolvers: []listenerExternalReferenceResolver{
+				createExternalReferencesForTLSSecretsResolver(gw.Namespace, secretMemoryMgr),
+			},
 		},
 	}
 }
 
-func validateListener(
-	gl v1beta1.Listener,
-	gw *v1beta1.Gateway,
-	validate func(gl v1beta1.Listener) []conditions.Condition,
-) (conds []conditions.Condition, validHostname bool) {
-	conds = validate(gl)
+// listenerValidator validates a listener. If the listener is invalid, the validator will return appropriate conditions.
+type listenerValidator func(v1beta1.Listener) []conditions.Condition
 
-	if len(gw.Spec.Addresses) > 0 {
-		path := field.NewPath("spec", "addresses")
-		valErr := field.Forbidden(path, "addresses are not supported")
-		conds = append(conds, conditions.NewListenerUnsupportedAddress(valErr.Error()))
-	}
+// listenerConflictResolver resolves conflicts between listeners. In case of a conflict, the resolver will make
+// the conflicting listeners invalid - i.e. it will modify the passed listener and the previously processed conflicting
+// listener. It will also add appropriate conditions to the listeners.
+type listenerConflictResolver func(listener *Listener)
 
-	validHostnameErr := validateListenerHostname(gl.Hostname)
-	if validHostnameErr != nil {
-		path := field.NewPath("hostname")
-		valErr := field.Invalid(path, gl.Hostname, validHostnameErr.Error())
-		conds = append(conds, conditions.NewListenerUnsupportedValue(valErr.Error()))
-	}
+// listenerExternalReferenceResolver resolves external references for a listener. If the reference is not resolvable,
+// the resolver will make the listener invalid and add appropriate conditions.
+type listenerExternalReferenceResolver func(listener *Listener)
 
-	return conds, validHostnameErr == nil
+// listenerConfigurator is responsible for configuring a listener.
+// validators, conflictResolvers, externalReferenceResolvers generate conditions for invalid fields of the listener.
+// Because the Gateway status includes a status field for each listener, the messages in those conditions
+// don't need to include the full path to the field (e.g. "spec.listeners[0].hostname"). They will include
+// a path starting from the field of a listener (e.g. "hostname", "tls.options").
+type listenerConfigurator struct {
+	// validators must not depend on the order of execution.
+	validators []listenerValidator
+
+	// conflictResolvers can depend on validators - they will only be executed if all validators pass.
+	conflictResolvers []listenerConflictResolver
+	// externalReferenceResolvers can depend on validators - they will only be executed if all validators pass.
+	externalReferenceResolvers []listenerExternalReferenceResolver
 }
 
-func (c *httpListenerConfigurator) ensureUniqueHostnamesAmongListeners(l *Listener) {
-	h := getHostname(l.Source.Hostname)
+func (c *listenerConfigurator) configure(listener v1beta1.Listener) *Listener {
+	var conds []conditions.Condition
 
-	if holder, exist := c.usedHostnames[h]; exist {
-		l.Valid = false
-
-		holder.Valid = false   // all listeners for the same hostname become conflicted
-		holder.SecretPath = "" // ensure secret path is unset for invalid listeners
-
-		format := "Multiple listeners for the same port use the same hostname %q; " +
-			"ensure only one listener uses that hostname"
-		conflictedConds := conditions.NewListenerConflictedHostname(fmt.Sprintf(format, h))
-
-		holder.Conditions = append(holder.Conditions, conflictedConds...)
-		l.Conditions = append(l.Conditions, conflictedConds...)
-
-		return
+	// validators might return different conditions, so we run them all.
+	for _, validator := range c.validators {
+		conds = append(conds, validator(listener)...)
 	}
 
-	c.usedHostnames[h] = l
-}
-
-func (c *httpListenerConfigurator) loadSecretIntoListener(l *Listener) {
-	if !l.Valid {
-		return
+	if len(conds) > 0 {
+		return &Listener{
+			Source:     listener,
+			Conditions: conds,
+			Valid:      false,
+		}
 	}
-
-	nsname := types.NamespacedName{
-		Namespace: c.gateway.Namespace,
-		Name:      string(l.Source.TLS.CertificateRefs[0].Name),
-	}
-
-	var err error
-
-	l.SecretPath, err = c.secretMemoryMgr.Request(nsname)
-	if err != nil {
-		path := field.NewPath("tls", "certificateRefs").Index(0)
-		// field.NotFound could be better, but it doesn't allow us to set the error message.
-		valErr := field.Invalid(path, nsname, err.Error())
-
-		l.Conditions = append(l.Conditions, conditions.NewListenerInvalidCertificateRef(valErr.Error())...)
-		l.Valid = false
-	}
-}
-
-func (c *httpListenerConfigurator) configure(gl v1beta1.Listener) *Listener {
-	// The functions called by configure() generate conditions for invalid fields of the listener.
-	// Because the Gateway status includes a status field for each listener, the messages in those conditions
-	// don't need to include the full path to the field (e.g. "spec.listeners[0].hostname"). They will include
-	// a path starting from the field of a listener (e.g. "hostname", "tls.options").
-
-	conds, validHostname := validateListener(gl, c.gateway, c.validate)
 
 	l := &Listener{
-		Source:            gl,
-		Valid:             len(conds) == 0,
+		Source:            listener,
 		Routes:            make(map[types.NamespacedName]*Route),
 		AcceptedHostnames: make(map[string]struct{}),
-		Conditions:        conds,
+		Valid:             true,
 	}
 
-	if validHostname {
-		c.ensureUniqueHostnamesAmongListeners(l)
+	// resolvers might add different conditions to the listener, so we run them all.
+
+	for _, resolver := range c.conflictResolvers {
+		resolver(l)
 	}
 
-	if gl.Protocol == v1beta1.HTTPSProtocolType {
-		c.loadSecretIntoListener(l)
+	for _, resolver := range c.externalReferenceResolvers {
+		resolver(l)
 	}
 
 	return l
 }
 
-type invalidProtocolListenerConfigurator struct{}
+func validateListenerHostname(listener v1beta1.Listener) []conditions.Condition {
+	if listener.Hostname == nil {
+		return nil
+	}
 
-func newInvalidProtocolListenerConfigurator() *invalidProtocolListenerConfigurator {
-	return &invalidProtocolListenerConfigurator{}
+	h := string(*listener.Hostname)
+
+	if h == "" {
+		return nil
+	}
+
+	err := validateHostname(h)
+	if err != nil {
+		path := field.NewPath("hostname")
+		valErr := field.Invalid(path, listener.Hostname, err.Error())
+		return []conditions.Condition{conditions.NewListenerUnsupportedValue(valErr.Error())}
+	}
+	return nil
 }
 
-func (c *invalidProtocolListenerConfigurator) configure(gl v1beta1.Listener) *Listener {
-	valErr := field.NotSupported(
-		field.NewPath("protocol"),
-		gl.Protocol,
-		[]string{string(v1beta1.HTTPProtocolType), string(v1beta1.HTTPSProtocolType)},
-	)
-
-	return &Listener{
-		Source:            gl,
-		Valid:             false,
-		Routes:            make(map[types.NamespacedName]*Route),
-		AcceptedHostnames: make(map[string]struct{}),
-		Conditions: []conditions.Condition{
-			conditions.NewListenerUnsupportedProtocol(valErr.Error()),
-		},
+func createAddressesValidator(gw *v1beta1.Gateway) listenerValidator {
+	return func(listener v1beta1.Listener) []conditions.Condition {
+		if len(gw.Spec.Addresses) > 0 {
+			path := field.NewPath("spec", "addresses")
+			valErr := field.Forbidden(path, "addresses are not supported")
+			return []conditions.Condition{conditions.NewListenerUnsupportedAddress(valErr.Error())}
+		}
+		return nil
 	}
 }
 
 func validateHTTPListener(listener v1beta1.Listener) []conditions.Condition {
-	var conds []conditions.Condition
-
 	if listener.Port != 80 {
 		path := field.NewPath("port")
 		valErr := field.NotSupported(path, listener.Port, []string{"80"})
-		conds = append(conds, conditions.NewListenerPortUnavailable(valErr.Error()))
+		return []conditions.Condition{conditions.NewListenerPortUnavailable(valErr.Error())}
 	}
 
 	if listener.TLS != nil {
 		panicForBrokenWebhookAssumption(fmt.Errorf("tls is not nil for HTTP listener %q", listener.Name))
 	}
 
-	return conds
+	return nil
 }
 
-func validateHTTPSListener(listener v1beta1.Listener, gwNsName string) []conditions.Condition {
-	var conds []conditions.Condition
+func createHTTPSListenerValidator(gwNsName string) listenerValidator {
+	return func(listener v1beta1.Listener) []conditions.Condition {
+		var conds []conditions.Condition
 
-	if listener.Port != 443 {
-		path := field.NewPath("port")
-		valErr := field.NotSupported(path, listener.Port, []string{"443"})
-		conds = append(conds, conditions.NewListenerPortUnavailable(valErr.Error()))
+		if listener.Port != 443 {
+			path := field.NewPath("port")
+			valErr := field.NotSupported(path, listener.Port, []string{"443"})
+			conds = append(conds, conditions.NewListenerPortUnavailable(valErr.Error()))
+		}
+
+		if listener.TLS == nil {
+			panicForBrokenWebhookAssumption(fmt.Errorf("tls is nil for HTTPS listener %q", listener.Name))
+		}
+
+		tlsPath := field.NewPath("tls")
+
+		if *listener.TLS.Mode != v1beta1.TLSModeTerminate {
+			valErr := field.NotSupported(
+				tlsPath.Child("mode"),
+				*listener.TLS.Mode,
+				[]string{string(v1beta1.TLSModeTerminate)},
+			)
+			conds = append(conds, conditions.NewListenerUnsupportedValue(valErr.Error()))
+		}
+
+		if len(listener.TLS.Options) > 0 {
+			path := tlsPath.Child("options")
+			valErr := field.Forbidden(path, "options are not supported")
+			conds = append(conds, conditions.NewListenerUnsupportedValue(valErr.Error()))
+		}
+
+		if len(listener.TLS.CertificateRefs) == 0 {
+			panicForBrokenWebhookAssumption(fmt.Errorf("zero certificateRefs for HTTPS listener %q", listener.Name))
+		}
+
+		certRef := listener.TLS.CertificateRefs[0]
+
+		certRefPath := tlsPath.Child("certificateRefs").Index(0)
+
+		if certRef.Kind != nil && *certRef.Kind != "Secret" {
+			path := certRefPath.Child("kind")
+			valErr := field.NotSupported(path, *certRef.Kind, []string{"Secret"})
+			conds = append(conds, conditions.NewListenerInvalidCertificateRef(valErr.Error())...)
+		}
+
+		// for Kind Secret, certRef.Group must be nil or empty
+		if certRef.Group != nil && *certRef.Group != "" {
+			path := certRefPath.Child("group")
+			valErr := field.NotSupported(path, *certRef.Group, []string{""})
+			conds = append(conds, conditions.NewListenerInvalidCertificateRef(valErr.Error())...)
+		}
+
+		// secret must be in the same namespace as the gateway
+		if certRef.Namespace != nil && string(*certRef.Namespace) != gwNsName {
+			const detail = "Referenced Secret must belong to the same namespace as the Gateway"
+			path := certRefPath.Child("namespace")
+			valErr := field.Invalid(path, certRef.Namespace, detail)
+			conds = append(conds, conditions.NewListenerInvalidCertificateRef(valErr.Error())...)
+		}
+
+		if l := len(listener.TLS.CertificateRefs); l > 1 {
+			path := tlsPath.Child("certificateRefs")
+			valErr := field.TooMany(path, l, 1)
+			conds = append(conds, conditions.NewListenerUnsupportedValue(valErr.Error()))
+		}
+
+		return conds
 	}
-
-	if listener.TLS == nil {
-		panicForBrokenWebhookAssumption(fmt.Errorf("tls is nil for HTTPS listener %q", listener.Name))
-	}
-
-	tlsPath := field.NewPath("tls")
-
-	if *listener.TLS.Mode != v1beta1.TLSModeTerminate {
-		valErr := field.NotSupported(
-			tlsPath.Child("mode"),
-			*listener.TLS.Mode,
-			[]string{string(v1beta1.TLSModeTerminate)},
-		)
-		conds = append(conds, conditions.NewListenerUnsupportedValue(valErr.Error()))
-	}
-
-	if len(listener.TLS.Options) > 0 {
-		path := tlsPath.Child("options")
-		valErr := field.Forbidden(path, "options are not supported")
-		conds = append(conds, conditions.NewListenerUnsupportedValue(valErr.Error()))
-	}
-
-	if len(listener.TLS.CertificateRefs) == 0 {
-		panicForBrokenWebhookAssumption(fmt.Errorf("zero certificateRefs for HTTPS listener %q", listener.Name))
-	}
-
-	certRef := listener.TLS.CertificateRefs[0]
-
-	certRefPath := tlsPath.Child("certificateRefs").Index(0)
-
-	if certRef.Kind != nil && *certRef.Kind != "Secret" {
-		path := certRefPath.Child("kind")
-		valErr := field.NotSupported(path, *certRef.Kind, []string{"Secret"})
-		conds = append(conds, conditions.NewListenerInvalidCertificateRef(valErr.Error())...)
-	}
-
-	// for Kind Secret, certRef.Group must be nil or empty
-	if certRef.Group != nil && *certRef.Group != "" {
-		path := certRefPath.Child("group")
-		valErr := field.NotSupported(path, *certRef.Group, []string{""})
-		conds = append(conds, conditions.NewListenerInvalidCertificateRef(valErr.Error())...)
-	}
-
-	// secret must be in the same namespace as the gateway
-	if certRef.Namespace != nil && string(*certRef.Namespace) != gwNsName {
-		const detail = "Referenced Secret must belong to the same namespace as the Gateway"
-		path := certRefPath.Child("namespace")
-		valErr := field.Invalid(path, certRef.Namespace, detail)
-		conds = append(conds, conditions.NewListenerInvalidCertificateRef(valErr.Error())...)
-	}
-
-	if l := len(listener.TLS.CertificateRefs); l > 1 {
-		path := tlsPath.Child("certificateRefs")
-		valErr := field.TooMany(path, l, 1)
-		conds = append(conds, conditions.NewListenerUnsupportedValue(valErr.Error()))
-	}
-
-	return conds
 }
 
-func validateListenerHostname(host *v1beta1.Hostname) error {
-	if host == nil {
-		return nil
+func createHostnameConflictResolver() listenerConflictResolver {
+	usedHostnames := make(map[string]*Listener)
+
+	return func(l *Listener) {
+		h := getHostname(l.Source.Hostname)
+
+		if holder, exist := usedHostnames[h]; exist {
+			l.Valid = false
+
+			holder.Valid = false // all listeners for the same hostname become conflicted
+
+			format := "Multiple listeners for the same port use the same hostname %q; " +
+				"ensure only one listener uses that hostname"
+			conflictedConds := conditions.NewListenerConflictedHostname(fmt.Sprintf(format, h))
+
+			holder.Conditions = append(holder.Conditions, conflictedConds...)
+			l.Conditions = append(l.Conditions, conflictedConds...)
+
+			return
+		}
+
+		usedHostnames[h] = l
 	}
+}
 
-	h := string(*host)
+func createExternalReferencesForTLSSecretsResolver(
+	gwNs string,
+	secretMemoryMgr secrets.SecretDiskMemoryManager,
+) listenerExternalReferenceResolver {
+	return func(l *Listener) {
+		nsname := types.NamespacedName{
+			Namespace: gwNs,
+			Name:      string(l.Source.TLS.CertificateRefs[0].Name),
+		}
 
-	if h == "" {
-		return nil
+		var err error
+
+		l.SecretPath, err = secretMemoryMgr.Request(nsname)
+		if err != nil {
+			path := field.NewPath("tls", "certificateRefs").Index(0)
+			// field.NotFound could be better, but it doesn't allow us to set the error message.
+			valErr := field.Invalid(path, nsname, err.Error())
+
+			l.Conditions = append(l.Conditions, conditions.NewListenerInvalidCertificateRef(valErr.Error())...)
+			l.Valid = false
+		}
 	}
-
-	return validateHostname(h)
 }

--- a/internal/state/graph/gateway_test.go
+++ b/internal/state/graph/gateway_test.go
@@ -320,10 +320,8 @@ func TestBuildGateway(t *testing.T) {
 				Source: getLastCreatedGetaway(),
 				Listeners: map[string]*Listener{
 					"listener-80-2": {
-						Source:            listener802,
-						Valid:             false,
-						Routes:            map[types.NamespacedName]*Route{},
-						AcceptedHostnames: map[string]struct{}{},
+						Source: listener802,
+						Valid:  false,
 						Conditions: []conditions.Condition{
 							conditions.NewListenerUnsupportedProtocol(
 								`protocol: Unsupported value: "TCP": supported values: "HTTP", "HTTPS"`,
@@ -340,10 +338,8 @@ func TestBuildGateway(t *testing.T) {
 				Source: getLastCreatedGetaway(),
 				Listeners: map[string]*Listener{
 					"listener-80-5": {
-						Source:            listener805,
-						Valid:             false,
-						Routes:            map[types.NamespacedName]*Route{},
-						AcceptedHostnames: map[string]struct{}{},
+						Source: listener805,
+						Valid:  false,
 						Conditions: []conditions.Condition{
 							conditions.NewListenerPortUnavailable(`port: Unsupported value: 81: supported values: "80"`),
 						},
@@ -358,10 +354,8 @@ func TestBuildGateway(t *testing.T) {
 				Source: getLastCreatedGetaway(),
 				Listeners: map[string]*Listener{
 					"listener-443-6": {
-						Source:            listener4436,
-						Valid:             false,
-						Routes:            map[types.NamespacedName]*Route{},
-						AcceptedHostnames: map[string]struct{}{},
+						Source: listener4436,
+						Valid:  false,
 						Conditions: []conditions.Condition{
 							conditions.NewListenerPortUnavailable(`port: Unsupported value: 444: supported values: "443"`),
 						},
@@ -376,19 +370,15 @@ func TestBuildGateway(t *testing.T) {
 				Source: getLastCreatedGetaway(),
 				Listeners: map[string]*Listener{
 					"listener-80-6": {
-						Source:            listener806,
-						Valid:             false,
-						Routes:            map[types.NamespacedName]*Route{},
-						AcceptedHostnames: map[string]struct{}{},
+						Source: listener806,
+						Valid:  false,
 						Conditions: []conditions.Condition{
 							conditions.NewListenerUnsupportedValue(invalidHostnameMsg),
 						},
 					},
 					"listener-443-4": {
-						Source:            listener4434,
-						Valid:             false,
-						Routes:            map[types.NamespacedName]*Route{},
-						AcceptedHostnames: map[string]struct{}{},
+						Source: listener4434,
+						Valid:  false,
 						Conditions: []conditions.Condition{
 							conditions.NewListenerUnsupportedValue(invalidHostnameMsg),
 						},
@@ -479,6 +469,7 @@ func TestBuildGateway(t *testing.T) {
 						Routes:            map[types.NamespacedName]*Route{},
 						AcceptedHostnames: map[string]struct{}{},
 						Conditions:        conditions.NewListenerConflictedHostname(conflictedHostnamesMsg),
+						SecretPath:        "/etc/nginx/secrets/test_secret",
 					},
 					"listener-443-3": {
 						Source:            listener4433,
@@ -486,6 +477,7 @@ func TestBuildGateway(t *testing.T) {
 						Routes:            map[types.NamespacedName]*Route{},
 						AcceptedHostnames: map[string]struct{}{},
 						Conditions:        conditions.NewListenerConflictedHostname(conflictedHostnamesMsg),
+						SecretPath:        "/etc/nginx/secrets/test_secret",
 					},
 				},
 			},
@@ -502,10 +494,8 @@ func TestBuildGateway(t *testing.T) {
 				Source: getLastCreatedGetaway(),
 				Listeners: map[string]*Listener{
 					"listener-80-1": {
-						Source:            listener801,
-						Valid:             false,
-						Routes:            map[types.NamespacedName]*Route{},
-						AcceptedHostnames: map[string]struct{}{},
+						Source: listener801,
+						Valid:  false,
 						Conditions: []conditions.Condition{
 							conditions.NewListenerUnsupportedAddress(
 								"spec.addresses: Forbidden: addresses are not supported",
@@ -513,11 +503,9 @@ func TestBuildGateway(t *testing.T) {
 						},
 					},
 					"listener-443-1": {
-						Source:            listener4431,
-						Valid:             false,
-						Routes:            map[types.NamespacedName]*Route{},
-						AcceptedHostnames: map[string]struct{}{},
-						SecretPath:        "",
+						Source:     listener4431,
+						Valid:      false,
+						SecretPath: "",
 						Conditions: []conditions.Condition{
 							conditions.NewListenerUnsupportedAddress(
 								"spec.addresses: Forbidden: addresses are not supported",
@@ -731,7 +719,9 @@ func TestValidateHTTPSListener(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 
-			result := validateHTTPSListener(test.l, gwNs)
+			v := createHTTPSListenerValidator(gwNs)
+
+			result := v(test.l)
 			g.Expect(result).To(Equal(test.expected))
 		})
 	}
@@ -774,12 +764,12 @@ func TestValidateListenerHostname(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 
-			err := validateListenerHostname(test.hostname)
+			conds := validateListenerHostname(v1beta1.Listener{Hostname: test.hostname})
 
 			if test.expectErr {
-				g.Expect(err).ToNot(BeNil())
+				g.Expect(conds).ToNot(BeEmpty())
 			} else {
-				g.Expect(err).To(BeNil())
+				g.Expect(conds).To(BeEmpty())
 			}
 		})
 	}

--- a/internal/state/graph/graph.go
+++ b/internal/state/graph/graph.go
@@ -49,7 +49,7 @@ func BuildGraph(
 
 	processedGws := processGateways(state.Gateways, gcName)
 
-	gw := buildGateway(processedGws.Winner, secretMemoryMgr)
+	gw := buildGateway(processedGws.Winner, secretMemoryMgr, gc)
 
 	routes := buildRoutesForGateways(validators.HTTPFieldsValidator, state.HTTPRoutes, processedGws.GetAllNsNames())
 	bindRoutesToListeners(routes, gw)


### PR DESCRIPTION
(1)
Refactor listener validation

This prepares the codebase for an easy implementation in (2)

(2)
If GatewayClass is invalid or doesn't exist:
- For Gateway Listeners: NKG will make every listener invalid and
report Accepted condition with status False and reason
NoValidGatewayClass in every listener status.
- For HTTPRoutes: An HTTPRoute will not be able to attach to any
listener, because they will be invalid. This is already handled: NKG
will report Accepted condition with status False and reason
InvalidListener.

Fixes https://github.com/nginxinc/nginx-kubernetes-gateway/issues/307