### PR TITLE
Set ResolvedRefs condition to true on HTTPRoutes

### DIFF
--- a/docs/gateway-api-compatibility.md
+++ b/docs/gateway-api-compatibility.md
@@ -99,6 +99,13 @@ Fields:
 	* `conditions` - partially supported. Supported (Condition/Status/Reason):
     	*  `Accepted/True/Accepted`
     	*  `Accepted/False/NoMatchingListenerHostname`
+        *  `Accepted/False/UnsupportedValue`: Custom reason for when the HTTPRoute includes an invalid or unsupported value.
+        *  `Accepted/False/InvalidListener`: Custom reason for when the HTTPRoute references an invalid listener.
+        *  `ResolvedRefs/True/ResolvedRefs`
+        *  `ResolvedRefs/False/InvalidKind`
+        *  `ResolvedRefs/False/RefNotPermitted`
+        *  `ResolvedRefs/False/BackendNotFound`
+        *  `ResolvedRefs/False/UnsupportedValue`: Custom reason for when one of the HTTPRoute rules has a backendRef with an unsupported value.
 
 ### TLSRoute
 

--- a/internal/state/change_processor_test.go
+++ b/internal/state/change_processor_test.go
@@ -342,6 +342,7 @@ var _ = Describe("ChangeProcessor", func() {
 											SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-80-1"),
 											Conditions: []conditions.Condition{
 												conditions.NewRouteInvalidListener(),
+												conditions.NewRouteResolvedRefs(),
 											},
 										},
 										{
@@ -349,6 +350,7 @@ var _ = Describe("ChangeProcessor", func() {
 											SectionName:   helpers.GetPointer[v1beta1.SectionName]("listener-443-1"),
 											Conditions: []conditions.Condition{
 												conditions.NewRouteInvalidListener(),
+												conditions.NewRouteResolvedRefs(),
 											},
 										},
 									},

--- a/internal/state/conditions/conditions.go
+++ b/internal/state/conditions/conditions.go
@@ -68,6 +68,7 @@ func DeduplicateConditions(conds []Condition) []Condition {
 func NewDefaultRouteConditions() []Condition {
 	return []Condition{
 		NewRouteAccepted(),
+		NewRouteResolvedRefs(),
 	}
 }
 
@@ -291,6 +292,16 @@ func NewRouteBackendRefUnsupportedValue(msg string) Condition {
 		Status:  metav1.ConditionFalse,
 		Reason:  RouteReasonBackendRefUnsupportedValue,
 		Message: msg,
+	}
+}
+
+// NewRouteResolvedRefs returns a Condition that indicates that all the references on the Route are resolved.
+func NewRouteResolvedRefs() Condition {
+	return Condition{
+		Type:    string(v1beta1.RouteConditionResolvedRefs),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(v1beta1.RouteReasonResolvedRefs),
+		Message: "All references are resolved",
 	}
 }
 


### PR DESCRIPTION
Previously, the ResolvedRefs condition was only set to False on HTTPRoutes when one or more references could not be resolved. With this commit, ResolvedRefs will be set to true when all references are resolved.

Closes #611 
