### PR TITLE
Move nginx.conf to ConfigMap

### DIFF
--- a/deploy/manifests/nginx-gateway.yaml
+++ b/deploy/manifests/nginx-gateway.yaml
@@ -69,6 +69,27 @@ roleRef:
   name: nginx-gateway
   apiGroup: rbac.authorization.k8s.io
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+  namespace: nginx-gateway
+data:
+  nginx.conf: |
+    load_module /usr/lib/nginx/modules/ngx_http_js_module.so;
+
+    events {}
+
+    pid /etc/nginx/nginx.pid;
+    error_log stderr debug;
+
+    http {
+      include /etc/nginx/conf.d/*.conf;
+      js_import /usr/lib/nginx/modules/njs/httpmatches.js;
+      server_names_hash_bucket_size 256;
+      server_names_hash_max_size 1024;
+    }
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -87,26 +108,29 @@ spec:
       shareProcessNamespace: true
       serviceAccountName: nginx-gateway
       volumes:
-      - name: nginx-config
+      - name: nginx
         emptyDir: { }
+      - name: nginx-conf
+        configMap:
+          name: nginx-conf
       - name: var-lib-nginx
         emptyDir: { }
       - name: njs-modules
         configMap:
           name: njs-modules
       initContainers:
-      - image: busybox:1.34 # FIXME(pleshakov): use gateway container to init the Config with proper main config
-        name: nginx-config-initializer
-        command: [ 'sh', '-c', 'echo "load_module /usr/lib/nginx/modules/ngx_http_js_module.so; events {}  pid /etc/nginx/nginx.pid; error_log stderr debug; http { include /etc/nginx/conf.d/*.conf; js_import /usr/lib/nginx/modules/njs/httpmatches.js; server_names_hash_bucket_size 256; server_names_hash_max_size 1024; }" > /etc/nginx/nginx.conf && (rm -r /etc/nginx/conf.d /etc/nginx/secrets; mkdir /etc/nginx/conf.d /etc/nginx/secrets && chown 1001:0 /etc/nginx/conf.d /etc/nginx/secrets)' ]
+      - image: busybox:1.36
+        name: set-permissions
+        command: [ 'sh', '-c', 'rm -r /etc/nginx/conf.d /etc/nginx/secrets; mkdir /etc/nginx/conf.d /etc/nginx/secrets && chown 1001:0 /etc/nginx/conf.d /etc/nginx/secrets' ]
         volumeMounts:
-        - name: nginx-config
+        - name: nginx
           mountPath: /etc/nginx
       containers:
       - image: ghcr.io/nginxinc/nginx-kubernetes-gateway:edge
         imagePullPolicy: Always
         name: nginx-gateway
         volumeMounts:
-        - name: nginx-config
+        - name: nginx
           mountPath: /etc/nginx
         securityContext:
           runAsUser: 1001
@@ -133,8 +157,11 @@ spec:
         - name: https
           containerPort: 443
         volumeMounts:
-        - name: nginx-config
+        - name: nginx
           mountPath: /etc/nginx
+        - name: nginx-conf
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
         - name: var-lib-nginx
           mountPath: /var/lib/nginx
         - name: njs-modules


### PR DESCRIPTION
To clean up the init container, the main nginx.conf is being moved to a ConfigMap and then mounted into the Pod. Also bumped container versions.
