### PR TITLE
Fix status reporting for invalid HTTPRoutes

### DIFF
--- a/internal/state/graph/backend_refs_test.go
+++ b/internal/state/graph/backend_refs_test.go
@@ -311,9 +311,11 @@ func TestAddBackendGroupsToRouteTest(t *testing.T) {
 
 	sectionNameRefs := []ParentRef{
 		{
-			Idx:      0,
-			Gateway:  types.NamespacedName{Namespace: "test", Name: "gateway"},
-			Attached: true,
+			Idx:     0,
+			Gateway: types.NamespacedName{Namespace: "test", Name: "gateway"},
+			Attachment: &ParentRefAttachmentStatus{
+				Attached: true,
+			},
 		},
 	}
 

--- a/internal/state/graph/graph_test.go
+++ b/internal/state/graph/graph_test.go
@@ -180,9 +180,11 @@ func TestBuildGraph(t *testing.T) {
 		Source: hr1,
 		ParentRefs: []ParentRef{
 			{
-				Idx:      0,
-				Gateway:  client.ObjectKeyFromObject(gw1),
-				Attached: true,
+				Idx:     0,
+				Gateway: client.ObjectKeyFromObject(gw1),
+				Attachment: &ParentRefAttachmentStatus{
+					Attached: true,
+				},
 			},
 		},
 		Rules: []Rule{createValidRuleWithBackendGroup(hr1Group)},
@@ -193,9 +195,11 @@ func TestBuildGraph(t *testing.T) {
 		Source: hr3,
 		ParentRefs: []ParentRef{
 			{
-				Idx:      0,
-				Gateway:  client.ObjectKeyFromObject(gw1),
-				Attached: true,
+				Idx:     0,
+				Gateway: client.ObjectKeyFromObject(gw1),
+				Attachment: &ParentRefAttachmentStatus{
+					Attached: true,
+				},
 			},
 		},
 		Rules: []Rule{createValidRuleWithBackendGroup(hr3Group)},

--- a/internal/state/graph/httproute_test.go
+++ b/internal/state/graph/httproute_test.go
@@ -763,6 +763,12 @@ func TestBindRouteToListeners(t *testing.T) {
 	}
 	notValidRoute := &Route{
 		Valid: false,
+		ParentRefs: []ParentRef{
+			{
+				Idx:     0,
+				Gateway: client.ObjectKeyFromObject(gw),
+			},
+		},
 	}
 
 	notValidListener := createModifiedListener(func(l *Listener) {
@@ -773,12 +779,11 @@ func TestBindRouteToListeners(t *testing.T) {
 	})
 
 	tests := []struct {
-		route                                  *Route
-		gateway                                *Gateway
-		expectedRouteUnattachedSectionNameRefs map[string]conditions.Condition
-		expectedGatewayListeners               map[string]*Listener
-		name                                   string
-		expectedSectionNameRefs                []ParentRef
+		route                    *Route
+		gateway                  *Gateway
+		expectedGatewayListeners map[string]*Listener
+		name                     string
+		expectedSectionNameRefs  []ParentRef
 	}{
 		{
 			route: createNormalRoute(),
@@ -790,9 +795,11 @@ func TestBindRouteToListeners(t *testing.T) {
 			},
 			expectedSectionNameRefs: []ParentRef{
 				{
-					Idx:      0,
-					Gateway:  client.ObjectKeyFromObject(gw),
-					Attached: true,
+					Idx:     0,
+					Gateway: client.ObjectKeyFromObject(gw),
+					Attachment: &ParentRefAttachmentStatus{
+						Attached: true,
+					},
 				},
 			},
 			expectedGatewayListeners: map[string]*Listener{
@@ -817,12 +824,14 @@ func TestBindRouteToListeners(t *testing.T) {
 			},
 			expectedSectionNameRefs: []ParentRef{
 				{
-					Idx:      0,
-					Gateway:  client.ObjectKeyFromObject(gw),
-					Attached: false,
-					FailedAttachmentCondition: conditions.NewRouteUnsupportedValue(
-						`spec.parentRefs[0].sectionName: Required value: cannot be empty`,
-					),
+					Idx:     0,
+					Gateway: client.ObjectKeyFromObject(gw),
+					Attachment: &ParentRefAttachmentStatus{
+						Attached: false,
+						FailedCondition: conditions.NewRouteUnsupportedValue(
+							`spec.parentRefs[0].sectionName: Required value: cannot be empty`,
+						),
+					},
 				},
 			},
 			expectedGatewayListeners: map[string]*Listener{
@@ -840,12 +849,14 @@ func TestBindRouteToListeners(t *testing.T) {
 			},
 			expectedSectionNameRefs: []ParentRef{
 				{
-					Idx:      0,
-					Gateway:  client.ObjectKeyFromObject(gw),
-					Attached: false,
-					FailedAttachmentCondition: conditions.NewRouteUnsupportedValue(
-						`spec.parentRefs[0].sectionName: Required value: cannot be empty`,
-					),
+					Idx:     0,
+					Gateway: client.ObjectKeyFromObject(gw),
+					Attachment: &ParentRefAttachmentStatus{
+						Attached: false,
+						FailedCondition: conditions.NewRouteUnsupportedValue(
+							`spec.parentRefs[0].sectionName: Required value: cannot be empty`,
+						),
+					},
 				},
 			},
 			expectedGatewayListeners: map[string]*Listener{
@@ -863,12 +874,14 @@ func TestBindRouteToListeners(t *testing.T) {
 			},
 			expectedSectionNameRefs: []ParentRef{
 				{
-					Idx:      0,
-					Gateway:  client.ObjectKeyFromObject(gw),
-					Attached: false,
-					FailedAttachmentCondition: conditions.NewRouteUnsupportedValue(
-						`spec.parentRefs[0].port: Forbidden: cannot be set`,
-					),
+					Idx:     0,
+					Gateway: client.ObjectKeyFromObject(gw),
+					Attachment: &ParentRefAttachmentStatus{
+						Attached: false,
+						FailedCondition: conditions.NewRouteUnsupportedValue(
+							`spec.parentRefs[0].port: Forbidden: cannot be set`,
+						),
+					},
 				},
 			},
 			expectedGatewayListeners: map[string]*Listener{
@@ -886,10 +899,12 @@ func TestBindRouteToListeners(t *testing.T) {
 			},
 			expectedSectionNameRefs: []ParentRef{
 				{
-					Idx:                       0,
-					Gateway:                   client.ObjectKeyFromObject(gw),
-					Attached:                  false,
-					FailedAttachmentCondition: conditions.NewTODO("listener is not found"),
+					Idx:     0,
+					Gateway: client.ObjectKeyFromObject(gw),
+					Attachment: &ParentRefAttachmentStatus{
+						Attached:        false,
+						FailedCondition: conditions.NewTODO("listener is not found"),
+					},
 				},
 			},
 			expectedGatewayListeners: map[string]*Listener{
@@ -907,10 +922,12 @@ func TestBindRouteToListeners(t *testing.T) {
 			},
 			expectedSectionNameRefs: []ParentRef{
 				{
-					Idx:                       0,
-					Gateway:                   client.ObjectKeyFromObject(gw),
-					Attached:                  false,
-					FailedAttachmentCondition: conditions.NewRouteInvalidListener(),
+					Idx:     0,
+					Gateway: client.ObjectKeyFromObject(gw),
+					Attachment: &ParentRefAttachmentStatus{
+						Attached:        false,
+						FailedCondition: conditions.NewRouteInvalidListener(),
+					},
 				},
 			},
 			expectedGatewayListeners: map[string]*Listener{
@@ -928,10 +945,12 @@ func TestBindRouteToListeners(t *testing.T) {
 			},
 			expectedSectionNameRefs: []ParentRef{
 				{
-					Idx:                       0,
-					Gateway:                   client.ObjectKeyFromObject(gw),
-					Attached:                  false,
-					FailedAttachmentCondition: conditions.NewRouteNoMatchingListenerHostname(),
+					Idx:     0,
+					Gateway: client.ObjectKeyFromObject(gw),
+					Attachment: &ParentRefAttachmentStatus{
+						Attached:        false,
+						FailedCondition: conditions.NewRouteNoMatchingListenerHostname(),
+					},
 				},
 			},
 			expectedGatewayListeners: map[string]*Listener{
@@ -949,10 +968,12 @@ func TestBindRouteToListeners(t *testing.T) {
 			},
 			expectedSectionNameRefs: []ParentRef{
 				{
-					Idx:                       0,
-					Gateway:                   ignoredGwNsName,
-					Attached:                  false,
-					FailedAttachmentCondition: conditions.NewTODO("Gateway is ignored"),
+					Idx:     0,
+					Gateway: ignoredGwNsName,
+					Attachment: &ParentRefAttachmentStatus{
+						Attached:        false,
+						FailedCondition: conditions.NewTODO("Gateway is ignored"),
+					},
 				},
 			},
 			expectedGatewayListeners: map[string]*Listener{
@@ -968,7 +989,13 @@ func TestBindRouteToListeners(t *testing.T) {
 					"listener-80-1": createListener(),
 				},
 			},
-			expectedRouteUnattachedSectionNameRefs: map[string]conditions.Condition{},
+			expectedSectionNameRefs: []ParentRef{
+				{
+					Idx:        0,
+					Gateway:    client.ObjectKeyFromObject(gw),
+					Attachment: nil,
+				},
+			},
 			expectedGatewayListeners: map[string]*Listener{
 				"listener-80-1": createListener(),
 			},

--- a/internal/state/statuses.go
+++ b/internal/state/statuses.go
@@ -133,7 +133,7 @@ func buildStatuses(graph *graph.Graph) Statuses {
 
 		for _, ref := range r.ParentRefs {
 			failedAttachmentCondCount := 0
-			if !ref.Attached {
+			if ref.Attachment != nil && !ref.Attachment.Attached {
 				failedAttachmentCondCount = 1
 			}
 			allConds := make([]conditions.Condition, 0, len(r.Conditions)+len(defaultConds)+failedAttachmentCondCount)
@@ -143,7 +143,7 @@ func buildStatuses(graph *graph.Graph) Statuses {
 			allConds = append(allConds, defaultConds...)
 			allConds = append(allConds, r.Conditions...)
 			if failedAttachmentCondCount == 1 {
-				allConds = append(allConds, ref.FailedAttachmentCondition)
+				allConds = append(allConds, ref.Attachment.FailedCondition)
 			}
 
 			routeRef := r.Source.Spec.ParentRefs[ref.Idx]


### PR DESCRIPTION
918d6506483fb42710a227b4ecb35c9dca43ccc5 introduced a bug which made NKG fail to report status conditions for an invalid HTTPRoute. It would try to report an empty condition in the status and fail because of the status CRD validation (example error):

```
{"level":"error","ts":"2023-04-18T15:37:49Z","logger":"statusUpdater","msg":"Failed to update status","namespace":"default","name":"coffee","kind":"HTTPRoute","error":"HTTPRoute.gateway.networking.k8s.io \"coffee\" is invalid: [status.parents[0].conditions[1].reason: Invalid value: \"\": status.parents[0].conditions[1].reason in body should be at least 1 chars long, status.parents[0].conditions[1].status: Unsupported value: \"\": supported values: \"True\", \"False\", \"Unknown\", status.parents[0].conditions[1].type: Invalid value: \"\": status.parents[0].conditions[1].type in body should match '^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$']","stacktrace":"github.com/nginxinc/nginx-kubernetes-gateway/internal/status.(*updaterImpl).update\n\t/home/runner/work/nginx-kubernetes-gateway/nginx-kubernetes-gateway/internal/status/updater.go:168\ngithub.com/nginxinc/nginx-kubernetes-gateway/internal/status.(*updaterImpl).Update\n\t/home/runner/work/nginx-kubernetes-gateway/nginx-kubernetes-gateway/internal/status/updater.go:128\ngithub.com/nginxinc/nginx-kubernetes-gateway/internal/events.(*EventHandlerImpl).HandleEventBatch\n\t/home/runner/work/nginx-kubernetes-gateway/nginx-kubernetes-gateway/internal/events/handler.go:90\ngithub.com/nginxinc/nginx-kubernetes-gateway/internal/events.(*EventLoop).Start.func1.1\n\t/home/runner/work/nginx-kubernetes-gateway/nginx-kubernetes-gateway/internal/events/loop.go:67"}
```

This PR fixes that bug.