### PR TITLE
Set upstream zone size to 512k

### DIFF
--- a/internal/nginx/config/upstreams_template.go
+++ b/internal/nginx/config/upstreams_template.go
@@ -1,7 +1,7 @@
 package config
 
 // FIXME(kate-osborn): Dynamically calculate upstream zone size based on the number of upstreams.
-// 512k will support up to 648 upstream servers. 
+// 512k will support up to 648 upstream servers.
 var upstreamsTemplateText = `
 {{ range $u := . }}
 upstream {{ $u.Name }} {

--- a/internal/nginx/config/upstreams_template.go
+++ b/internal/nginx/config/upstreams_template.go
@@ -1,6 +1,7 @@
 package config
 
 // FIXME(kate-osborn): Dynamically calculate upstream zone size based on the number of upstreams.
+// 512k will support up to 648 upstream servers. 
 var upstreamsTemplateText = `
 {{ range $u := . }}
 upstream {{ $u.Name }} {

--- a/internal/nginx/config/upstreams_template.go
+++ b/internal/nginx/config/upstreams_template.go
@@ -1,11 +1,11 @@
 package config
 
-// FIXME(kate-osborn): Add upstream zone size for each upstream.
-// This should be dynamically calculated based on the number of upstreams.
+// FIXME(kate-osborn): Dynamically calculate upstream zone size based on the number of upstreams.
 var upstreamsTemplateText = `
 {{ range $u := . }}
 upstream {{ $u.Name }} {
     random two least_conn;
+    zone {{ $u.Name }} 512k;
     {{ range $server := $u.Servers }} 
     server {{ $server.Address }};
     {{- end }}


### PR DESCRIPTION
Sets the upstream zone size for every upstream to 512k. This will support up to 648 upstream servers. 

Fixes #482 
