### PR TITLE
Ensure uniqueness and validity of generated names and labels

### DIFF
--- a/internal/provisioner/handler.go
+++ b/internal/provisioner/handler.go
@@ -138,6 +138,8 @@ func (h *eventHandler) HandleEventBatch(ctx context.Context, batch events.EventB
 }
 
 func (h *eventHandler) generateDeploymentID() string {
+	// This approach will break if the provisioner is restarted, because the existing Gateways might get
+	// IDs different from the previous replica of the provisioner.
 	id := h.gatewayNextID
 	h.gatewayNextID++
 

--- a/internal/provisioner/handler.go
+++ b/internal/provisioner/handler.go
@@ -30,6 +30,8 @@ type eventHandler struct {
 	logger        logr.Logger
 
 	staticModeDeploymentYAML []byte
+
+	gatewayNextID int64
 }
 
 func newEventHandler(
@@ -47,6 +49,7 @@ func newEventHandler(
 		k8sClient:                k8sClient,
 		logger:                   logger,
 		staticModeDeploymentYAML: staticModeDeploymentYAML,
+		gatewayNextID:            1,
 	}
 }
 
@@ -91,7 +94,7 @@ func (h *eventHandler) ensureDeploymentsMatchGateways(ctx context.Context) {
 	// Create new deployments
 
 	for _, nsname := range gwsWithoutDeps {
-		deployment, err := prepareDeployment(h.staticModeDeploymentYAML, generateDeploymentID(nsname), nsname)
+		deployment, err := prepareDeployment(h.staticModeDeploymentYAML, h.generateDeploymentID(), nsname)
 		if err != nil {
 			panic(fmt.Errorf("failed to prepare deployment: %w", err))
 		}
@@ -103,7 +106,10 @@ func (h *eventHandler) ensureDeploymentsMatchGateways(ctx context.Context) {
 
 		h.provisions[nsname] = deployment
 
-		h.logger.Info("Created deployment", "deployment", client.ObjectKeyFromObject(deployment))
+		h.logger.Info("Created deployment",
+			"deployment", client.ObjectKeyFromObject(deployment),
+			"gateway", nsname,
+		)
 	}
 
 	// Remove unnecessary deployments
@@ -118,7 +124,10 @@ func (h *eventHandler) ensureDeploymentsMatchGateways(ctx context.Context) {
 
 		delete(h.provisions, nsname)
 
-		h.logger.Info("Deleted deployment", "deployment", client.ObjectKeyFromObject(deployment))
+		h.logger.Info("Deleted deployment",
+			"deployment", client.ObjectKeyFromObject(deployment),
+			"gateway", nsname,
+		)
 	}
 }
 
@@ -128,9 +137,9 @@ func (h *eventHandler) HandleEventBatch(ctx context.Context, batch events.EventB
 	h.ensureDeploymentsMatchGateways(ctx)
 }
 
-func generateDeploymentID(gatewayNsName types.NamespacedName) string {
-	// for production, make sure the ID is:
-	// - a valid resource name (ex. can't be too long);
-	// - unique among all Gateway resources (Gateways test-test/test and test/test-test should not have the same ID)
-	return fmt.Sprintf("nginx-gateway-%s-%s", gatewayNsName.Namespace, gatewayNsName.Name)
+func (h *eventHandler) generateDeploymentID() string {
+	id := h.gatewayNextID
+	h.gatewayNextID++
+
+	return fmt.Sprintf("nginx-gateway-%d", id)
 }


### PR DESCRIPTION
Problem:

Provisioner could generate an invalid name or a label for NKG static mode deployment. As a result, the provisioner would fail with an error like below:
```
{“level”:“info”,“ts”:“2023-06-05T17:26:04Z”,“logger”:“eventLoop”,“msg”:“added an event to the next batch”,“type”:“*events.UpsertEvent”,“total”:1}
panic: failed to create deployment: Deployment.apps “nginx-gateway-gateway-conformance-infra-same-namespace-with-http-listener-on-8080" is invalid: [spec.selector.matchLabels: Invalid value: “nginx-gateway-gateway-conformance-infra-same-namespace-with-http-listener-on-8080”: must be no more than 63 characters, spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{“app”:“nginx-gateway-gateway-conformance-infra-same-namespace-with-http-listener-on-8080”}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: invalid label selector]
```


Solution:

Provisioner will use the following format for names and labels of Deployments:
`nginx-gateway-<number>`, where the number if an interger >= 1. For every new Gateway resource, the provisioner will increment the number by one.

This approach will break if the provisioner is restarted, but we don't support provisioner for production yet, so it is acceptable.


Note: correlation between a Gateway resource and the corresponding Deployment can be found in the provisioner log. For example:
```
{"level":"info","ts":"2023-06-05T21:23:33Z","logger":"eventHandler","msg":"Created deployment","deployment":{"name":"nginx-gateway-1","namespace":"nginx-gateway"},"gateway":{"name":"same-namespace","namespace":"gateway-conformance-infra"}}
```

This PR will unblock https://github.com/nginxinc/nginx-kubernetes-gateway/pull/713#issuecomment-1577200778 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
