### PR TITLE
Allow empty sectionName in HTTPRoute parentRef

### DIFF
--- a/docs/gateway-api-compatibility.md
+++ b/docs/gateway-api-compatibility.md
@@ -79,7 +79,7 @@ Fields:
 
 Fields:
 * `spec`
-  * `parentRefs` - partially supported. `sectionName` must always be set. 
+  * `parentRefs` - partially supported. Port not supported.
   * `hostnames` - partially supported. Wildcard binding is not supported: a hostname like `example.com` will not bind to a listener with the hostname `*.example.com`. However, `example.com` will bind to a listener with the empty hostname.
   * `rules`
 	* `matches`

--- a/examples/advanced-routing/cafe-routes.yaml
+++ b/examples/advanced-routing/cafe-routes.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   parentRefs:
   - name: gateway
-    sectionName: http
   hostnames:
   - "cafe.example.com"
   rules:
@@ -40,7 +39,6 @@ metadata:
 spec:
   parentRefs:
   - name: gateway
-    sectionName: http
   hostnames:
   - "cafe.example.com"
   rules:

--- a/internal/nginx/config/servers.go
+++ b/internal/nginx/config/servers.go
@@ -144,6 +144,8 @@ func createLocations(pathRules []dataplane.PathRule, listenerPort int) []http.Lo
 		}
 
 		if len(matches) > 0 {
+			// FIXME(sberman): De-dupe matches and associated locations
+			// so we don't need nginx/njs to perform unnecessary matching.
 			b, err := json.Marshal(matches)
 			if err != nil {
 				// panic is safe here because we should never fail to marshal the match unless we constructed it incorrectly.

--- a/internal/state/dataplane/configuration.go
+++ b/internal/state/dataplane/configuration.go
@@ -230,7 +230,14 @@ func (hpr *hostPathRules) upsertListener(l *graph.Listener) {
 		}
 
 		for _, h := range hostnames {
-			hpr.listenersForHost[h] = l
+			if prevListener, exists := hpr.listenersForHost[h]; exists {
+				// override the previous listener if the new one has a more specific hostname
+				if hostnameMoreSpecific(l.Source.Hostname, prevListener.Source.Hostname) {
+					hpr.listenersForHost[h] = l
+				}
+			} else {
+				hpr.listenersForHost[h] = l
+			}
 
 			if _, exist := hpr.rulesPerHost[h]; !exist {
 				hpr.rulesPerHost[h] = make(map[pathAndType]PathRule)
@@ -319,7 +326,8 @@ func (hpr *hostPathRules) buildServers() []VirtualServer {
 
 	for _, l := range hpr.httpsListeners {
 		hostname := getListenerHostname(l.Source.Hostname)
-		// generate a 404 ssl server block for listeners with no routes or listeners with wildcard (match-all) routes
+		// Generate a 404 ssl server block for listeners with no routes or listeners with wildcard (match-all) routes.
+		// This server overrides the default ssl server.
 		// FIXME(kate-osborn): when we support regex hostnames (e.g. *.example.com)
 		// we will have to modify this check to catch regex hostnames.
 		if len(l.Routes) == 0 || hostname == wildcardHostname {
@@ -433,4 +441,36 @@ func convertPathType(pathType v1beta1.PathMatchType) PathType {
 	default:
 		panic(fmt.Sprintf("unsupported path type: %s", pathType))
 	}
+}
+
+// Returns true if host1 is more specific than host2 (using length).
+//
+// FIXME(sberman): Since the only caller of this function specifies listener hostnames that are both
+// bound to the same route hostname, this function assumes that host1 and host2 match, either
+// exactly or as a wildcard/substring.
+//
+// For example:
+// - *.example.com and foo.example.com (host2 wins)
+// - foo.example.com and "" (host1 wins)
+// Non-example:
+// - foo.example.com and bar.example.com (should not be given to this function)
+//
+// As we add regex support, we should put in the proper
+// validation and error handling for this function to ensure that the hostnames are actually matching,
+// to avoid the unintended inputs above for the invalid case.
+func hostnameMoreSpecific(host1, host2 *v1beta1.Hostname) bool {
+	var host1Str, host2Str string
+	if host1 == nil {
+		host1Str = ""
+	} else {
+		host1Str = string(*host1)
+	}
+
+	if host2 == nil {
+		host2Str = ""
+	} else {
+		host2Str = string(*host2)
+	}
+
+	return len(host1Str) >= len(host2Str)
 }

--- a/internal/state/dataplane/configuration.go
+++ b/internal/state/dataplane/configuration.go
@@ -447,10 +447,9 @@ func convertPathType(pathType v1beta1.PathMatchType) PathType {
 //
 // FIXME(sberman): Since the only caller of this function specifies listener hostnames that are both
 // bound to the same route hostname, this function assumes that host1 and host2 match, either
-// exactly or as a wildcard/substring.
+// exactly or as a substring.
 //
 // For example:
-// - *.example.com and foo.example.com (host2 wins)
 // - foo.example.com and "" (host1 wins)
 // Non-example:
 // - foo.example.com and bar.example.com (should not be given to this function)
@@ -460,15 +459,11 @@ func convertPathType(pathType v1beta1.PathMatchType) PathType {
 // to avoid the unintended inputs above for the invalid case.
 func listenerHostnameMoreSpecific(host1, host2 *v1beta1.Hostname) bool {
 	var host1Str, host2Str string
-	if host1 == nil {
-		host1Str = ""
-	} else {
+	if host1 != nil {
 		host1Str = string(*host1)
 	}
 
-	if host2 == nil {
-		host2Str = ""
-	} else {
+	if host2 != nil {
 		host2Str = string(*host2)
 	}
 

--- a/internal/state/dataplane/configuration.go
+++ b/internal/state/dataplane/configuration.go
@@ -232,7 +232,7 @@ func (hpr *hostPathRules) upsertListener(l *graph.Listener) {
 		for _, h := range hostnames {
 			if prevListener, exists := hpr.listenersForHost[h]; exists {
 				// override the previous listener if the new one has a more specific hostname
-				if hostnameMoreSpecific(l.Source.Hostname, prevListener.Source.Hostname) {
+				if listenerHostnameMoreSpecific(l.Source.Hostname, prevListener.Source.Hostname) {
 					hpr.listenersForHost[h] = l
 				}
 			} else {
@@ -443,7 +443,7 @@ func convertPathType(pathType v1beta1.PathMatchType) PathType {
 	}
 }
 
-// Returns true if host1 is more specific than host2 (using length).
+// listenerHostnameMoreSpecific returns true if host1 is more specific than host2 (using length).
 //
 // FIXME(sberman): Since the only caller of this function specifies listener hostnames that are both
 // bound to the same route hostname, this function assumes that host1 and host2 match, either
@@ -458,7 +458,7 @@ func convertPathType(pathType v1beta1.PathMatchType) PathType {
 // As we add regex support, we should put in the proper
 // validation and error handling for this function to ensure that the hostnames are actually matching,
 // to avoid the unintended inputs above for the invalid case.
-func hostnameMoreSpecific(host1, host2 *v1beta1.Hostname) bool {
+func listenerHostnameMoreSpecific(host1, host2 *v1beta1.Hostname) bool {
 	var host1Str, host2Str string
 	if host1 == nil {
 		host1Str = ""

--- a/internal/state/dataplane/configuration_test.go
+++ b/internal/state/dataplane/configuration_test.go
@@ -1749,6 +1749,6 @@ func TestHostnameMoreSpecific(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		g.Expect(hostnameMoreSpecific(tc.host1, tc.host2)).To(Equal(tc.host1Wins), tc.msg)
+		g.Expect(listenerHostnameMoreSpecific(tc.host1, tc.host2)).To(Equal(tc.host1Wins), tc.msg)
 	}
 }

--- a/internal/state/graph/httproute.go
+++ b/internal/state/graph/httproute.go
@@ -340,10 +340,10 @@ func bindRouteToListeners(r *Route, gw *Gateway) {
 			return true
 		}
 
-		var valid bool
+		var validListener bool
 		if getSectionName(routeRef.SectionName) == "" {
 			for _, l := range gw.Listeners {
-				valid = bind(l) || valid
+				validListener = bind(l) || validListener
 			}
 		} else {
 			l, exists := gw.Listeners[string(*routeRef.SectionName)]
@@ -354,9 +354,9 @@ func bindRouteToListeners(r *Route, gw *Gateway) {
 				continue
 			}
 
-			valid = bind(l)
+			validListener = bind(l)
 		}
-		if !valid {
+		if !validListener {
 			attachment.FailedCondition = conditions.NewRouteInvalidListener()
 			continue
 		}

--- a/internal/state/graph/httproute_test.go
+++ b/internal/state/graph/httproute_test.go
@@ -873,6 +873,29 @@ func TestBindRouteToListeners(t *testing.T) {
 			name: "section name is empty",
 		},
 		{
+			route: routeWithEmptySectionName,
+			gateway: &Gateway{
+				Source: gw,
+				Listeners: map[string]*Listener{
+					"listener-80-1": notValidListener,
+				},
+			},
+			expectedSectionNameRefs: []ParentRef{
+				{
+					Idx:     0,
+					Gateway: client.ObjectKeyFromObject(gw),
+					Attachment: &ParentRefAttachmentStatus{
+						Attached:        false,
+						FailedCondition: conditions.NewRouteInvalidListener(),
+					},
+				},
+			},
+			expectedGatewayListeners: map[string]*Listener{
+				"listener-80-1": notValidListener,
+			},
+			name: "empty section name with no valid listeners",
+		},
+		{
 			route: routeWithPort,
 			gateway: &Gateway{
 				Source: gw,

--- a/internal/state/graph/httproute_test.go
+++ b/internal/state/graph/httproute_test.go
@@ -827,15 +827,19 @@ func TestBindRouteToListeners(t *testing.T) {
 					Idx:     0,
 					Gateway: client.ObjectKeyFromObject(gw),
 					Attachment: &ParentRefAttachmentStatus{
-						Attached: false,
-						FailedCondition: conditions.NewRouteUnsupportedValue(
-							`spec.parentRefs[0].sectionName: Required value: cannot be empty`,
-						),
+						Attached: true,
 					},
 				},
 			},
 			expectedGatewayListeners: map[string]*Listener{
-				"listener-80-1": createListener(),
+				"listener-80-1": createModifiedListener(func(l *Listener) {
+					l.Routes = map[types.NamespacedName]*Route{
+						client.ObjectKeyFromObject(hr): routeWithMissingSectionName,
+					}
+					l.AcceptedHostnames = map[string]struct{}{
+						"foo.example.com": {},
+					}
+				}),
 			},
 			name: "section name is nil",
 		},
@@ -852,15 +856,19 @@ func TestBindRouteToListeners(t *testing.T) {
 					Idx:     0,
 					Gateway: client.ObjectKeyFromObject(gw),
 					Attachment: &ParentRefAttachmentStatus{
-						Attached: false,
-						FailedCondition: conditions.NewRouteUnsupportedValue(
-							`spec.parentRefs[0].sectionName: Required value: cannot be empty`,
-						),
+						Attached: true,
 					},
 				},
 			},
 			expectedGatewayListeners: map[string]*Listener{
-				"listener-80-1": createListener(),
+				"listener-80-1": createModifiedListener(func(l *Listener) {
+					l.Routes = map[types.NamespacedName]*Route{
+						client.ObjectKeyFromObject(hr): routeWithEmptySectionName,
+					}
+					l.AcceptedHostnames = map[string]struct{}{
+						"foo.example.com": {},
+					}
+				}),
 			},
 			name: "section name is empty",
 		},


### PR DESCRIPTION
Support for empty sectionName in HTTPRoute parentRef. This will bind the route to all listeners with matching hostnames.

If multiple listeners match, we'll choose the most specific one (mainly for TLS case to ensure proper certs are used). Either way, we should end up with a single nginx server for the hostname. We could end up with duplicate match rules if multiple listeners match, but nginx/njs will send traffic properly. At some point we'll need to figure out how to de-dupe these.

Closes #479

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
