### PR TITLE
Add timeout and retry logic for finding NGINX PID file

### DIFF
--- a/internal/nginx/runtime/manager_test.go
+++ b/internal/nginx/runtime/manager_test.go
@@ -2,7 +2,9 @@ package runtime
 
 import (
 	"errors"
+	"io/fs"
 	"testing"
+	"time"
 )
 
 func TestFindMainProcess(t *testing.T) {
@@ -18,40 +20,65 @@ func TestFindMainProcess(t *testing.T) {
 		return nil, errors.New("error")
 	}
 
+	checkFileFuncGen := func(content fs.FileInfo) checkFileFunc {
+		return func(name string) (fs.FileInfo, error) {
+			if name != pidFile {
+				return nil, errors.New("error")
+			}
+			return content, nil
+		}
+	}
+	checkFileError := func(string) (fs.FileInfo, error) {
+		return nil, errors.New("error")
+	}
+	var testFileInfo fs.FileInfo
+
 	tests := []struct {
 		readFile    readFileFunc
+		checkFile   checkFileFunc
 		msg         string
 		expected    int
 		expectError bool
 	}{
 		{
 			readFile:    readFileFuncGen([]byte("1\n")),
+			checkFile:   checkFileFuncGen(testFileInfo),
 			expected:    1,
 			expectError: false,
 			msg:         "normal case",
 		},
 		{
 			readFile:    readFileFuncGen([]byte("")),
+			checkFile:   checkFileFuncGen(testFileInfo),
 			expected:    0,
 			expectError: true,
 			msg:         "empty file content",
 		},
 		{
 			readFile:    readFileFuncGen([]byte("not a number")),
+			checkFile:   checkFileFuncGen(testFileInfo),
 			expected:    0,
 			expectError: true,
 			msg:         "bad file content",
 		},
 		{
 			readFile:    readFileError,
+			checkFile:   checkFileFuncGen(testFileInfo),
 			expected:    0,
 			expectError: true,
 			msg:         "cannot read file",
 		},
+		{
+			readFile:    readFileFuncGen([]byte("1\n")),
+			checkFile:   checkFileError,
+			expected:    0,
+			expectError: true,
+			msg:         "cannot file pid file",
+		},
 	}
 
 	for _, test := range tests {
-		result, err := findMainProcess(test.readFile)
+		result, err := findMainProcess(test.checkFile, test.readFile, 1*time.Microsecond)
 
 		if result != test.expected {
 			t.Errorf("findMainProcess() returned %d but expected %d for case %q", result, test.expected, test.msg)


### PR DESCRIPTION
### Proposed changes
Occasionally, the Gateway container starts before the NGINX container, and this means we may attempt a reload of NGINX before the NGINX process exists. This commit checks if the PID file exists with timeout and retry logic to give the NGINX container time to start.

Closes https://github.com/nginxinc/nginx-kubernetes-gateway/issues/600

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
