### PR TITLE
Fix field path in error message for HTTPRoute path validation

### DIFF
--- a/internal/state/graph/httproute.go
+++ b/internal/state/graph/httproute.go
@@ -524,12 +524,12 @@ func validatePathMatch(
 	}
 
 	if *path.Type != v1beta1.PathMatchPathPrefix {
-		valErr := field.NotSupported(fieldPath, *path.Type, []string{string(v1beta1.PathMatchPathPrefix)})
+		valErr := field.NotSupported(fieldPath.Child("type"), *path.Type, []string{string(v1beta1.PathMatchPathPrefix)})
 		allErrs = append(allErrs, valErr)
 	}
 
 	if err := validator.ValidatePathInPrefixMatch(*path.Value); err != nil {
-		valErr := field.Invalid(fieldPath, *path.Value, err.Error())
+		valErr := field.Invalid(fieldPath.Child("value"), *path.Value, err.Error())
 		allErrs = append(allErrs, valErr)
 	}
 

--- a/internal/state/graph/httproute_test.go
+++ b/internal/state/graph/httproute_test.go
@@ -520,7 +520,7 @@ func TestBuildRoute(t *testing.T) {
 				},
 				Conditions: []conditions.Condition{
 					conditions.NewRouteUnsupportedValue(
-						`All rules are invalid: spec.rules[0].matches[0].path: Invalid value: "/invalid": invalid path`,
+						`All rules are invalid: spec.rules[0].matches[0].path.value: Invalid value: "/invalid": invalid path`,
 					),
 				},
 				Rules: []Rule{
@@ -581,7 +581,7 @@ func TestBuildRoute(t *testing.T) {
 				Conditions: []conditions.Condition{
 					conditions.NewTODO(
 						`Some rules are invalid: ` +
-							`[spec.rules[0].matches[0].path: Invalid value: "/invalid": invalid path, ` +
+							`[spec.rules[0].matches[0].path.value: Invalid value: "/invalid": invalid path, ` +
 							`spec.rules[1].filters[0].requestRedirect.hostname: Invalid value: ` +
 							`"invalid.example.com": invalid hostname]`,
 					),


### PR DESCRIPTION
Fix field path in error message for HTTPRoute path validation

Bug was introduced in https://github.com/nginxinc/nginx-kubernetes-gateway/commit/52fab05f8455ad9d9c0f08a11c0dd6e992b5a797

Before:
```
 [spec.rules[0].matches[0].path: Unsupported value: "RegularExpression": supported values: "PathPrefix", spec.rules[0].matches[0].path: Invalid value: "/$coffee": cannot contain $]
```

After
```
 [spec.rules[0].matches[0].path.type: Unsupported value: "RegularExpression": supported values: "PathPrefix", spec.rules[0].matches[0].path.value: Invalid value: "/$coffee": cannot contain $]
```