### PR TITLE
Fix supported gateway conditions in compatibility doc

### DIFF
--- a/docs/gateway-api-compatibility.md
+++ b/docs/gateway-api-compatibility.md
@@ -68,18 +68,29 @@ Fields:
 	* `addresses` - not supported.
 * `status`
   * `addresses` - Pod IPAddress supported.
-  * `conditions` - not supported.
+  * `conditions` - Supported (Condition/Status/Reason):
+    * `Accepted/True/Accepted`
+    * `Accepted/True/ListenersNotValid`
+    * `Accepted/False/ListenersNotValid`
+    * `Accepted/False/Invalid`
+    * `Accepted/False/UnsupportedValue`: Custom reason for when a value of a field in a Gateway is invalid or not supported.
+    * `Accepted/False/GatewayConflict`: Custom reason for when the Gateway is ignored due to a conflicting Gateway. NKG only supports a single Gateway.
   * `listeners`
 	* `name` - supported.
 	* `supportedKinds` - not supported.
 	* `attachedRoutes` - supported.
 	* `conditions` - Supported (Condition/Status/Reason):
       * `Accepted/True/Accepted`
-      * `Accepted/True/ListenersNotValid`
-      * `Accepted/False/Invalid`
-      * `Accepted/False/ListenersNotValid`
-      * `Accepted/False/UnsupportedValue`: Custom reason for when a value of a field in a Gateway is invalid or not supported.
+      * `Accepted/False/UnsupportedProtocol`
+      * `Accepted/False/InvalidCertificateRef`
+      * `Accepted/False/HostnameConflict`
+      * `Accepted/False/PortUnavailable`
+      * `Accepted/False/UnsupportedValue`: Custom reason for when a value of a field in a Listener is invalid or not supported.
       * `Accepted/False/GatewayConflict`: Custom reason for when the Gateway is ignored due to a conflicting Gateway. NKG only supports a single Gateway.
+      * `ResolvedRefs/True/ResolvedRefs`
+      * `ResolvedRefs/False/ListenerReasonInvalidCertificateRef`
+      * `Conflicted/True/HostnameConflict`
+      * `Conflicted/False/NoConflicts`
 
 ### HTTPRoute
 

--- a/docs/gateway-api-compatibility.md
+++ b/docs/gateway-api-compatibility.md
@@ -88,7 +88,7 @@ Fields:
       * `Accepted/False/UnsupportedValue`: Custom reason for when a value of a field in a Listener is invalid or not supported.
       * `Accepted/False/GatewayConflict`: Custom reason for when the Gateway is ignored due to a conflicting Gateway. NKG only supports a single Gateway.
       * `ResolvedRefs/True/ResolvedRefs`
-      * `ResolvedRefs/False/ListenerReasonInvalidCertificateRef`
+      * `ResolvedRefs/False/InvalidCertificateRef`
       * `Conflicted/True/HostnameConflict`
       * `Conflicted/False/NoConflicts`
 


### PR DESCRIPTION
In https://github.com/nginxinc/nginx-kubernetes-gateway/pull/633 I placed the Gateway conditions under the listener conditions. This PR moves the Gateway conditions under `gateway.status.conditions` and adds all the listener conditions to `gateway.status.listeners.conditions`

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
