### PR TITLE
Set gateway Pod IP as GatewayStatus address

### DIFF
--- a/cmd/gateway/gateway_suite_test.go
+++ b/cmd/gateway/gateway_suite_test.go
@@ -3,7 +3,7 @@ package main_test
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -33,17 +33,13 @@ var (
 	)
 
 	gatewayClassName = flag.String("gatewayclass", "", gatewayClassNameUsage)
+
+	// Environment variables
+	podIP = os.Getenv("POD_IP")
 )
 
 func main() {
 	flag.Parse()
-
-	logger := zap.New()
-	conf := config.Config{
-		GatewayCtlrName:  *gatewayCtlrName,
-		Logger:           logger,
-		GatewayClassName: *gatewayClassName,
-	}
 
 	MustValidateArguments(
 		flag.CommandLine,
@@ -51,10 +47,24 @@ func main() {
 		GatewayClassParam(),
 	)
 
+	if err := ValidatePodIP(podIP); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+	logger := zap.New()
+	conf := config.Config{
+		GatewayCtlrName:  *gatewayCtlrName,
+		Logger:           logger,
+		GatewayClassName: *gatewayClassName,
+		PodIP:            podIP,
+	}
+
 	logger.Info("Starting NGINX Kubernetes Gateway",
 		"version", version,
 		"commit", commit,
-		"date", date)
+		"date", date,
+	)
 
 	err := manager.Start(conf)
 	if err != nil {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"net"
 	"os"
 
 	flag "github.com/spf13/pflag"
@@ -38,6 +40,17 @@ var (
 	podIP = os.Getenv("POD_IP")
 )
 
+func validateIP(podIP string) error {
+	if podIP == "" {
+		return errors.New("IP address must be set")
+	}
+	if net.ParseIP(podIP) == nil {
+		return fmt.Errorf("%q must be a valid IP address", podIP)
+	}
+
+	return nil
+}
+
 func main() {
 	flag.Parse()
 
@@ -47,8 +60,8 @@ func main() {
 		GatewayClassParam(),
 	)
 
-	if err := ValidatePodIP(podIP); err != nil {
-		fmt.Println(err.Error())
+	if err := validateIP(podIP); err != nil {
+		fmt.Printf("error validating POD_IP environment variable: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -40,12 +40,12 @@ var (
 	podIP = os.Getenv("POD_IP")
 )
 
-func validateIP(podIP string) error {
-	if podIP == "" {
+func validateIP(ip string) error {
+	if ip == "" {
 		return errors.New("IP address must be set")
 	}
-	if net.ParseIP(podIP) == nil {
-		return fmt.Errorf("%q must be a valid IP address", podIP)
+	if net.ParseIP(ip) == nil {
+		return fmt.Errorf("%q must be a valid IP address", ip)
 	}
 
 	return nil

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -1,27 +1,47 @@
 package main
 
 import (
-	. "github.com/onsi/ginkgo/v2"
+	"testing"
+
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Main", func() {
-	type testCase struct {
+func TestValidateIP(t *testing.T) {
+	tests := []struct {
+		name      string
 		expSubMsg string
-		podIP     string
+		ip        string
 		expErr    bool
-	}
-	DescribeTable("should validate an IP address",
-		func(tc testCase) {
-			err := validateIP(tc.podIP)
-			if !tc.expErr {
-				Expect(err).ToNot(HaveOccurred())
-			} else {
-				Expect(err.Error()).To(ContainSubstring(tc.expSubMsg))
-			}
+	}{
+		{
+			name:      "var not set",
+			ip:        "",
+			expErr:    true,
+			expSubMsg: "must be set",
 		},
-		Entry("var not set", testCase{podIP: "", expErr: true, expSubMsg: "must be set"}),
-		Entry("var set to invalid value", testCase{podIP: "invalid", expErr: true, expSubMsg: "must be a valid"}),
-		Entry("var set to valid value", testCase{podIP: "1.2.3.4", expErr: false}),
-	) // should validate an IP address
-})
+		{
+			name:      "invalid ip address",
+			ip:        "invalid",
+			expErr:    true,
+			expSubMsg: "must be a valid",
+		},
+		{
+			name:   "valid ip address",
+			ip:     "1.2.3.4",
+			expErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			err := validateIP(tc.ip)
+			if !tc.expErr {
+				g.Expect(err).ToNot(HaveOccurred())
+			} else {
+				g.Expect(err.Error()).To(ContainSubstring(tc.expSubMsg))
+			}
+		})
+	}
+}

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Main", func() {
+	type testCase struct {
+		expSubMsg string
+		podIP     string
+		expErr    bool
+	}
+	DescribeTable("should validate an IP address",
+		func(tc testCase) {
+			err := validateIP(tc.podIP)
+			if !tc.expErr {
+				Expect(err).ToNot(HaveOccurred())
+			} else {
+				Expect(err.Error()).To(ContainSubstring(tc.expSubMsg))
+			}
+		},
+		Entry("var not set", testCase{podIP: "", expErr: true, expSubMsg: "must be set"}),
+		Entry("var set to invalid value", testCase{podIP: "invalid", expErr: true, expSubMsg: "must be a valid"}),
+		Entry("var set to valid value", testCase{podIP: "1.2.3.4", expErr: false}),
+	) // should validate an IP address
+})

--- a/cmd/gateway/setup.go
+++ b/cmd/gateway/setup.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"regexp"
 	"strings"
@@ -25,6 +26,12 @@ type (
 	Validator        func(*flag.FlagSet) error
 	ValidatorContext struct {
 		V   Validator
+		Key string
+	}
+
+	EnvValidator        func(string) error
+	EnvValidatorContext struct {
+		V   EnvValidator
 		Key string
 	}
 )
@@ -119,4 +126,14 @@ func MustValidateArguments(flagset *flag.FlagSet, validators ...ValidatorContext
 
 		os.Exit(1)
 	}
+}
+
+func ValidatePodIP(podIP string) error {
+	if podIP == "" {
+		return errors.New("POD_IP environment variable must be set")
+	} else if net.ParseIP(podIP) == nil {
+		return fmt.Errorf("POD_IP '%s' must be a valid IP address", podIP)
+	}
+
+	return nil
 }

--- a/cmd/gateway/setup.go
+++ b/cmd/gateway/setup.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"regexp"
 	"strings"
@@ -120,15 +119,4 @@ func MustValidateArguments(flagset *flag.FlagSet, validators ...ValidatorContext
 
 		os.Exit(1)
 	}
-}
-
-func ValidatePodIP(podIP string) error {
-	if podIP == "" {
-		return errors.New("POD_IP environment variable must be set")
-	}
-	if net.ParseIP(podIP) == nil {
-		return fmt.Errorf("POD_IP %q must be a valid IP address", podIP)
-	}
-
-	return nil
 }

--- a/cmd/gateway/setup.go
+++ b/cmd/gateway/setup.go
@@ -28,12 +28,6 @@ type (
 		V   Validator
 		Key string
 	}
-
-	EnvValidator        func(string) error
-	EnvValidatorContext struct {
-		V   EnvValidator
-		Key string
-	}
 )
 
 func GatewayControllerParam(domain string) ValidatorContext {
@@ -131,8 +125,9 @@ func MustValidateArguments(flagset *flag.FlagSet, validators ...ValidatorContext
 func ValidatePodIP(podIP string) error {
 	if podIP == "" {
 		return errors.New("POD_IP environment variable must be set")
-	} else if net.ParseIP(podIP) == nil {
-		return fmt.Errorf("POD_IP '%s' must be a valid IP address", podIP)
+	}
+	if net.ParseIP(podIP) == nil {
+		return fmt.Errorf("POD_IP %q must be a valid IP address", podIP)
 	}
 
 	return nil

--- a/cmd/gateway/setup_test.go
+++ b/cmd/gateway/setup_test.go
@@ -263,4 +263,17 @@ var _ = Describe("Main", func() {
 			}) // should fail with invalid name
 		}) // gatewayclass validation
 	}) // CLI argument validation
+
+	Describe("environment variable validaton", func() {
+		It("should validate the POD_IP env var", func() {
+			// var not set
+			err := ValidatePodIP("")
+			Expect(err.Error()).To(ContainSubstring("must be set"))
+			// var set to invalid value
+			err = ValidatePodIP("invalid")
+			Expect(err.Error()).To(ContainSubstring("must be a valid"))
+			// var set to valid value
+			Expect(ValidatePodIP("1.2.3.4")).To(Succeed())
+		})
+	}) // environment variable validation
 }) // end Main

--- a/cmd/gateway/setup_test.go
+++ b/cmd/gateway/setup_test.go
@@ -3,7 +3,7 @@ package main_test
 import (
 	"errors"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	flag "github.com/spf13/pflag"
 
@@ -265,15 +265,23 @@ var _ = Describe("Main", func() {
 	}) // CLI argument validation
 
 	Describe("environment variable validaton", func() {
-		It("should validate the POD_IP env var", func() {
-			// var not set
-			err := ValidatePodIP("")
-			Expect(err.Error()).To(ContainSubstring("must be set"))
-			// var set to invalid value
-			err = ValidatePodIP("invalid")
-			Expect(err.Error()).To(ContainSubstring("must be a valid"))
-			// var set to valid value
-			Expect(ValidatePodIP("1.2.3.4")).To(Succeed())
-		})
+		type testCase struct {
+			expSubMsg string
+			podIP     string
+			expErr    bool
+		}
+		DescribeTable("should validate the POD_IP env var",
+			func(tc testCase) {
+				err := ValidatePodIP(tc.podIP)
+				if !tc.expErr {
+					Expect(err).ToNot(HaveOccurred())
+				} else {
+					Expect(err.Error()).To(ContainSubstring(tc.expSubMsg))
+				}
+			},
+			Entry("var not set", testCase{podIP: "", expErr: true, expSubMsg: "must be set"}),
+			Entry("var set to invalid value", testCase{podIP: "invalid", expErr: true, expSubMsg: "must be a valid"}),
+			Entry("var set to valid value", testCase{podIP: "1.2.3.4", expErr: false}),
+		)
 	}) // environment variable validation
 }) // end Main

--- a/cmd/gateway/setup_test.go
+++ b/cmd/gateway/setup_test.go
@@ -24,7 +24,7 @@ func MockValidator(name string, called *int, succeed bool) ValidatorContext {
 	}
 }
 
-var _ = Describe("Main", func() {
+var _ = Describe("Main Setup", func() {
 	Describe("Generic Validator", func() {
 		var mockFlags *flag.FlagSet
 		BeforeEach(func() {
@@ -263,25 +263,4 @@ var _ = Describe("Main", func() {
 			}) // should fail with invalid name
 		}) // gatewayclass validation
 	}) // CLI argument validation
-
-	Describe("environment variable validaton", func() {
-		type testCase struct {
-			expSubMsg string
-			podIP     string
-			expErr    bool
-		}
-		DescribeTable("should validate the POD_IP env var",
-			func(tc testCase) {
-				err := ValidatePodIP(tc.podIP)
-				if !tc.expErr {
-					Expect(err).ToNot(HaveOccurred())
-				} else {
-					Expect(err.Error()).To(ContainSubstring(tc.expSubMsg))
-				}
-			},
-			Entry("var not set", testCase{podIP: "", expErr: true, expSubMsg: "must be set"}),
-			Entry("var set to invalid value", testCase{podIP: "invalid", expErr: true, expSubMsg: "must be a valid"}),
-			Entry("var set to valid value", testCase{podIP: "1.2.3.4", expErr: false}),
-		)
-	}) // environment variable validation
 }) // end Main

--- a/deploy/manifests/nginx-gateway.yaml
+++ b/deploy/manifests/nginx-gateway.yaml
@@ -113,6 +113,11 @@ spec:
           # FIXME(pleshakov) - figure out which capabilities are required
           # dropping ALL and adding only CAP_KILL doesn't work
           # Note: CAP_KILL is needed for sending HUP signal to NGINX main process
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         args:
         - --gateway-ctlr-name=k8s-gateway.nginx.org/nginx-gateway-controller
         - --gatewayclass=nginx

--- a/docs/gateway-api-compatibility.md
+++ b/docs/gateway-api-compatibility.md
@@ -65,7 +65,7 @@ Fields:
 		* `allowedRoutes` - not supported. 
 	* `addresses` - not supported.
 * `status`
-  * `addresses` - not supported.
+  * `addresses` - Pod IPAddress supported.
   * `conditions` - not supported.
   * `listeners`
 	* `name` - supported.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/go-logr/logr v1.2.4
 	github.com/google/go-cmp v0.5.9
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.6.1
-	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/ginkgo/v2 v2.9.5
 	github.com/onsi/gomega v1.27.6
 	github.com/spf13/pflag v1.0.5
@@ -45,7 +44,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
@@ -66,7 +64,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.26.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,6 @@ github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCv
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
-github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -99,7 +97,6 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.14 h1:gm3vOOXfiuw5i9p5N9xJvfjvuofpyvLA9Wr6QfK5Fng=
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -172,7 +169,6 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
@@ -223,17 +219,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
-github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
-github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
-github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
-github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
-github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.9.5 h1:+6Hr4uxzP4XIUyAkg61dWBw8lb/gc4/X5luuxN/EC+Q=
 github.com/onsi/ginkgo/v2 v2.9.5/go.mod h1:tvAoo1QUJwNEU2ITftXTpR7R1RbCzoZUOs3RonqW57k=
-github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
-github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
 github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -345,7 +332,6 @@ golang.org/x/mod v0.10.0 h1:lFO9qtOdlre5W1jxS3r/4szv2/6iXxScdzjoBMXNhYk=
 golang.org/x/mod v0.10.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -368,7 +354,6 @@ golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200501053045-e0ff5e5a1de5/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200506145744-7e3656a0809f/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
@@ -400,7 +385,6 @@ golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.2.0 h1:PUR+T4wwASmuSTYdKjYHI5TD22Wy5ogLU5qZCOLxBrI=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -411,10 +395,7 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -435,7 +416,6 @@ golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -505,7 +485,6 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
-golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.9.1 h1:8WMNJAz3zrtPmnYC7ISf5dEn3MT0gY7jBJfw27yrrLo=
 golang.org/x/tools v0.9.1/go.mod h1:owI94Op576fPu3cIGQeHs3joujW/2Oc6MtlxbF5dfNc=
@@ -602,11 +581,8 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,4 +13,6 @@ type Config struct {
 	GatewayNsName types.NamespacedName
 	// GatewayClassName is the name of the GatewayClass resource that the Gateway will use.
 	GatewayClassName string
+	// PodIP is the IP address of this Pod.
+	PodIP string
 }

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -136,6 +136,7 @@ func Start(cfg config.Config) error {
 		GatewayCtlrName:  cfg.GatewayCtlrName,
 		GatewayClassName: cfg.GatewayClassName,
 		Client:           mgr.GetClient(),
+		PodIP:            cfg.PodIP,
 		// FIXME(pleshakov) Make sure each component:
 		// (1) Has a dedicated named logger.
 		// (2) Get it from the Manager (the WithName is done here for all components).

--- a/internal/status/gateway.go
+++ b/internal/status/gateway.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"os"
 	"sort"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,8 +49,15 @@ func prepareGatewayStatus(gatewayStatus state.GatewayStatus, transitionTime meta
 		})
 	}
 
+	ipAddrType := v1beta1.IPAddressType
+	podIP := v1beta1.GatewayAddress{
+		Type:  &ipAddrType,
+		Value: os.Getenv("POD_IP"),
+	}
+
 	return v1beta1.GatewayStatus{
 		Listeners:  listenerStatuses,
+		Addresses:  []v1beta1.GatewayAddress{podIP},
 		Conditions: nil, // FIXME(pleshakov) Create conditions for the Gateway resource.
 	}
 }

--- a/internal/status/gateway.go
+++ b/internal/status/gateway.go
@@ -1,7 +1,6 @@
 package status
 
 import (
-	"os"
 	"sort"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,7 +23,11 @@ const (
 // FIXME(pleshakov): Be compliant with in the Gateway API.
 // Currently, we only support simple valid/invalid status per each listener.
 // Extend support to cover more cases.
-func prepareGatewayStatus(gatewayStatus state.GatewayStatus, transitionTime metav1.Time) v1beta1.GatewayStatus {
+func prepareGatewayStatus(
+	gatewayStatus state.GatewayStatus,
+	podIP string,
+	transitionTime metav1.Time,
+) v1beta1.GatewayStatus {
 	listenerStatuses := make([]v1beta1.ListenerStatus, 0, len(gatewayStatus.ListenerStatuses))
 
 	// FIXME(pleshakov) Maintain the order from the Gateway resource
@@ -50,14 +53,14 @@ func prepareGatewayStatus(gatewayStatus state.GatewayStatus, transitionTime meta
 	}
 
 	ipAddrType := v1beta1.IPAddressType
-	podIP := v1beta1.GatewayAddress{
+	gwPodIP := v1beta1.GatewayAddress{
 		Type:  &ipAddrType,
-		Value: os.Getenv("POD_IP"),
+		Value: podIP,
 	}
 
 	return v1beta1.GatewayStatus{
 		Listeners:  listenerStatuses,
-		Addresses:  []v1beta1.GatewayAddress{podIP},
+		Addresses:  []v1beta1.GatewayAddress{gwPodIP},
 		Conditions: nil, // FIXME(pleshakov) Create conditions for the Gateway resource.
 	}
 }

--- a/internal/status/gateway_test.go
+++ b/internal/status/gateway_test.go
@@ -14,6 +14,13 @@ import (
 )
 
 func TestPrepareGatewayStatus(t *testing.T) {
+	t.Setenv("POD_IP", "1.2.3.4")
+	ipAddrType := v1beta1.IPAddressType
+	podIP := v1beta1.GatewayAddress{
+		Type:  &ipAddrType,
+		Value: "1.2.3.4",
+	}
+
 	status := state.GatewayStatus{
 		ListenerStatuses: state.ListenerStatuses{
 			"listener": {
@@ -39,6 +46,7 @@ func TestPrepareGatewayStatus(t *testing.T) {
 				Conditions:     CreateExpectedAPIConditions(1, transitionTime),
 			},
 		},
+		Addresses: []v1beta1.GatewayAddress{podIP},
 	}
 
 	g := NewGomegaWithT(t)

--- a/internal/status/gateway_test.go
+++ b/internal/status/gateway_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestPrepareGatewayStatus(t *testing.T) {
-	t.Setenv("POD_IP", "1.2.3.4")
 	ipAddrType := v1beta1.IPAddressType
 	podIP := v1beta1.GatewayAddress{
 		Type:  &ipAddrType,
@@ -51,7 +50,7 @@ func TestPrepareGatewayStatus(t *testing.T) {
 
 	g := NewGomegaWithT(t)
 
-	result := prepareGatewayStatus(status, transitionTime)
+	result := prepareGatewayStatus(status, "1.2.3.4", transitionTime)
 	g.Expect(helpers.Diff(expected, result)).To(BeEmpty())
 }
 

--- a/internal/status/updater.go
+++ b/internal/status/updater.go
@@ -32,6 +32,8 @@ type UpdaterConfig struct {
 	GatewayCtlrName string
 	// GatewayClassName is the name of the GatewayClass resource.
 	GatewayClassName string
+	// PodIP is the IP address of this Pod.
+	PodIP string
 }
 
 // updaterImpl updates statuses of the Gateway API resources.
@@ -101,7 +103,7 @@ func (upd *updaterImpl) Update(ctx context.Context, statuses state.Statuses) {
 	if statuses.GatewayStatus != nil {
 		upd.update(ctx, statuses.GatewayStatus.NsName, &v1beta1.Gateway{}, func(object client.Object) {
 			gw := object.(*v1beta1.Gateway)
-			gw.Status = prepareGatewayStatus(*statuses.GatewayStatus, upd.cfg.Clock.Now())
+			gw.Status = prepareGatewayStatus(*statuses.GatewayStatus, upd.cfg.PodIP, upd.cfg.Clock.Now())
 		})
 	}
 

--- a/internal/status/updater_test.go
+++ b/internal/status/updater_test.go
@@ -55,6 +55,7 @@ var _ = Describe("Updater", func() {
 			Client:           client,
 			Logger:           zap.New(),
 			Clock:            fakeClock,
+			PodIP:            "1.2.3.4",
 		})
 	})
 
@@ -123,7 +124,8 @@ var _ = Describe("Updater", func() {
 			createExpectedGwWithGeneration = func(generation int64) *v1beta1.Gateway {
 				ipAddrType := v1beta1.IPAddressType
 				addr := v1beta1.GatewayAddress{
-					Type: &ipAddrType,
+					Type:  &ipAddrType,
+					Value: "1.2.3.4",
 				}
 
 				return &v1beta1.Gateway{

--- a/internal/status/updater_test.go
+++ b/internal/status/updater_test.go
@@ -121,6 +121,11 @@ var _ = Describe("Updater", func() {
 			}
 
 			createExpectedGwWithGeneration = func(generation int64) *v1beta1.Gateway {
+				ipAddrType := v1beta1.IPAddressType
+				addr := v1beta1.GatewayAddress{
+					Type: &ipAddrType,
+				}
+
 				return &v1beta1.Gateway{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "test",
@@ -143,6 +148,7 @@ var _ = Describe("Updater", func() {
 								Conditions:     status.CreateExpectedAPIConditions(generation, fakeClockTime),
 							},
 						},
+						Addresses: []v1beta1.GatewayAddress{addr},
 					},
 				}
 			}


### PR DESCRIPTION
To satisfy conformance and provide the address of the gateway, we'll now set the pod IP address of the gateway on the GatewayStatus resource. Eventually we will also support other addresses.

Closes #370 

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
