### PR TITLE
Add in required capabilities for writing TLS secrets

### DIFF
--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -83,3 +83,4 @@ spec:
             - NET_BIND_SERVICE
             - SETGID
             - SETUID
+            - DAC_OVERRIDE


### PR DESCRIPTION
### Proposed changes

Problem: TLS termination is not working because the NGINX container is missing the `DAC_OVERRIDE` capability. This is required to bypass write permission checks on the files in `/etc/nginx/secrets` so we can write the TLS secrets to disk.

Solution: Explain the approach you took to implement the solution, highlighting any significant design decisions or
considerations.

Closes https://github.com/nginxinc/nginx-kubernetes-gateway/issues/714

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
