### PR TITLE
Fix whitespace in nginx templates

### DIFF
--- a/internal/nginx/config/servers_template.go
+++ b/internal/nginx/config/servers_template.go
@@ -1,23 +1,23 @@
 package config
 
 var serversTemplateText = `
-{{ range $s := . }}
-	{{ if $s.IsDefaultSSL }}
+{{ range $s := . -}}
+	{{ if $s.IsDefaultSSL -}}
 server {
 	listen 443 ssl default_server;
 
 	ssl_reject_handshake on;
 }
-	{{ else if $s.IsDefaultHTTP }}
+	{{- else if $s.IsDefaultHTTP }}
 server {
 	listen 80 default_server;
 
 	default_type text/html;
 	return 404;
 }
-	{{ else }}
+	{{- else }}
 server {
-		{{ if $s.SSL }}
+		{{- if $s.SSL }}
 	listen 443 ssl;
 	ssl_certificate {{ $s.SSL.Certificate }};
 	ssl_certificate_key {{ $s.SSL.CertificateKey }};
@@ -25,33 +25,33 @@ server {
 	if ($ssl_server_name != $host) {
 		return 421;
 	}
-		{{ end }}
+		{{- end }}
 
 	server_name {{ $s.ServerName }};
 
 		{{ range $l := $s.Locations }}
 	location {{ $l.Path }} {
-		{{ if $l.Internal }}
+		{{ if $l.Internal -}}
 		internal;
 		{{ end }}
 
-		{{ if $l.Return }}
+		{{- if $l.Return -}}
 		return {{ $l.Return.Code }} "{{ $l.Return.Body }}";
 		{{ end }}
 
-		{{ if $l.HTTPMatchVar }}
+		{{- if $l.HTTPMatchVar -}}
 		set $http_matches {{ $l.HTTPMatchVar | printf "%q" }};
 		js_content httpmatches.redirect;
 		{{ end }}
 
-		{{ if $l.ProxyPass }}
+		{{- if $l.ProxyPass -}}
 		proxy_set_header Host $host;
 		proxy_pass {{ $l.ProxyPass }}$request_uri;
-		{{ end }}
+		{{- end }}
 	}
 		{{ end }}
 }
-	{{ end }}
+	{{- end }}
 {{ end }}
 server {
     listen unix:/var/lib/nginx/nginx-502-server.sock;

--- a/internal/nginx/config/split_clients_template.go
+++ b/internal/nginx/config/split_clients_template.go
@@ -3,12 +3,13 @@ package config
 var splitClientsTemplateText = `
 {{ range $sc := . }}
 split_clients $request_id ${{ $sc.VariableName }} {
-    {{ range $d := $sc.Distributions }}
-        {{ if eq $d.Percent "0.00" }}
+    {{- range $d := $sc.Distributions }}
+        {{- if eq $d.Percent "0.00" }}
     # {{ $d.Percent }}% {{ $d.Value }};
-        {{ else }}
+        {{- else }}
     {{ $d.Percent }}% {{ $d.Value }};
-        {{ end }}
-    {{ end }}
+        {{- end }}
+    {{- end }}
 }
-{{ end }}`
+{{ end }}
+`

--- a/internal/nginx/config/upstreams_template.go
+++ b/internal/nginx/config/upstreams_template.go
@@ -8,6 +8,7 @@ upstream {{ $u.Name }} {
     random two least_conn;
     {{ range $server := $u.Servers }} 
     server {{ $server.Address }};
-    {{ end }}
+    {{- end }}
 }
-{{ end }}`
+{{ end }}
+`


### PR DESCRIPTION
The nginx templates were hard to read due to excessive whitespacing in the templates. It's not perfect, but these changes should clean things up quite a bit.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
