### PR TITLE
Set Accepted condition type on Gateway status

### DIFF
--- a/docs/gateway-api-compatibility.md
+++ b/docs/gateway-api-compatibility.md
@@ -71,7 +71,13 @@ Fields:
 	* `name` - supported.
 	* `supportedKinds` - not supported.
 	* `attachedRoutes` - supported.
-	* `conditions` - partially supported.
+	* `conditions` - Supported (Condition/Status/Reason):
+      * `Accepted/True/Accepted`
+      * `Accepted/True/ListenersNotValid`
+      * `Accepted/False/Invalid`
+      * `Accepted/False/ListenersNotValid`
+      * `Accepted/False/UnsupportedValue`: Custom reason for when a value of a field in a Gateway is invalid or not supported.
+      * `Accepted/False/GatewayConflict`: Custom reason for when the Gateway is ignored due to a conflicting Gateway. NKG only supports a single Gateway.
 
 ### HTTPRoute
 

--- a/internal/state/change_processor_test.go
+++ b/internal/state/change_processor_test.go
@@ -293,8 +293,8 @@ var _ = Describe("ChangeProcessor", func() {
 
 							expectedConf := dataplane.Configuration{}
 							expectedStatuses := state.Statuses{
-								IgnoredGatewayStatuses: map[types.NamespacedName]state.IgnoredGatewayStatus{},
-								HTTPRouteStatuses:      map[types.NamespacedName]state.HTTPRouteStatus{},
+								GatewayStatuses:   state.GatewayStatuses{},
+								HTTPRouteStatuses: state.HTTPRouteStatuses{},
 							}
 
 							changed, conf, statuses := processor.Process(context.TODO())
@@ -310,30 +310,15 @@ var _ = Describe("ChangeProcessor", func() {
 
 						expectedConf := dataplane.Configuration{}
 						expectedStatuses := state.Statuses{
-							GatewayStatus: &state.GatewayStatus{
-								NsName:             types.NamespacedName{Namespace: "test", Name: "gateway-1"},
-								ObservedGeneration: gw1.Generation,
-								ListenerStatuses: map[string]state.ListenerStatus{
-									"listener-80-1": {
-										AttachedRoutes: 0,
-										Conditions: []conditions.Condition{
-											conditions.NewListenerResolvedRefs(),
-											conditions.NewListenerNoConflicts(),
-											conditions.NewListenerNoValidGatewayClass("GatewayClass doesn't exist"),
-										},
+							GatewayStatuses: state.GatewayStatuses{
+								{Namespace: "test", Name: "gateway-1"}: {
+									Conditions: []conditions.Condition{
+										conditions.NewGatewayInvalid("GatewayClass doesn't exist"),
 									},
-									"listener-443-1": {
-										AttachedRoutes: 0,
-										Conditions: []conditions.Condition{
-											conditions.NewListenerResolvedRefs(),
-											conditions.NewListenerNoConflicts(),
-											conditions.NewListenerNoValidGatewayClass("GatewayClass doesn't exist"),
-										},
-									},
+									ObservedGeneration: gw1.Generation,
 								},
 							},
-							IgnoredGatewayStatuses: map[types.NamespacedName]state.IgnoredGatewayStatus{},
-							HTTPRouteStatuses: map[types.NamespacedName]state.HTTPRouteStatus{
+							HTTPRouteStatuses: state.HTTPRouteStatuses{
 								{Namespace: "test", Name: "hr-1"}: {
 									ObservedGeneration: hr1.Generation,
 									ParentStatuses: []state.ParentStatus{
@@ -341,16 +326,16 @@ var _ = Describe("ChangeProcessor", func() {
 											GatewayNsName: client.ObjectKeyFromObject(gw1),
 											SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-80-1"),
 											Conditions: []conditions.Condition{
-												conditions.NewRouteInvalidListener(),
 												conditions.NewRouteResolvedRefs(),
+												conditions.NewRouteInvalidGateway(),
 											},
 										},
 										{
 											GatewayNsName: client.ObjectKeyFromObject(gw1),
 											SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-443-1"),
 											Conditions: []conditions.Condition{
-												conditions.NewRouteInvalidListener(),
 												conditions.NewRouteResolvedRefs(),
+												conditions.NewRouteInvalidGateway(),
 											},
 										},
 									},
@@ -427,22 +412,23 @@ var _ = Describe("ChangeProcessor", func() {
 							ObservedGeneration: gc.Generation,
 							Conditions:         conditions.NewDefaultGatewayClassConditions(),
 						},
-						GatewayStatus: &state.GatewayStatus{
-							NsName:             types.NamespacedName{Namespace: "test", Name: "gateway-1"},
-							ObservedGeneration: gw1.Generation,
-							ListenerStatuses: map[string]state.ListenerStatus{
-								"listener-80-1": {
-									AttachedRoutes: 1,
-									Conditions:     conditions.NewDefaultListenerConditions(),
-								},
-								"listener-443-1": {
-									AttachedRoutes: 1,
-									Conditions:     conditions.NewDefaultListenerConditions(),
+						GatewayStatuses: state.GatewayStatuses{
+							{Namespace: "test", Name: "gateway-1"}: {
+								Conditions:         conditions.NewDefaultGatewayConditions(),
+								ObservedGeneration: gw1.Generation,
+								ListenerStatuses: map[string]state.ListenerStatus{
+									"listener-80-1": {
+										AttachedRoutes: 1,
+										Conditions:     conditions.NewDefaultListenerConditions(),
+									},
+									"listener-443-1": {
+										AttachedRoutes: 1,
+										Conditions:     conditions.NewDefaultListenerConditions(),
+									},
 								},
 							},
 						},
-						IgnoredGatewayStatuses: map[types.NamespacedName]state.IgnoredGatewayStatus{},
-						HTTPRouteStatuses: map[types.NamespacedName]state.HTTPRouteStatus{
+						HTTPRouteStatuses: state.HTTPRouteStatuses{
 							{Namespace: "test", Name: "hr-1"}: {
 								ObservedGeneration: hr1.Generation,
 								ParentStatuses: []state.ParentStatus{
@@ -540,22 +526,23 @@ var _ = Describe("ChangeProcessor", func() {
 							ObservedGeneration: gc.Generation,
 							Conditions:         conditions.NewDefaultGatewayClassConditions(),
 						},
-						GatewayStatus: &state.GatewayStatus{
-							NsName:             types.NamespacedName{Namespace: "test", Name: "gateway-1"},
-							ObservedGeneration: gw1.Generation,
-							ListenerStatuses: map[string]state.ListenerStatus{
-								"listener-80-1": {
-									AttachedRoutes: 1,
-									Conditions:     conditions.NewDefaultListenerConditions(),
-								},
-								"listener-443-1": {
-									AttachedRoutes: 1,
-									Conditions:     conditions.NewDefaultListenerConditions(),
+						GatewayStatuses: state.GatewayStatuses{
+							{Namespace: "test", Name: "gateway-1"}: {
+								Conditions:         conditions.NewDefaultGatewayConditions(),
+								ObservedGeneration: gw1.Generation,
+								ListenerStatuses: map[string]state.ListenerStatus{
+									"listener-80-1": {
+										AttachedRoutes: 1,
+										Conditions:     conditions.NewDefaultListenerConditions(),
+									},
+									"listener-443-1": {
+										AttachedRoutes: 1,
+										Conditions:     conditions.NewDefaultListenerConditions(),
+									},
 								},
 							},
 						},
-						IgnoredGatewayStatuses: map[types.NamespacedName]state.IgnoredGatewayStatus{},
-						HTTPRouteStatuses: map[types.NamespacedName]state.HTTPRouteStatus{
+						HTTPRouteStatuses: state.HTTPRouteStatuses{
 							{Namespace: "test", Name: "hr-1"}: {
 								ObservedGeneration: hr1Updated.Generation,
 								ParentStatuses: []state.ParentStatus{
@@ -654,22 +641,23 @@ var _ = Describe("ChangeProcessor", func() {
 							ObservedGeneration: gc.Generation,
 							Conditions:         conditions.NewDefaultGatewayClassConditions(),
 						},
-						GatewayStatus: &state.GatewayStatus{
-							NsName:             types.NamespacedName{Namespace: "test", Name: "gateway-1"},
-							ObservedGeneration: gw1Updated.Generation,
-							ListenerStatuses: map[string]state.ListenerStatus{
-								"listener-80-1": {
-									AttachedRoutes: 1,
-									Conditions:     conditions.NewDefaultListenerConditions(),
-								},
-								"listener-443-1": {
-									AttachedRoutes: 1,
-									Conditions:     conditions.NewDefaultListenerConditions(),
+						GatewayStatuses: state.GatewayStatuses{
+							{Namespace: "test", Name: "gateway-1"}: {
+								Conditions:         conditions.NewDefaultGatewayConditions(),
+								ObservedGeneration: gw1Updated.Generation,
+								ListenerStatuses: map[string]state.ListenerStatus{
+									"listener-80-1": {
+										AttachedRoutes: 1,
+										Conditions:     conditions.NewDefaultListenerConditions(),
+									},
+									"listener-443-1": {
+										AttachedRoutes: 1,
+										Conditions:     conditions.NewDefaultListenerConditions(),
+									},
 								},
 							},
 						},
-						IgnoredGatewayStatuses: map[types.NamespacedName]state.IgnoredGatewayStatus{},
-						HTTPRouteStatuses: map[types.NamespacedName]state.HTTPRouteStatus{
+						HTTPRouteStatuses: state.HTTPRouteStatuses{
 							{Namespace: "test", Name: "hr-1"}: {
 								ObservedGeneration: hr1Updated.Generation,
 								ParentStatuses: []state.ParentStatus{
@@ -767,22 +755,23 @@ var _ = Describe("ChangeProcessor", func() {
 							ObservedGeneration: gcUpdated.Generation,
 							Conditions:         conditions.NewDefaultGatewayClassConditions(),
 						},
-						GatewayStatus: &state.GatewayStatus{
-							NsName:             types.NamespacedName{Namespace: "test", Name: "gateway-1"},
-							ObservedGeneration: gw1Updated.Generation,
-							ListenerStatuses: map[string]state.ListenerStatus{
-								"listener-80-1": {
-									AttachedRoutes: 1,
-									Conditions:     conditions.NewDefaultListenerConditions(),
-								},
-								"listener-443-1": {
-									AttachedRoutes: 1,
-									Conditions:     conditions.NewDefaultListenerConditions(),
+						GatewayStatuses: state.GatewayStatuses{
+							{Namespace: "test", Name: "gateway-1"}: {
+								Conditions:         conditions.NewDefaultGatewayConditions(),
+								ObservedGeneration: gw1Updated.Generation,
+								ListenerStatuses: map[string]state.ListenerStatus{
+									"listener-80-1": {
+										AttachedRoutes: 1,
+										Conditions:     conditions.NewDefaultListenerConditions(),
+									},
+									"listener-443-1": {
+										AttachedRoutes: 1,
+										Conditions:     conditions.NewDefaultListenerConditions(),
+									},
 								},
 							},
 						},
-						IgnoredGatewayStatuses: map[types.NamespacedName]state.IgnoredGatewayStatus{},
-						HTTPRouteStatuses: map[types.NamespacedName]state.HTTPRouteStatus{
+						HTTPRouteStatuses: state.HTTPRouteStatuses{
 							{Namespace: "test", Name: "hr-1"}: {
 								ObservedGeneration: hr1Updated.Generation,
 								ParentStatuses: []state.ParentStatus{
@@ -879,26 +868,27 @@ var _ = Describe("ChangeProcessor", func() {
 							ObservedGeneration: gcUpdated.Generation,
 							Conditions:         conditions.NewDefaultGatewayClassConditions(),
 						},
-						GatewayStatus: &state.GatewayStatus{
-							NsName:             types.NamespacedName{Namespace: "test", Name: "gateway-1"},
-							ObservedGeneration: gw1Updated.Generation,
-							ListenerStatuses: map[string]state.ListenerStatus{
-								"listener-80-1": {
-									AttachedRoutes: 1,
-									Conditions:     conditions.NewDefaultListenerConditions(),
-								},
-								"listener-443-1": {
-									AttachedRoutes: 1,
-									Conditions:     conditions.NewDefaultListenerConditions(),
+						GatewayStatuses: state.GatewayStatuses{
+							{Namespace: "test", Name: "gateway-1"}: {
+								Conditions:         conditions.NewDefaultGatewayConditions(),
+								ObservedGeneration: gw1Updated.Generation,
+								ListenerStatuses: map[string]state.ListenerStatus{
+									"listener-80-1": {
+										AttachedRoutes: 1,
+										Conditions:     conditions.NewDefaultListenerConditions(),
+									},
+									"listener-443-1": {
+										AttachedRoutes: 1,
+										Conditions:     conditions.NewDefaultListenerConditions(),
+									},
 								},
 							},
-						},
-						IgnoredGatewayStatuses: map[types.NamespacedName]state.IgnoredGatewayStatus{
 							{Namespace: "test", Name: "gateway-2"}: {
+								Conditions:         []conditions.Condition{conditions.NewGatewayConflict()},
 								ObservedGeneration: gw2.Generation,
 							},
 						},
-						HTTPRouteStatuses: map[types.NamespacedName]state.HTTPRouteStatus{
+						HTTPRouteStatuses: state.HTTPRouteStatuses{
 							{Namespace: "test", Name: "hr-1"}: {
 								ObservedGeneration: hr1Updated.Generation,
 								ParentStatuses: []state.ParentStatus{
@@ -984,26 +974,27 @@ var _ = Describe("ChangeProcessor", func() {
 							ObservedGeneration: gcUpdated.Generation,
 							Conditions:         conditions.NewDefaultGatewayClassConditions(),
 						},
-						GatewayStatus: &state.GatewayStatus{
-							NsName:             types.NamespacedName{Namespace: "test", Name: "gateway-1"},
-							ObservedGeneration: gw1Updated.Generation,
-							ListenerStatuses: map[string]state.ListenerStatus{
-								"listener-80-1": {
-									AttachedRoutes: 1,
-									Conditions:     conditions.NewDefaultListenerConditions(),
-								},
-								"listener-443-1": {
-									AttachedRoutes: 1,
-									Conditions:     conditions.NewDefaultListenerConditions(),
+						GatewayStatuses: state.GatewayStatuses{
+							{Namespace: "test", Name: "gateway-1"}: {
+								Conditions:         conditions.NewDefaultGatewayConditions(),
+								ObservedGeneration: gw1Updated.Generation,
+								ListenerStatuses: map[string]state.ListenerStatus{
+									"listener-80-1": {
+										AttachedRoutes: 1,
+										Conditions:     conditions.NewDefaultListenerConditions(),
+									},
+									"listener-443-1": {
+										AttachedRoutes: 1,
+										Conditions:     conditions.NewDefaultListenerConditions(),
+									},
 								},
 							},
-						},
-						IgnoredGatewayStatuses: map[types.NamespacedName]state.IgnoredGatewayStatus{
 							{Namespace: "test", Name: "gateway-2"}: {
 								ObservedGeneration: gw2.Generation,
+								Conditions:         []conditions.Condition{conditions.NewGatewayConflict()},
 							},
 						},
-						HTTPRouteStatuses: map[types.NamespacedName]state.HTTPRouteStatus{
+						HTTPRouteStatuses: state.HTTPRouteStatuses{
 							{Namespace: "test", Name: "hr-1"}: {
 								ObservedGeneration: hr1Updated.Generation,
 								ParentStatuses: []state.ParentStatus{
@@ -1113,22 +1104,23 @@ var _ = Describe("ChangeProcessor", func() {
 							ObservedGeneration: gcUpdated.Generation,
 							Conditions:         conditions.NewDefaultGatewayClassConditions(),
 						},
-						GatewayStatus: &state.GatewayStatus{
-							NsName:             types.NamespacedName{Namespace: "test", Name: "gateway-2"},
-							ObservedGeneration: gw2.Generation,
-							ListenerStatuses: map[string]state.ListenerStatus{
-								"listener-80-1": {
-									AttachedRoutes: 1,
-									Conditions:     conditions.NewDefaultListenerConditions(),
-								},
-								"listener-443-1": {
-									AttachedRoutes: 1,
-									Conditions:     conditions.NewDefaultListenerConditions(),
+						GatewayStatuses: state.GatewayStatuses{
+							{Namespace: "test", Name: "gateway-2"}: {
+								Conditions:         conditions.NewDefaultGatewayConditions(),
+								ObservedGeneration: gw2.Generation,
+								ListenerStatuses: map[string]state.ListenerStatus{
+									"listener-80-1": {
+										AttachedRoutes: 1,
+										Conditions:     conditions.NewDefaultListenerConditions(),
+									},
+									"listener-443-1": {
+										AttachedRoutes: 1,
+										Conditions:     conditions.NewDefaultListenerConditions(),
+									},
 								},
 							},
 						},
-						IgnoredGatewayStatuses: map[types.NamespacedName]state.IgnoredGatewayStatus{},
-						HTTPRouteStatuses: map[types.NamespacedName]state.HTTPRouteStatus{
+						HTTPRouteStatuses: state.HTTPRouteStatuses{
 							{Namespace: "test", Name: "hr-2"}: {
 								ObservedGeneration: hr2.Generation,
 								ParentStatuses: []state.ParentStatus{
@@ -1181,22 +1173,23 @@ var _ = Describe("ChangeProcessor", func() {
 							ObservedGeneration: gcUpdated.Generation,
 							Conditions:         conditions.NewDefaultGatewayClassConditions(),
 						},
-						GatewayStatus: &state.GatewayStatus{
-							NsName:             types.NamespacedName{Namespace: "test", Name: "gateway-2"},
-							ObservedGeneration: gw2.Generation,
-							ListenerStatuses: map[string]state.ListenerStatus{
-								"listener-80-1": {
-									AttachedRoutes: 0,
-									Conditions:     conditions.NewDefaultListenerConditions(),
-								},
-								"listener-443-1": {
-									AttachedRoutes: 0,
-									Conditions:     conditions.NewDefaultListenerConditions(),
+						GatewayStatuses: state.GatewayStatuses{
+							{Namespace: "test", Name: "gateway-2"}: {
+								Conditions:         conditions.NewDefaultGatewayConditions(),
+								ObservedGeneration: gw2.Generation,
+								ListenerStatuses: map[string]state.ListenerStatus{
+									"listener-80-1": {
+										AttachedRoutes: 0,
+										Conditions:     conditions.NewDefaultListenerConditions(),
+									},
+									"listener-443-1": {
+										AttachedRoutes: 0,
+										Conditions:     conditions.NewDefaultListenerConditions(),
+									},
 								},
 							},
 						},
-						IgnoredGatewayStatuses: map[types.NamespacedName]state.IgnoredGatewayStatus{},
-						HTTPRouteStatuses:      map[types.NamespacedName]state.HTTPRouteStatus{},
+						HTTPRouteStatuses: state.HTTPRouteStatuses{},
 					}
 
 					changed, conf, statuses := processor.Process(context.TODO())
@@ -1214,30 +1207,15 @@ var _ = Describe("ChangeProcessor", func() {
 
 					expectedConf := dataplane.Configuration{}
 					expectedStatuses := state.Statuses{
-						GatewayStatus: &state.GatewayStatus{
-							NsName:             types.NamespacedName{Namespace: "test", Name: "gateway-2"},
-							ObservedGeneration: gw2.Generation,
-							ListenerStatuses: map[string]state.ListenerStatus{
-								"listener-80-1": {
-									AttachedRoutes: 0,
-									Conditions: []conditions.Condition{
-										conditions.NewListenerResolvedRefs(),
-										conditions.NewListenerNoConflicts(),
-										conditions.NewListenerNoValidGatewayClass("GatewayClass doesn't exist"),
-									},
+						GatewayStatuses: state.GatewayStatuses{
+							{Namespace: "test", Name: "gateway-2"}: {
+								Conditions: []conditions.Condition{
+									conditions.NewGatewayInvalid("GatewayClass doesn't exist"),
 								},
-								"listener-443-1": {
-									AttachedRoutes: 0,
-									Conditions: []conditions.Condition{
-										conditions.NewListenerResolvedRefs(),
-										conditions.NewListenerNoConflicts(),
-										conditions.NewListenerNoValidGatewayClass("GatewayClass doesn't exist"),
-									},
-								},
+								ObservedGeneration: gw2.Generation,
 							},
 						},
-						IgnoredGatewayStatuses: map[types.NamespacedName]state.IgnoredGatewayStatus{},
-						HTTPRouteStatuses:      map[types.NamespacedName]state.HTTPRouteStatus{},
+						HTTPRouteStatuses: state.HTTPRouteStatuses{},
 					}
 
 					changed, conf, statuses := processor.Process(context.TODO())
@@ -1255,8 +1233,8 @@ var _ = Describe("ChangeProcessor", func() {
 
 					expectedConf := dataplane.Configuration{}
 					expectedStatuses := state.Statuses{
-						IgnoredGatewayStatuses: map[types.NamespacedName]state.IgnoredGatewayStatus{},
-						HTTPRouteStatuses:      map[types.NamespacedName]state.HTTPRouteStatus{},
+						GatewayStatuses:   state.GatewayStatuses{},
+						HTTPRouteStatuses: state.HTTPRouteStatuses{},
 					}
 
 					changed, conf, statuses := processor.Process(context.TODO())
@@ -1274,8 +1252,8 @@ var _ = Describe("ChangeProcessor", func() {
 
 					expectedConf := dataplane.Configuration{}
 					expectedStatuses := state.Statuses{
-						IgnoredGatewayStatuses: map[types.NamespacedName]state.IgnoredGatewayStatus{},
-						HTTPRouteStatuses:      map[types.NamespacedName]state.HTTPRouteStatus{},
+						GatewayStatuses:   state.GatewayStatuses{},
+						HTTPRouteStatuses: state.HTTPRouteStatuses{},
 					}
 
 					changed, conf, statuses := processor.Process(context.TODO())
@@ -2056,8 +2034,8 @@ var _ = Describe("ChangeProcessor", func() {
 					ObservedGeneration: gc.Generation,
 					Conditions:         conditions.NewDefaultGatewayClassConditions(),
 				},
-				IgnoredGatewayStatuses: map[types.NamespacedName]state.IgnoredGatewayStatus{},
-				HTTPRouteStatuses:      map[types.NamespacedName]state.HTTPRouteStatus{},
+				GatewayStatuses:   state.GatewayStatuses{},
+				HTTPRouteStatuses: state.HTTPRouteStatuses{},
 			}
 
 			changed, conf, statuses := processor.Process(context.TODO())
@@ -2128,18 +2106,19 @@ var _ = Describe("ChangeProcessor", func() {
 						ObservedGeneration: gc.Generation,
 						Conditions:         conditions.NewDefaultGatewayClassConditions(),
 					},
-					GatewayStatus: &state.GatewayStatus{
-						NsName:             gwNsName,
-						ObservedGeneration: gw.Generation,
-						ListenerStatuses: map[string]state.ListenerStatus{
-							"listener-80-1": {
-								AttachedRoutes: 1,
-								Conditions:     conditions.NewDefaultListenerConditions(),
+					GatewayStatuses: state.GatewayStatuses{
+						gwNsName: {
+							Conditions:         conditions.NewDefaultGatewayConditions(),
+							ObservedGeneration: gw.Generation,
+							ListenerStatuses: map[string]state.ListenerStatus{
+								"listener-80-1": {
+									AttachedRoutes: 1,
+									Conditions:     conditions.NewDefaultListenerConditions(),
+								},
 							},
 						},
 					},
-					IgnoredGatewayStatuses: map[types.NamespacedName]state.IgnoredGatewayStatus{},
-					HTTPRouteStatuses: map[types.NamespacedName]state.HTTPRouteStatus{
+					HTTPRouteStatuses: state.HTTPRouteStatuses{
 						hrNsName: {
 							ObservedGeneration: hr.Generation,
 							ParentStatuses: []state.ParentStatus{
@@ -2180,18 +2159,19 @@ var _ = Describe("ChangeProcessor", func() {
 						ObservedGeneration: gc.Generation,
 						Conditions:         conditions.NewDefaultGatewayClassConditions(),
 					},
-					GatewayStatus: &state.GatewayStatus{
-						NsName:             gwNsName,
-						ObservedGeneration: gw.Generation,
-						ListenerStatuses: map[string]state.ListenerStatus{
-							"listener-80-1": {
-								AttachedRoutes: 0,
-								Conditions:     conditions.NewDefaultListenerConditions(),
+					GatewayStatuses: state.GatewayStatuses{
+						gwNsName: {
+							Conditions:         conditions.NewDefaultGatewayConditions(),
+							ObservedGeneration: gw.Generation,
+							ListenerStatuses: map[string]state.ListenerStatus{
+								"listener-80-1": {
+									AttachedRoutes: 0,
+									Conditions:     conditions.NewDefaultListenerConditions(),
+								},
 							},
 						},
 					},
-					IgnoredGatewayStatuses: map[types.NamespacedName]state.IgnoredGatewayStatus{},
-					HTTPRouteStatuses:      map[types.NamespacedName]state.HTTPRouteStatus{},
+					HTTPRouteStatuses: state.HTTPRouteStatuses{},
 				}
 
 				changed, conf, statuses := processor.Process(context.TODO())
@@ -2215,8 +2195,8 @@ var _ = Describe("ChangeProcessor", func() {
 						ObservedGeneration: gc.Generation,
 						Conditions:         conditions.NewDefaultGatewayClassConditions(),
 					},
-					IgnoredGatewayStatuses: map[types.NamespacedName]state.IgnoredGatewayStatus{},
-					HTTPRouteStatuses:      map[types.NamespacedName]state.HTTPRouteStatus{},
+					GatewayStatuses:   state.GatewayStatuses{},
+					HTTPRouteStatuses: state.HTTPRouteStatuses{},
 				}
 
 				changed, conf, statuses := processor.Process(context.TODO())

--- a/internal/state/graph/gateway_test.go
+++ b/internal/state/graph/gateway_test.go
@@ -304,6 +304,7 @@ func TestBuildGateway(t *testing.T) {
 						AcceptedHostnames: map[string]struct{}{},
 					},
 				},
+				Valid: true,
 			},
 			name: "valid http listener",
 		},
@@ -321,6 +322,7 @@ func TestBuildGateway(t *testing.T) {
 						SecretPath:        secretPath,
 					},
 				},
+				Valid: true,
 			},
 			name: "valid https listener",
 		},
@@ -340,6 +342,7 @@ func TestBuildGateway(t *testing.T) {
 						},
 					},
 				},
+				Valid: true,
 			},
 			name: "invalid listener protocol",
 		},
@@ -359,6 +362,7 @@ func TestBuildGateway(t *testing.T) {
 						},
 					},
 				},
+				Valid: true,
 			},
 			name: "invalid http listener",
 		},
@@ -378,6 +382,7 @@ func TestBuildGateway(t *testing.T) {
 						},
 					},
 				},
+				Valid: true,
 			},
 			name: "invalid https listener",
 		},
@@ -402,6 +407,7 @@ func TestBuildGateway(t *testing.T) {
 						},
 					},
 				},
+				Valid: true,
 			},
 			name: "invalid hostnames",
 		},
@@ -421,6 +427,7 @@ func TestBuildGateway(t *testing.T) {
 						),
 					},
 				},
+				Valid: true,
 			},
 			name: "invalid https listener (secret does not exist)",
 		},
@@ -459,6 +466,7 @@ func TestBuildGateway(t *testing.T) {
 						SecretPath:        secretPath,
 					},
 				},
+				Valid: true,
 			},
 			name: "multiple valid http/https listeners",
 		},
@@ -501,6 +509,7 @@ func TestBuildGateway(t *testing.T) {
 						SecretPath:        "/etc/nginx/secrets/test_secret",
 					},
 				},
+				Valid: true,
 			},
 			name: "collisions",
 		},
@@ -514,26 +523,9 @@ func TestBuildGateway(t *testing.T) {
 			gatewayClass: validGC,
 			expected: &Gateway{
 				Source: getLastCreatedGetaway(),
-				Listeners: map[string]*Listener{
-					"listener-80-1": {
-						Source: listener801,
-						Valid:  false,
-						Conditions: []conditions.Condition{
-							conditions.NewListenerUnsupportedValue(
-								"spec.addresses: Forbidden: addresses are not supported",
-							),
-						},
-					},
-					"listener-443-1": {
-						Source:     listener4431,
-						Valid:      false,
-						SecretPath: "",
-						Conditions: []conditions.Condition{
-							conditions.NewListenerUnsupportedValue(
-								"spec.addresses: Forbidden: addresses are not supported",
-							),
-						},
-					},
+				Valid:  false,
+				Conditions: []conditions.Condition{
+					conditions.NewGatewayUnsupportedValue("spec.addresses: Forbidden: addresses are not supported"),
 				},
 			},
 			name: "gateway addresses are not supported",
@@ -544,35 +536,25 @@ func TestBuildGateway(t *testing.T) {
 			name:     "nil gateway",
 		},
 		{
-			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{listener801}}),
+			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{listener801, listener802}}),
 			gatewayClass: invalidGC,
 			expected: &Gateway{
 				Source: getLastCreatedGetaway(),
-				Listeners: map[string]*Listener{
-					"listener-80-1": {
-						Source: listener801,
-						Valid:  false,
-						Conditions: []conditions.Condition{
-							conditions.NewListenerNoValidGatewayClass("GatewayClass is invalid"),
-						},
-					},
+				Valid:  false,
+				Conditions: []conditions.Condition{
+					conditions.NewGatewayInvalid("GatewayClass is invalid"),
 				},
 			},
 			name: "invalid gatewayclass",
 		},
 		{
-			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{listener801}}),
+			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{listener801, listener802}}),
 			gatewayClass: nil,
 			expected: &Gateway{
 				Source: getLastCreatedGetaway(),
-				Listeners: map[string]*Listener{
-					"listener-80-1": {
-						Source: listener801,
-						Valid:  false,
-						Conditions: []conditions.Condition{
-							conditions.NewListenerNoValidGatewayClass("GatewayClass doesn't exist"),
-						},
-					},
+				Valid:  false,
+				Conditions: []conditions.Condition{
+					conditions.NewGatewayInvalid("GatewayClass doesn't exist"),
 				},
 			},
 			name: "nil gatewayclass",

--- a/internal/state/graph/graph_test.go
+++ b/internal/state/graph/graph_test.go
@@ -234,6 +234,7 @@ func TestBuildGraph(t *testing.T) {
 						SecretPath: secretPath,
 					},
 				},
+				Valid: true,
 			},
 			IgnoredGateways: map[types.NamespacedName]*v1beta1.Gateway{
 				{Namespace: "test", Name: "gateway-2"}: gw2,

--- a/internal/state/graph/httproute.go
+++ b/internal/state/graph/httproute.go
@@ -281,7 +281,14 @@ func bindRouteToListeners(r *Route, gw *Gateway) {
 			continue
 		}
 
-		// Case 3 - winning Gateway
+		// Case 3: Attachment is not possible because Gateway is invalid
+
+		if !gw.Valid {
+			attachment.FailedCondition = conditions.NewRouteInvalidGateway()
+			continue
+		}
+
+		// Case 4 - winning Gateway
 
 		// Find a listener
 

--- a/internal/state/graph/httproute_test.go
+++ b/internal/state/graph/httproute_test.go
@@ -688,6 +688,7 @@ func TestBindRouteToListeners(t *testing.T) {
 			route: createNormalRoute(),
 			gateway: &Gateway{
 				Source: gw,
+				Valid:  true,
 				Listeners: map[string]*Listener{
 					"listener-80-1": createListener(),
 				},
@@ -717,6 +718,7 @@ func TestBindRouteToListeners(t *testing.T) {
 			route: routeWithMissingSectionName,
 			gateway: &Gateway{
 				Source: gw,
+				Valid:  true,
 				Listeners: map[string]*Listener{
 					"listener-80-1": createListener(),
 				},
@@ -746,6 +748,7 @@ func TestBindRouteToListeners(t *testing.T) {
 			route: routeWithEmptySectionName,
 			gateway: &Gateway{
 				Source: gw,
+				Valid:  true,
 				Listeners: map[string]*Listener{
 					"listener-80-1": createListener(),
 				},
@@ -775,6 +778,7 @@ func TestBindRouteToListeners(t *testing.T) {
 			route: routeWithEmptySectionName,
 			gateway: &Gateway{
 				Source: gw,
+				Valid:  true,
 				Listeners: map[string]*Listener{
 					"listener-80-1": notValidListener,
 				},
@@ -798,6 +802,7 @@ func TestBindRouteToListeners(t *testing.T) {
 			route: routeWithPort,
 			gateway: &Gateway{
 				Source: gw,
+				Valid:  true,
 				Listeners: map[string]*Listener{
 					"listener-80-1": createListener(),
 				},
@@ -823,6 +828,7 @@ func TestBindRouteToListeners(t *testing.T) {
 			route: routeWithNonExistingListener,
 			gateway: &Gateway{
 				Source: gw,
+				Valid:  true,
 				Listeners: map[string]*Listener{
 					"listener-80-1": createListener(),
 				},
@@ -846,6 +852,7 @@ func TestBindRouteToListeners(t *testing.T) {
 			route: createNormalRoute(),
 			gateway: &Gateway{
 				Source: gw,
+				Valid:  true,
 				Listeners: map[string]*Listener{
 					"listener-80-1": notValidListener,
 				},
@@ -869,6 +876,7 @@ func TestBindRouteToListeners(t *testing.T) {
 			route: createNormalRoute(),
 			gateway: &Gateway{
 				Source: gw,
+				Valid:  true,
 				Listeners: map[string]*Listener{
 					"listener-80-1": nonMatchingHostnameListener,
 				},
@@ -892,6 +900,7 @@ func TestBindRouteToListeners(t *testing.T) {
 			route: routeWithIgnoredGateway,
 			gateway: &Gateway{
 				Source: gw,
+				Valid:  true,
 				Listeners: map[string]*Listener{
 					"listener-80-1": createListener(),
 				},
@@ -915,6 +924,7 @@ func TestBindRouteToListeners(t *testing.T) {
 			route: notValidRoute,
 			gateway: &Gateway{
 				Source: gw,
+				Valid:  true,
 				Listeners: map[string]*Listener{
 					"listener-80-1": createListener(),
 				},
@@ -930,6 +940,30 @@ func TestBindRouteToListeners(t *testing.T) {
 				"listener-80-1": createListener(),
 			},
 			name: "route isn't valid",
+		},
+		{
+			route: createNormalRoute(),
+			gateway: &Gateway{
+				Source: gw,
+				Valid:  false,
+				Listeners: map[string]*Listener{
+					"listener-80-1": createListener(),
+				},
+			},
+			expectedSectionNameRefs: []ParentRef{
+				{
+					Idx:     0,
+					Gateway: client.ObjectKeyFromObject(gw),
+					Attachment: &ParentRefAttachmentStatus{
+						Attached:        false,
+						FailedCondition: conditions.NewRouteInvalidGateway(),
+					},
+				},
+			},
+			expectedGatewayListeners: map[string]*Listener{
+				"listener-80-1": createListener(),
+			},
+			name: "invalid gateway",
 		},
 	}
 

--- a/internal/status/conditions_test.go
+++ b/internal/status/conditions_test.go
@@ -11,16 +11,16 @@ import (
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state/conditions"
 )
 
-func CreateTestConditions() []conditions.Condition {
+func CreateTestConditions(condType string) []conditions.Condition {
 	return []conditions.Condition{
 		{
-			Type:    "Test",
+			Type:    condType,
 			Status:  metav1.ConditionTrue,
 			Reason:  "TestReason1",
 			Message: "Test message1",
 		},
 		{
-			Type:    "Test",
+			Type:    condType,
 			Status:  metav1.ConditionFalse,
 			Reason:  "TestReason2",
 			Message: "Test message2",
@@ -28,10 +28,14 @@ func CreateTestConditions() []conditions.Condition {
 	}
 }
 
-func CreateExpectedAPIConditions(observedGeneration int64, transitionTime metav1.Time) []metav1.Condition {
+func CreateExpectedAPIConditions(
+	condType string,
+	observedGeneration int64,
+	transitionTime metav1.Time,
+) []metav1.Condition {
 	return []metav1.Condition{
 		{
-			Type:               "Test",
+			Type:               condType,
 			Status:             metav1.ConditionTrue,
 			ObservedGeneration: observedGeneration,
 			LastTransitionTime: transitionTime,
@@ -39,7 +43,7 @@ func CreateExpectedAPIConditions(observedGeneration int64, transitionTime metav1
 			Message:            "Test message1",
 		},
 		{
-			Type:               "Test",
+			Type:               condType,
 			Status:             metav1.ConditionFalse,
 			ObservedGeneration: observedGeneration,
 			LastTransitionTime: transitionTime,
@@ -55,8 +59,8 @@ func TestConvertRouteConditions(t *testing.T) {
 	var generation int64 = 1
 	transitionTime := metav1.NewTime(time.Now())
 
-	expected := CreateExpectedAPIConditions(generation, transitionTime)
+	expected := CreateExpectedAPIConditions("Test", generation, transitionTime)
 
-	result := convertConditions(CreateTestConditions(), generation, transitionTime)
+	result := convertConditions(CreateTestConditions("Test"), generation, transitionTime)
 	g.Expect(helpers.Diff(expected, result)).To(BeEmpty())
 }

--- a/internal/status/gateway.go
+++ b/internal/status/gateway.go
@@ -51,5 +51,6 @@ func prepareGatewayStatus(
 	return v1beta1.GatewayStatus{
 		Listeners:  listenerStatuses,
 		Addresses:  []v1beta1.GatewayAddress{gwPodIP},
-		Conditions: convertConditions(gatewayStatus.Conditions, gatewayStatus.ObservedGeneration, transitionTime)}
+		Conditions: convertConditions(gatewayStatus.Conditions, gatewayStatus.ObservedGeneration, transitionTime),
+	}
 }

--- a/internal/status/gatewayclass_test.go
+++ b/internal/status/gatewayclass_test.go
@@ -17,10 +17,10 @@ func TestPrepareGatewayClassStatus(t *testing.T) {
 
 	status := state.GatewayClassStatus{
 		ObservedGeneration: 1,
-		Conditions:         CreateTestConditions(),
+		Conditions:         CreateTestConditions("Test"),
 	}
 	expected := v1beta1.GatewayClassStatus{
-		Conditions: CreateExpectedAPIConditions(1, transitionTime),
+		Conditions: CreateExpectedAPIConditions("Test", 1, transitionTime),
 	}
 
 	g := NewGomegaWithT(t)

--- a/internal/status/httproute_test.go
+++ b/internal/status/httproute_test.go
@@ -23,12 +23,12 @@ func TestPrepareHTTPRouteStatus(t *testing.T) {
 			{
 				GatewayNsName: gwNsName1,
 				SectionName:   helpers.GetPointer[v1beta1.SectionName]("http"),
-				Conditions:    CreateTestConditions(),
+				Conditions:    CreateTestConditions("Test"),
 			},
 			{
 				GatewayNsName: gwNsName2,
 				SectionName:   nil,
-				Conditions:    CreateTestConditions(),
+				Conditions:    CreateTestConditions("Test"),
 			},
 		},
 	}
@@ -46,7 +46,7 @@ func TestPrepareHTTPRouteStatus(t *testing.T) {
 						SectionName: helpers.GetPointer[v1beta1.SectionName]("http"),
 					},
 					ControllerName: v1beta1.GatewayController(gatewayCtlrName),
-					Conditions:     CreateExpectedAPIConditions(1, transitionTime),
+					Conditions:     CreateExpectedAPIConditions("Test", 1, transitionTime),
 				},
 				{
 					ParentRef: v1beta1.ParentReference{
@@ -55,7 +55,7 @@ func TestPrepareHTTPRouteStatus(t *testing.T) {
 						SectionName: nil,
 					},
 					ControllerName: v1beta1.GatewayController(gatewayCtlrName),
-					Conditions:     CreateExpectedAPIConditions(1, transitionTime),
+					Conditions:     CreateExpectedAPIConditions("Test", 1, transitionTime),
 				},
 			},
 		},

--- a/internal/status/updater.go
+++ b/internal/status/updater.go
@@ -100,23 +100,10 @@ func (upd *updaterImpl) Update(ctx context.Context, statuses state.Statuses) {
 		)
 	}
 
-	if statuses.GatewayStatus != nil {
-		upd.update(ctx, statuses.GatewayStatus.NsName, &v1beta1.Gateway{}, func(object client.Object) {
-			gw := object.(*v1beta1.Gateway)
-			gw.Status = prepareGatewayStatus(*statuses.GatewayStatus, upd.cfg.PodIP, upd.cfg.Clock.Now())
-		})
-	}
-
-	for nsname, gs := range statuses.IgnoredGatewayStatuses {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
-
+	for nsname, gs := range statuses.GatewayStatuses {
 		upd.update(ctx, nsname, &v1beta1.Gateway{}, func(object client.Object) {
 			gw := object.(*v1beta1.Gateway)
-			gw.Status = prepareIgnoredGatewayStatus(gs, upd.cfg.Clock.Now())
+			gw.Status = prepareGatewayStatus(gs, upd.cfg.PodIP, upd.cfg.Clock.Now())
 		})
 	}
 


### PR DESCRIPTION
Closes #368 

Sets Accepted condition type on Gateway status. Accepted can be `true/false` and the following reasons are used: `ListenersNotValid`, `Invalid`, `GatewayConflict`, and `Accepted`. 

The `Invalid` reason is used when the GatewayClass for the Gateway is missing or invalid. In this case, both the Gateway and all its listeners are considered invalid. No additional validation is performed for the listeners. The Gateway and its listeners will have the condition `Accepted/false/Invalid` set on their statuses. 

This PR also replaces the `ListenerUnsupportedAddress` Condition reason with the `ListenerUnsupportedValue` reason to be consistent with the rest of our unsupported fields. 
