### PR TITLE
Set Gateway Programmed condition

### DIFF
--- a/docs/gateway-api-compatibility.md
+++ b/docs/gateway-api-compatibility.md
@@ -39,11 +39,11 @@ of the [static-mode](./cli-help.md#static-mode) command.
 
 Fields:
 * `spec`
-	* `controllerName` - supported.
-	* `parametersRef` - not supported.
-	* `description` - supported.
+    * `controllerName` - supported.
+    * `parametersRef` - not supported.
+    * `description` - supported.
 * `status`
-	* `conditions` - partially supported.
+    * `conditions` - partially supported.
 
 ### Gateway
 
@@ -54,18 +54,18 @@ See [static-mode](./cli-help.md#static-mode) command for more info.
 
 Fields:
 * `spec`
-	* `gatewayClassName` - supported.
-	* `listeners`
-		* `name` - supported.
-		* `hostname` - partially supported. Wildcard hostnames like `*.example.com` are not yet supported.
-		* `port` - partially supported. Allowed values: `80` for HTTP listeners and `443` for HTTPS listeners.
-		* `protocol` - partially supported. Allowed values: `HTTP`, `HTTPS`.
-		* `tls`
-		  * `mode` - partially supported. Allowed value: `Terminate`.
-		  * `certificateRefs` - partially supported. The TLS certificate and key must be stored in a Secret resource of type `kubernetes.io/tls` in the same namespace as the Gateway resource. Only a single reference is supported. You must deploy the Secret before the Gateway resource. Secret rotation (watching for updates) is not supported.
-		  * `options` - not supported.
-		* `allowedRoutes` - not supported. 
-	* `addresses` - not supported.
+    * `gatewayClassName` - supported.
+    * `listeners`
+        * `name` - supported.
+        * `hostname` - partially supported. Wildcard hostnames like `*.example.com` are not yet supported.
+        * `port` - partially supported. Allowed values: `80` for HTTP listeners and `443` for HTTPS listeners.
+        * `protocol` - partially supported. Allowed values: `HTTP`, `HTTPS`.
+        * `tls`
+          * `mode` - partially supported. Allowed value: `Terminate`.
+          * `certificateRefs` - partially supported. The TLS certificate and key must be stored in a Secret resource of type `kubernetes.io/tls` in the same namespace as the Gateway resource. Only a single reference is supported. You must deploy the Secret before the Gateway resource. Secret rotation (watching for updates) is not supported.
+          * `options` - not supported.
+        * `allowedRoutes` - not supported.
+    * `addresses` - not supported.
 * `status`
   * `addresses` - Pod IPAddress supported.
   * `conditions` - Supported (Condition/Status/Reason):
@@ -75,11 +75,14 @@ Fields:
     * `Accepted/False/Invalid`
     * `Accepted/False/UnsupportedValue`: Custom reason for when a value of a field in a Gateway is invalid or not supported.
     * `Accepted/False/GatewayConflict`: Custom reason for when the Gateway is ignored due to a conflicting Gateway. NKG only supports a single Gateway.
+    * `Programmed/True/Programmed`
+    * `Programmed/False/Invalid`
+    * `Programmed/False/GatewayConflict`: Custom reason for when the Gateway is ignored due to a conflicting Gateway. NKG only supports a single Gateway.
   * `listeners`
-	* `name` - supported.
-	* `supportedKinds` - not supported.
-	* `attachedRoutes` - supported.
-	* `conditions` - Supported (Condition/Status/Reason):
+    * `name` - supported.
+    * `supportedKinds` - not supported.
+    * `attachedRoutes` - supported.
+    * `conditions` - Supported (Condition/Status/Reason):
       * `Accepted/True/Accepted`
       * `Accepted/False/UnsupportedProtocol`
       * `Accepted/False/InvalidCertificateRef`
@@ -101,26 +104,27 @@ Fields:
   * `parentRefs` - partially supported. Port not supported.
   * `hostnames` - partially supported. Wildcard binding is not supported: a hostname like `example.com` will not bind to a listener with the hostname `*.example.com`. However, `example.com` will bind to a listener with the empty hostname.
   * `rules`
-	* `matches`
-	  * `path` - partially supported. Only `PathPrefix` and `Exact` types.
-	  * `headers` - partially supported. Only `Exact` type.
-	  * `queryParams` - partially supported. Only `Exact` type. 
-	  * `method` -  supported.
-	* `filters`
-		* `type` - supported.
-		* `requestRedirect` - supported except for the experimental `path` field. If multiple filters with `requestRedirect` are configured, NGINX Kubernetes Gateway will choose the first one and ignore the rest. 
-		* `requestHeaderModifier`, `requestMirror`, `urlRewrite`, `extensionRef` - not supported.
-	* `backendRefs` - partially supported. Backend ref `filters` are not supported.
+    * `matches`
+      * `path` - partially supported. Only `PathPrefix` and `Exact` types.
+      * `headers` - partially supported. Only `Exact` type.
+      * `queryParams` - partially supported. Only `Exact` type.
+      * `method` -  supported.
+    * `filters`
+        * `type` - supported.
+        * `requestRedirect` - supported except for the experimental `path` field. If multiple filters with `requestRedirect` are configured, NGINX Kubernetes Gateway will choose the first one and ignore the rest.
+        * `requestHeaderModifier`, `requestMirror`, `urlRewrite`, `extensionRef` - not supported.
+    * `backendRefs` - partially supported. Backend ref `filters` are not supported.
 * `status`
   * `parents`
-	* `parentRef` - supported.
-	* `controllerName` - supported.
-	* `conditions` - partially supported. Supported (Condition/Status/Reason):
-    	*  `Accepted/True/Accepted`
-    	*  `Accepted/False/NoMatchingListenerHostname`
+    * `parentRef` - supported.
+    * `controllerName` - supported.
+    * `conditions` - partially supported. Supported (Condition/Status/Reason):
+        *  `Accepted/True/Accepted`
+        *  `Accepted/False/NoMatchingListenerHostname`
         *  `Accepted/False/NoMatchingParent`
         *  `Accepted/False/UnsupportedValue`: Custom reason for when the HTTPRoute includes an invalid or unsupported value.
         *  `Accepted/False/InvalidListener`: Custom reason for when the HTTPRoute references an invalid listener.
+        *  `Accepted/False/GatewayNotProgrammed`: Custom reason for when the Gateway is not Programmed. HTTPRoute may be valid and configured, but will maintain this status as long as the Gateway is not Programmed.
         *  `ResolvedRefs/True/ResolvedRefs`
         *  `ResolvedRefs/False/InvalidKind`
         *  `ResolvedRefs/False/RefNotPermitted`

--- a/internal/events/handler.go
+++ b/internal/events/handler.go
@@ -77,14 +77,14 @@ func (h *EventHandlerImpl) HandleEventBatch(ctx context.Context, batch EventBatc
 		}
 	}
 
-	changed, graphCfg := h.cfg.Processor.Process()
+	changed, graph := h.cfg.Processor.Process()
 	if !changed {
 		h.cfg.Logger.Info("Handling events didn't result into NGINX configuration changes")
 		return
 	}
 
 	var nginxReloadRes status.NginxReloadResult
-	err := h.updateNginx(ctx, dataplane.BuildConfiguration(ctx, graphCfg, h.cfg.ServiceResolver))
+	err := h.updateNginx(ctx, dataplane.BuildConfiguration(ctx, graph, h.cfg.ServiceResolver))
 	if err != nil {
 		h.cfg.Logger.Error(err, "Failed to update NGINX configuration")
 		nginxReloadRes.Error = err
@@ -92,7 +92,7 @@ func (h *EventHandlerImpl) HandleEventBatch(ctx context.Context, batch EventBatc
 		h.cfg.Logger.Info("NGINX configuration was successfully updated")
 	}
 
-	h.cfg.StatusUpdater.Update(ctx, status.BuildStatuses(graphCfg, nginxReloadRes))
+	h.cfg.StatusUpdater.Update(ctx, status.BuildStatuses(graph, nginxReloadRes))
 }
 
 func (h *EventHandlerImpl) updateNginx(ctx context.Context, conf dataplane.Configuration) error {

--- a/internal/events/handler.go
+++ b/internal/events/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/nginx/runtime"
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state"
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state/dataplane"
+	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state/resolver"
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state/secrets"
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/status"
 )
@@ -35,6 +36,8 @@ type EventHandlerConfig struct {
 	SecretStore secrets.SecretStore
 	// SecretMemoryManager is the state SecretMemoryManager.
 	SecretMemoryManager secrets.SecretDiskMemoryManager
+	// ServiceResolver resolves Services to Endpoints.
+	ServiceResolver resolver.ServiceResolver
 	// Generator is the nginx config Generator.
 	Generator config.Generator
 	// NginxFileMgr is the file Manager for nginx.
@@ -74,20 +77,22 @@ func (h *EventHandlerImpl) HandleEventBatch(ctx context.Context, batch EventBatc
 		}
 	}
 
-	changed, conf, statuses := h.cfg.Processor.Process(ctx)
+	changed, graphCfg := h.cfg.Processor.Process()
 	if !changed {
 		h.cfg.Logger.Info("Handling events didn't result into NGINX configuration changes")
 		return
 	}
 
-	err := h.updateNginx(ctx, conf)
+	var nginxReloadRes status.NginxReloadResult
+	err := h.updateNginx(ctx, dataplane.BuildConfiguration(ctx, graphCfg, h.cfg.ServiceResolver))
 	if err != nil {
 		h.cfg.Logger.Error(err, "Failed to update NGINX configuration")
+		nginxReloadRes.Error = err
 	} else {
 		h.cfg.Logger.Info("NGINX configuration was successfully updated")
 	}
 
-	h.cfg.StatusUpdater.Update(ctx, statuses)
+	h.cfg.StatusUpdater.Update(ctx, status.BuildStatuses(graphCfg, nginxReloadRes))
 }
 
 func (h *EventHandlerImpl) updateNginx(ctx context.Context, conf dataplane.Configuration) error {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -133,7 +133,6 @@ func Start(cfg config.Config) error {
 		GatewayCtlrName:      cfg.GatewayCtlrName,
 		GatewayClassName:     cfg.GatewayClassName,
 		SecretMemoryManager:  secretMemoryMgr,
-		ServiceResolver:      resolver.NewServiceResolverImpl(mgr.GetClient()),
 		RelationshipCapturer: relationship.NewCapturerImpl(),
 		Logger:               cfg.Logger.WithName("changeProcessor"),
 		Validators: validation.Validators{
@@ -160,6 +159,7 @@ func Start(cfg config.Config) error {
 		Processor:           processor,
 		SecretStore:         secretStore,
 		SecretMemoryManager: secretMemoryMgr,
+		ServiceResolver:     resolver.NewServiceResolverImpl(mgr.GetClient()),
 		Generator:           configGenerator,
 		Logger:              cfg.Logger.WithName("eventHandler"),
 		NginxFileMgr:        nginxFileMgr,

--- a/internal/nginx/runtime/manager.go
+++ b/internal/nginx/runtime/manager.go
@@ -51,7 +51,6 @@ func (m *ManagerImpl) Reload(ctx context.Context) error {
 
 	// FIXME(pleshakov)
 	// (1) ensure the reload actually happens.
-	// (2) ensure that in case of an error, the error message can be seen by the admins.
 	// https://github.com/nginxinc/nginx-kubernetes-gateway/issues/664
 
 	// for now, to prevent a subsequent reload starting before the in-flight reload finishes, we simply sleep.

--- a/internal/state/change_processor.go
+++ b/internal/state/change_processor.go
@@ -32,7 +32,7 @@ const (
 
 type extractGVKFunc func(obj client.Object) schema.GroupVersionKind
 
-// ChangeProcessor processes the changes to resources producing the internal representation
+// ChangeProcessor processes the changes to resources and produces a graph-like representation
 // of the Gateway configuration. It only supports one GatewayClass resource.
 type ChangeProcessor interface {
 	// CaptureUpsertChange captures an upsert change to a resource.
@@ -43,7 +43,7 @@ type ChangeProcessor interface {
 	// The method panics if the resource is of unsupported type or if the passed Gateway is different from the one
 	// this ChangeProcessor was created for.
 	CaptureDeleteChange(resourceType client.Object, nsname types.NamespacedName)
-	// Process produces a Graph-like representation of GatewayAPI resources.
+	// Process produces a graph-like representation of GatewayAPI resources.
 	// If no changes were captured, the changed return argument will be false and graph will be empty.
 	Process() (changed bool, graphCfg *graph.Graph)
 }

--- a/internal/state/change_processor.go
+++ b/internal/state/change_processor.go
@@ -43,7 +43,7 @@ type ChangeProcessor interface {
 	// The method panics if the resource is of unsupported type or if the passed Gateway is different from the one
 	// this ChangeProcessor was created for.
 	CaptureDeleteChange(resourceType client.Object, nsname types.NamespacedName)
-	// Process produces an internal representation of the Gateway configuration.
+	// Process produces a Graph-like representation of GatewayAPI resources.
 	// If no changes were captured, the changed return argument will be false and graph will be empty.
 	Process() (changed bool, graphCfg *graph.Graph)
 }

--- a/internal/state/change_processor_test.go
+++ b/internal/state/change_processor_test.go
@@ -190,6 +190,7 @@ func createScheme() *runtime.Scheme {
 }
 
 var _ = Describe("ChangeProcessor", func() {
+	// graph outputs are large, so allow gomega to print everything on test failure
 	format.MaxLength = 0
 	Describe("Normal cases of processing changes", func() {
 		var (

--- a/internal/state/graph/gateway.go
+++ b/internal/state/graph/gateway.go
@@ -116,16 +116,16 @@ func validateGateway(gw *v1beta1.Gateway, gc *GatewayClass) []conditions.Conditi
 	var conds []conditions.Condition
 
 	if gc == nil {
-		conds = append(conds, conditions.NewGatewayInvalid("GatewayClass doesn't exist"))
+		conds = append(conds, conditions.NewGatewayInvalid("GatewayClass doesn't exist")...)
 	} else if !gc.Valid {
-		conds = append(conds, conditions.NewGatewayInvalid("GatewayClass is invalid"))
+		conds = append(conds, conditions.NewGatewayInvalid("GatewayClass is invalid")...)
 	}
 
 	if len(gw.Spec.Addresses) > 0 {
 		path := field.NewPath("spec", "addresses")
 		valErr := field.Forbidden(path, "addresses are not supported")
 
-		conds = append(conds, conditions.NewGatewayUnsupportedValue(valErr.Error()))
+		conds = append(conds, conditions.NewGatewayUnsupportedValue(valErr.Error())...)
 	}
 
 	return conds

--- a/internal/state/graph/gateway_test.go
+++ b/internal/state/graph/gateway_test.go
@@ -511,11 +511,9 @@ func TestBuildGateway(t *testing.T) {
 			}),
 			gatewayClass: validGC,
 			expected: &Gateway{
-				Source: getLastCreatedGetaway(),
-				Valid:  false,
-				Conditions: []conditions.Condition{
-					conditions.NewGatewayUnsupportedValue("spec.addresses: Forbidden: addresses are not supported"),
-				},
+				Source:     getLastCreatedGetaway(),
+				Valid:      false,
+				Conditions: conditions.NewGatewayUnsupportedValue("spec.addresses: Forbidden: addresses are not supported"),
 			},
 			name: "gateway addresses are not supported",
 		},
@@ -528,11 +526,9 @@ func TestBuildGateway(t *testing.T) {
 			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{listener801, listener802}}),
 			gatewayClass: invalidGC,
 			expected: &Gateway{
-				Source: getLastCreatedGetaway(),
-				Valid:  false,
-				Conditions: []conditions.Condition{
-					conditions.NewGatewayInvalid("GatewayClass is invalid"),
-				},
+				Source:     getLastCreatedGetaway(),
+				Valid:      false,
+				Conditions: conditions.NewGatewayInvalid("GatewayClass is invalid"),
 			},
 			name: "invalid gatewayclass",
 		},
@@ -540,11 +536,9 @@ func TestBuildGateway(t *testing.T) {
 			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{listener801, listener802}}),
 			gatewayClass: nil,
 			expected: &Gateway{
-				Source: getLastCreatedGetaway(),
-				Valid:  false,
-				Conditions: []conditions.Condition{
-					conditions.NewGatewayInvalid("GatewayClass doesn't exist"),
-				},
+				Source:     getLastCreatedGetaway(),
+				Valid:      false,
+				Conditions: conditions.NewGatewayInvalid("GatewayClass doesn't exist"),
 			},
 			name: "nil gatewayclass",
 		},

--- a/internal/state/statefakes/fake_change_processor.go
+++ b/internal/state/statefakes/fake_change_processor.go
@@ -2,11 +2,10 @@
 package statefakes
 
 import (
-	"context"
 	"sync"
 
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state"
-	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state/dataplane"
+	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state/graph"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -23,20 +22,17 @@ type FakeChangeProcessor struct {
 	captureUpsertChangeArgsForCall []struct {
 		arg1 client.Object
 	}
-	ProcessStub        func(context.Context) (bool, dataplane.Configuration, state.Statuses)
+	ProcessStub        func() (bool, *graph.Graph)
 	processMutex       sync.RWMutex
 	processArgsForCall []struct {
-		arg1 context.Context
 	}
 	processReturns struct {
 		result1 bool
-		result2 dataplane.Configuration
-		result3 state.Statuses
+		result2 *graph.Graph
 	}
 	processReturnsOnCall map[int]struct {
 		result1 bool
-		result2 dataplane.Configuration
-		result3 state.Statuses
+		result2 *graph.Graph
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -107,23 +103,22 @@ func (fake *FakeChangeProcessor) CaptureUpsertChangeArgsForCall(i int) client.Ob
 	return argsForCall.arg1
 }
 
-func (fake *FakeChangeProcessor) Process(arg1 context.Context) (bool, dataplane.Configuration, state.Statuses) {
+func (fake *FakeChangeProcessor) Process() (bool, *graph.Graph) {
 	fake.processMutex.Lock()
 	ret, specificReturn := fake.processReturnsOnCall[len(fake.processArgsForCall)]
 	fake.processArgsForCall = append(fake.processArgsForCall, struct {
-		arg1 context.Context
-	}{arg1})
+	}{})
 	stub := fake.ProcessStub
 	fakeReturns := fake.processReturns
-	fake.recordInvocation("Process", []interface{}{arg1})
+	fake.recordInvocation("Process", []interface{}{})
 	fake.processMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub()
 	}
 	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeChangeProcessor) ProcessCallCount() int {
@@ -132,46 +127,36 @@ func (fake *FakeChangeProcessor) ProcessCallCount() int {
 	return len(fake.processArgsForCall)
 }
 
-func (fake *FakeChangeProcessor) ProcessCalls(stub func(context.Context) (bool, dataplane.Configuration, state.Statuses)) {
+func (fake *FakeChangeProcessor) ProcessCalls(stub func() (bool, *graph.Graph)) {
 	fake.processMutex.Lock()
 	defer fake.processMutex.Unlock()
 	fake.ProcessStub = stub
 }
 
-func (fake *FakeChangeProcessor) ProcessArgsForCall(i int) context.Context {
-	fake.processMutex.RLock()
-	defer fake.processMutex.RUnlock()
-	argsForCall := fake.processArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeChangeProcessor) ProcessReturns(result1 bool, result2 dataplane.Configuration, result3 state.Statuses) {
+func (fake *FakeChangeProcessor) ProcessReturns(result1 bool, result2 *graph.Graph) {
 	fake.processMutex.Lock()
 	defer fake.processMutex.Unlock()
 	fake.ProcessStub = nil
 	fake.processReturns = struct {
 		result1 bool
-		result2 dataplane.Configuration
-		result3 state.Statuses
-	}{result1, result2, result3}
+		result2 *graph.Graph
+	}{result1, result2}
 }
 
-func (fake *FakeChangeProcessor) ProcessReturnsOnCall(i int, result1 bool, result2 dataplane.Configuration, result3 state.Statuses) {
+func (fake *FakeChangeProcessor) ProcessReturnsOnCall(i int, result1 bool, result2 *graph.Graph) {
 	fake.processMutex.Lock()
 	defer fake.processMutex.Unlock()
 	fake.ProcessStub = nil
 	if fake.processReturnsOnCall == nil {
 		fake.processReturnsOnCall = make(map[int]struct {
 			result1 bool
-			result2 dataplane.Configuration
-			result3 state.Statuses
+			result2 *graph.Graph
 		})
 	}
 	fake.processReturnsOnCall[i] = struct {
 		result1 bool
-		result2 dataplane.Configuration
-		result3 state.Statuses
-	}{result1, result2, result3}
+		result2 *graph.Graph
+	}{result1, result2}
 }
 
 func (fake *FakeChangeProcessor) Invocations() map[string][][]interface{} {

--- a/internal/status/gateway.go
+++ b/internal/status/gateway.go
@@ -5,13 +5,11 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
-
-	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state"
 )
 
 // prepareGatewayStatus prepares the status for a Gateway resource.
 func prepareGatewayStatus(
-	gatewayStatus state.GatewayStatus,
+	gatewayStatus GatewayStatus,
 	podIP string,
 	transitionTime metav1.Time,
 ) v1beta1.GatewayStatus {

--- a/internal/status/gateway_test.go
+++ b/internal/status/gateway_test.go
@@ -9,7 +9,6 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/helpers"
-	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state"
 )
 
 func TestPrepareGatewayStatus(t *testing.T) {
@@ -19,9 +18,9 @@ func TestPrepareGatewayStatus(t *testing.T) {
 		Value: "1.2.3.4",
 	}
 
-	status := state.GatewayStatus{
+	status := GatewayStatus{
 		Conditions: CreateTestConditions("GatewayTest"),
-		ListenerStatuses: state.ListenerStatuses{
+		ListenerStatuses: ListenerStatuses{
 			"listener": {
 				AttachedRoutes: 3,
 				Conditions:     CreateTestConditions("ListenerTest"),

--- a/internal/status/gatewayclass.go
+++ b/internal/status/gatewayclass.go
@@ -3,12 +3,10 @@ package status
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
-
-	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state"
 )
 
 // prepareGatewayClassStatus prepares the status for the GatewayClass resource.
-func prepareGatewayClassStatus(status state.GatewayClassStatus, transitionTime metav1.Time) v1beta1.GatewayClassStatus {
+func prepareGatewayClassStatus(status GatewayClassStatus, transitionTime metav1.Time) v1beta1.GatewayClassStatus {
 	return v1beta1.GatewayClassStatus{
 		Conditions: convertConditions(status.Conditions, status.ObservedGeneration, transitionTime),
 	}

--- a/internal/status/gatewayclass_test.go
+++ b/internal/status/gatewayclass_test.go
@@ -9,13 +9,12 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/helpers"
-	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state"
 )
 
 func TestPrepareGatewayClassStatus(t *testing.T) {
 	transitionTime := metav1.NewTime(time.Now())
 
-	status := state.GatewayClassStatus{
+	status := GatewayClassStatus{
 		ObservedGeneration: 1,
 		Conditions:         CreateTestConditions("Test"),
 	}

--- a/internal/status/httproute.go
+++ b/internal/status/httproute.go
@@ -3,13 +3,11 @@ package status
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
-
-	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state"
 )
 
 // prepareHTTPRouteStatus prepares the status for an HTTPRoute resource.
 func prepareHTTPRouteStatus(
-	status state.HTTPRouteStatus,
+	status HTTPRouteStatus,
 	gatewayCtlrName string,
 	transitionTime metav1.Time,
 ) v1beta1.HTTPRouteStatus {

--- a/internal/status/httproute_test.go
+++ b/internal/status/httproute_test.go
@@ -10,16 +10,15 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/helpers"
-	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state"
 )
 
 func TestPrepareHTTPRouteStatus(t *testing.T) {
 	gwNsName1 := types.NamespacedName{Namespace: "test", Name: "gateway-1"}
 	gwNsName2 := types.NamespacedName{Namespace: "test", Name: "gateway-2"}
 
-	status := state.HTTPRouteStatus{
+	status := HTTPRouteStatus{
 		ObservedGeneration: 1,
-		ParentStatuses: []state.ParentStatus{
+		ParentStatuses: []ParentStatus{
 			{
 				GatewayNsName: gwNsName1,
 				SectionName:   helpers.GetPointer[v1beta1.SectionName]("http"),

--- a/internal/status/statusfakes/fake_updater.go
+++ b/internal/status/statusfakes/fake_updater.go
@@ -5,26 +5,25 @@ import (
 	"context"
 	"sync"
 
-	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state"
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/status"
 )
 
 type FakeUpdater struct {
-	UpdateStub        func(context.Context, state.Statuses)
+	UpdateStub        func(context.Context, status.Statuses)
 	updateMutex       sync.RWMutex
 	updateArgsForCall []struct {
 		arg1 context.Context
-		arg2 state.Statuses
+		arg2 status.Statuses
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeUpdater) Update(arg1 context.Context, arg2 state.Statuses) {
+func (fake *FakeUpdater) Update(arg1 context.Context, arg2 status.Statuses) {
 	fake.updateMutex.Lock()
 	fake.updateArgsForCall = append(fake.updateArgsForCall, struct {
 		arg1 context.Context
-		arg2 state.Statuses
+		arg2 status.Statuses
 	}{arg1, arg2})
 	stub := fake.UpdateStub
 	fake.recordInvocation("Update", []interface{}{arg1, arg2})
@@ -40,13 +39,13 @@ func (fake *FakeUpdater) UpdateCallCount() int {
 	return len(fake.updateArgsForCall)
 }
 
-func (fake *FakeUpdater) UpdateCalls(stub func(context.Context, state.Statuses)) {
+func (fake *FakeUpdater) UpdateCalls(stub func(context.Context, status.Statuses)) {
 	fake.updateMutex.Lock()
 	defer fake.updateMutex.Unlock()
 	fake.UpdateStub = stub
 }
 
-func (fake *FakeUpdater) UpdateArgsForCall(i int) (context.Context, state.Statuses) {
+func (fake *FakeUpdater) UpdateArgsForCall(i int) (context.Context, status.Statuses) {
 	fake.updateMutex.RLock()
 	defer fake.updateMutex.RUnlock()
 	argsForCall := fake.updateArgsForCall[i]

--- a/internal/status/updater.go
+++ b/internal/status/updater.go
@@ -8,8 +8,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
-
-	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . Updater
@@ -17,7 +15,7 @@ import (
 // Updater updates statuses of the Gateway API resources.
 type Updater interface {
 	// Update updates the statuses of the resources.
-	Update(context.Context, state.Statuses)
+	Update(context.Context, Statuses)
 }
 
 // UpdaterConfig holds configuration parameters for Updater.
@@ -81,7 +79,7 @@ func NewUpdater(cfg UpdaterConfig) Updater {
 	}
 }
 
-func (upd *updaterImpl) Update(ctx context.Context, statuses state.Statuses) {
+func (upd *updaterImpl) Update(ctx context.Context, statuses Statuses) {
 	// FIXME(pleshakov) Merge the new Conditions in the status with the existing Conditions
 	// https://github.com/nginxinc/nginx-kubernetes-gateway/issues/558
 


### PR DESCRIPTION
When the Gateway configuration has been successfully uploaded to nginx, we will set the status Programmed to true. If there's any error with updating nginx, then we set Programmed to false. We'll also set a negative status on the HTTPRoutes in the system to explain that the Gateway is not programmed.
Closes #610 

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
