### PR TITLE
Add tech-debt label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,6 +7,9 @@ bug:
 chore:
 - branch: ['chore/**']
 
+tech-debt:
+- branch: ['tech-debt/**', 'techdebt/**', 'debt/**']
+
 documentation:
 - branch: ['docs/**', 'doc/**']
 - '**/*.md'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -18,6 +18,9 @@ changelog:
     - title: 🧪 Tests
       labels:
         - tests
+    - title: 🧹 Tech debt
+      labels:
+        - tech-debt
     - title: 🔨 Maintenance
       labels:
         - chore


### PR DESCRIPTION
- Make PR labeler aware of tech-debt label
- Add Tech debt section to auto-generated changelog