### PR TITLE
Update route condition where listener is not found

### DIFF
--- a/docs/gateway-api-compatibility.md
+++ b/docs/gateway-api-compatibility.md
@@ -118,6 +118,7 @@ Fields:
 	* `conditions` - partially supported. Supported (Condition/Status/Reason):
     	*  `Accepted/True/Accepted`
     	*  `Accepted/False/NoMatchingListenerHostname`
+        *  `Accepted/False/NoMatchingParent`
         *  `Accepted/False/UnsupportedValue`: Custom reason for when the HTTPRoute includes an invalid or unsupported value.
         *  `Accepted/False/InvalidListener`: Custom reason for when the HTTPRoute references an invalid listener.
         *  `ResolvedRefs/True/ResolvedRefs`

--- a/internal/state/conditions/conditions.go
+++ b/internal/state/conditions/conditions.go
@@ -201,6 +201,17 @@ func NewRouteInvalidGateway() Condition {
 	}
 }
 
+// NewRouteNoMatchingParent returns a Condition that indicates that the Route is not Accepted because
+// it specifies a Port and/or SectionName that does not match any Listeners in the Gateway.
+func NewRouteNoMatchingParent() Condition {
+	return Condition{
+		Type:    string(v1beta1.RouteConditionAccepted),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(v1beta1.RouteReasonNoMatchingParent),
+		Message: "Listener is not found for this parent ref",
+	}
+}
+
 // NewDefaultListenerConditions returns the default Conditions that must be present in the status of a Listener.
 func NewDefaultListenerConditions() []Condition {
 	return []Condition{

--- a/internal/state/graph/httproute.go
+++ b/internal/state/graph/httproute.go
@@ -317,9 +317,7 @@ func tryToAttachRouteToListeners(
 	validListeners, listenerExists := findValidListeners(getSectionName(sectionName), listeners)
 
 	if !listenerExists {
-		// FIXME(pleshakov): Add a proper condition once it is available in the Gateway API.
-		// https://github.com/nginxinc/nginx-kubernetes-gateway/issues/665
-		return conditions.NewTODO("listener is not found"), false
+		return conditions.NewRouteNoMatchingParent(), false
 	}
 
 	if len(validListeners) == 0 {

--- a/internal/state/graph/httproute_test.go
+++ b/internal/state/graph/httproute_test.go
@@ -841,7 +841,7 @@ func TestBindRouteToListeners(t *testing.T) {
 					Gateway: client.ObjectKeyFromObject(gw),
 					Attachment: &ParentRefAttachmentStatus{
 						Attached:          false,
-						FailedCondition:   conditions.NewTODO("listener is not found"),
+						FailedCondition:   conditions.NewRouteNoMatchingParent(),
 						AcceptedHostnames: map[string][]string{},
 					},
 				},


### PR DESCRIPTION
### Proposed changes
Report Accepted(false), Reason NoMatchingParent, in the status of HTTPRoute when the section name (listener) in the Gateway is not found.

Closes https://github.com/nginxinc/nginx-kubernetes-gateway/issues/306

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
