### PR TITLE
AllowedRoutes support for Listeners

### DIFF
--- a/deploy/manifests/rbac.yaml
+++ b/deploy/manifests/rbac.yaml
@@ -12,6 +12,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
   - services
   - secrets
   verbs:

--- a/docs/gateway-api-compatibility.md
+++ b/docs/gateway-api-compatibility.md
@@ -64,7 +64,7 @@ Fields:
           * `mode` - partially supported. Allowed value: `Terminate`.
           * `certificateRefs` - partially supported. The TLS certificate and key must be stored in a Secret resource of type `kubernetes.io/tls` in the same namespace as the Gateway resource. Only a single reference is supported. You must deploy the Secret before the Gateway resource. Secret rotation (watching for updates) is not supported.
           * `options` - not supported.
-        * `allowedRoutes` - not supported.
+        * `allowedRoutes` - supported.
     * `addresses` - not supported.
 * `status`
   * `addresses` - Pod IPAddress supported.
@@ -122,6 +122,7 @@ Fields:
         *  `Accepted/True/Accepted`
         *  `Accepted/False/NoMatchingListenerHostname`
         *  `Accepted/False/NoMatchingParent`
+        *  `Accepted/False/NotAllowedByListeners`
         *  `Accepted/False/UnsupportedValue`: Custom reason for when the HTTPRoute includes an invalid or unsupported value.
         *  `Accepted/False/InvalidListener`: Custom reason for when the HTTPRoute references an invalid listener.
         *  `Accepted/False/GatewayNotProgrammed`: Custom reason for when the Gateway is not Programmed. HTTPRoute may be valid and configured, but will maintain this status as long as the Gateway is not Programmed.

--- a/internal/events/handler.go
+++ b/internal/events/handler.go
@@ -128,6 +128,8 @@ func (h *EventHandlerImpl) propagateUpsert(e *UpsertEvent) {
 		h.cfg.Processor.CaptureUpsertChange(r)
 	case *apiv1.Service:
 		h.cfg.Processor.CaptureUpsertChange(r)
+	case *apiv1.Namespace:
+		h.cfg.Processor.CaptureUpsertChange(r)
 	case *apiv1.Secret:
 		// FIXME(kate-osborn): need to handle certificate rotation
 		// https://github.com/nginxinc/nginx-kubernetes-gateway/issues/553
@@ -148,6 +150,8 @@ func (h *EventHandlerImpl) propagateDelete(e *DeleteEvent) {
 	case *v1beta1.HTTPRoute:
 		h.cfg.Processor.CaptureDeleteChange(e.Type, e.NamespacedName)
 	case *apiv1.Service:
+		h.cfg.Processor.CaptureDeleteChange(e.Type, e.NamespacedName)
+	case *apiv1.Namespace:
 		h.cfg.Processor.CaptureDeleteChange(e.Type, e.NamespacedName)
 	case *apiv1.Secret:
 		// FIXME(kate-osborn): make sure that affected servers are updated

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -112,6 +112,12 @@ func Start(cfg config.Config) error {
 				controller.WithFieldIndices(index.CreateEndpointSliceFieldIndices()),
 			},
 		},
+		{
+			objectType: &apiv1.Namespace{},
+			options: []controller.Option{
+				controller.WithK8sPredicate(k8spredicate.LabelChangedPredicate{}),
+			},
+		},
 	}
 
 	ctx := ctlr.SetupSignalHandler()
@@ -195,6 +201,7 @@ func prepareFirstEventBatchPreparerArgs(
 	objectLists := []client.ObjectList{
 		&apiv1.ServiceList{},
 		&apiv1.SecretList{},
+		&apiv1.NamespaceList{},
 		&discoveryV1.EndpointSliceList{},
 		&gatewayv1beta1.HTTPRouteList{},
 	}

--- a/internal/manager/manager_test.go
+++ b/internal/manager/manager_test.go
@@ -30,6 +30,7 @@ func TestPrepareFirstEventBatchPreparerArgs(t *testing.T) {
 			expectedObjectLists: []client.ObjectList{
 				&apiv1.ServiceList{},
 				&apiv1.SecretList{},
+				&apiv1.NamespaceList{},
 				&discoveryV1.EndpointSliceList{},
 				&gatewayv1beta1.HTTPRouteList{},
 				&gatewayv1beta1.GatewayList{},
@@ -48,6 +49,7 @@ func TestPrepareFirstEventBatchPreparerArgs(t *testing.T) {
 			expectedObjectLists: []client.ObjectList{
 				&apiv1.ServiceList{},
 				&apiv1.SecretList{},
+				&apiv1.NamespaceList{},
 				&discoveryV1.EndpointSliceList{},
 				&gatewayv1beta1.HTTPRouteList{},
 			},

--- a/internal/state/change_processor.go
+++ b/internal/state/change_processor.go
@@ -60,7 +60,7 @@ type ChangeProcessorConfig struct {
 	Logger logr.Logger
 	// EventRecorder records events for Kubernetes resources.
 	EventRecorder record.EventRecorder
-	// Scheme is the a Kubernetes scheme.
+	// Scheme is the Kubernetes scheme.
 	Scheme *runtime.Scheme
 	// GatewayCtlrName is the name of the Gateway controller.
 	GatewayCtlrName string
@@ -89,6 +89,7 @@ func NewChangeProcessorImpl(cfg ChangeProcessorConfig) *ChangeProcessorImpl {
 		Gateways:       make(map[types.NamespacedName]*v1beta1.Gateway),
 		HTTPRoutes:     make(map[types.NamespacedName]*v1beta1.HTTPRoute),
 		Services:       make(map[types.NamespacedName]*apiv1.Service),
+		Namespaces:     make(map[types.NamespacedName]*apiv1.Namespace),
 	}
 
 	extractGVK := func(obj client.Object) schema.GroupVersionKind {
@@ -117,6 +118,11 @@ func NewChangeProcessorImpl(cfg ChangeProcessorConfig) *ChangeProcessorImpl {
 				gvk:               extractGVK(&v1beta1.HTTPRoute{}),
 				store:             newObjectStoreMapAdapter(clusterStore.HTTPRoutes),
 				trackUpsertDelete: true,
+			},
+			{
+				gvk:               extractGVK(&apiv1.Namespace{}),
+				store:             newObjectStoreMapAdapter(clusterStore.Namespaces),
+				trackUpsertDelete: false,
 			},
 			{
 				gvk:               extractGVK(&apiv1.Service{}),

--- a/internal/state/change_processor_test.go
+++ b/internal/state/change_processor_test.go
@@ -963,8 +963,9 @@ var _ = Describe("ChangeProcessor", func() {
 					changed, _ := processor.Process()
 					Expect(changed).To(BeTrue())
 
-					ns.Labels = nil
-					processor.CaptureUpsertChange(ns)
+					newNS := ns.DeepCopy()
+					newNS.Labels = nil
+					processor.CaptureUpsertChange(newNS)
 
 					changed, _ = processor.Process()
 					Expect(changed).To(BeTrue())

--- a/internal/state/conditions/conditions.go
+++ b/internal/state/conditions/conditions.go
@@ -109,6 +109,17 @@ func NewDefaultRouteConditions() []Condition {
 	}
 }
 
+// NewRouteNotAllowedByListeners returns a Condition that indicates that the HTTPRoute is not allowed by
+// any listener.
+func NewRouteNotAllowedByListeners() Condition {
+	return Condition{
+		Type:    string(v1beta1.RouteConditionAccepted),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(v1beta1.RouteReasonNotAllowedByListeners),
+		Message: "HTTPRoute is not allowed by any listener",
+	}
+}
+
 // NewRouteNoMatchingListenerHostname returns a Condition that indicates that the hostname of the listener
 // does not match the hostnames of the HTTPRoute.
 func NewRouteNoMatchingListenerHostname() Condition {

--- a/internal/state/graph/gateway_listener.go
+++ b/internal/state/graph/gateway_listener.go
@@ -351,8 +351,10 @@ func createExternalReferencesForTLSSecretsResolver(
 
 // GetAllowedRouteLabelSelector returns a listener's AllowedRoutes label selector if it exists.
 func GetAllowedRouteLabelSelector(l v1beta1.Listener) *metav1.LabelSelector {
-	if l.AllowedRoutes != nil && l.AllowedRoutes.Namespaces != nil && l.AllowedRoutes.Namespaces.Selector != nil {
-		return l.AllowedRoutes.Namespaces.Selector
+	if l.AllowedRoutes != nil && l.AllowedRoutes.Namespaces != nil {
+		if *l.AllowedRoutes.Namespaces.From == v1beta1.NamespacesFromSelector && l.AllowedRoutes.Namespaces.Selector != nil {
+			return l.AllowedRoutes.Namespaces.Selector
+		}
 	}
 
 	return nil

--- a/internal/state/graph/graph.go
+++ b/internal/state/graph/graph.go
@@ -15,6 +15,7 @@ type ClusterState struct {
 	Gateways       map[types.NamespacedName]*v1beta1.Gateway
 	HTTPRoutes     map[types.NamespacedName]*v1beta1.HTTPRoute
 	Services       map[types.NamespacedName]*v1.Service
+	Namespaces     map[types.NamespacedName]*v1.Namespace
 }
 
 // Graph is a Graph-like representation of Gateway API resources.
@@ -52,7 +53,7 @@ func BuildGraph(
 	gw := buildGateway(processedGws.Winner, secretMemoryMgr, gc)
 
 	routes := buildRoutesForGateways(validators.HTTPFieldsValidator, state.HTTPRoutes, processedGws.GetAllNsNames())
-	bindRoutesToListeners(routes, gw)
+	bindRoutesToListeners(routes, gw, state.Namespaces)
 	addBackendRefsToRouteRules(routes, state.Services)
 
 	g := &Graph{

--- a/internal/state/graph/httproute.go
+++ b/internal/state/graph/httproute.go
@@ -284,7 +284,9 @@ func bindRouteToListeners(r *Route, gw *Gateway, namespaces map[types.Namespaced
 
 		// Case 2: the parentRef references an ignored Gateway resource.
 
-		if ref.Gateway.Namespace == gw.Source.Namespace && ref.Gateway.Name != gw.Source.Name {
+		referencesWinningGw := ref.Gateway.Namespace == gw.Source.Namespace && ref.Gateway.Name == gw.Source.Name
+
+		if !referencesWinningGw {
 			attachment.FailedCondition = conditions.NewTODO("Gateway is ignored")
 			continue
 		}
@@ -438,10 +440,7 @@ func routeAllowedByListener(
 			if !exists {
 				panic(fmt.Errorf("route namespace %q not found in map", routeNS))
 			}
-			if listener.AllowedRouteLabelSelector.Matches(labels.Set(ns.Labels)) {
-				return true
-			}
-			return false
+			return listener.AllowedRouteLabelSelector.Matches(labels.Set(ns.Labels))
 		}
 	}
 	return true

--- a/internal/state/graph/httproute.go
+++ b/internal/state/graph/httproute.go
@@ -434,7 +434,10 @@ func routeAllowedByListener(
 				return false
 			}
 
-			ns := namespaces[types.NamespacedName{Name: routeNS}]
+			ns, exists := namespaces[types.NamespacedName{Name: routeNS}]
+			if !exists {
+				panic(fmt.Errorf("route namespace %q not found in map", routeNS))
+			}
 			if listener.AllowedRouteLabelSelector.Matches(labels.Set(ns.Labels)) {
 				return true
 			}

--- a/internal/state/graph/httproute_test.go
+++ b/internal/state/graph/httproute_test.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -552,6 +554,12 @@ func TestBindRouteToListeners(t *testing.T) {
 			Name:      "gateway",
 		},
 	}
+	gwDiffNamespace := &v1beta1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "diff-namespace",
+			Name:      "gateway",
+		},
+	}
 
 	createHTTPRouteWithSectionNameAndPort := func(
 		sectionName *v1beta1.SectionName,
@@ -982,13 +990,226 @@ func TestBindRouteToListeners(t *testing.T) {
 			},
 			name: "invalid gateway",
 		},
+		{
+			route: createNormalRoute(),
+			gateway: &Gateway{
+				Source: gw,
+				Valid:  true,
+				Listeners: map[string]*Listener{
+					"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
+						l.Source.AllowedRoutes = &v1beta1.AllowedRoutes{
+							Namespaces: &v1beta1.RouteNamespaces{
+								From: helpers.GetPointer(v1beta1.NamespacesFromSelector),
+							},
+						}
+						allowedLabels := map[string]string{"app": "not-allowed"}
+						l.AllowedRouteLabelSelector = labels.SelectorFromSet(allowedLabels)
+					}),
+				},
+			},
+			expectedSectionNameRefs: []ParentRef{
+				{
+					Idx:     0,
+					Gateway: client.ObjectKeyFromObject(gw),
+					Attachment: &ParentRefAttachmentStatus{
+						Attached:          false,
+						FailedCondition:   conditions.NewRouteNotAllowedByListeners(),
+						AcceptedHostnames: map[string][]string{},
+					},
+				},
+			},
+			expectedGatewayListeners: map[string]*Listener{
+				"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
+					l.Source.AllowedRoutes = &v1beta1.AllowedRoutes{
+						Namespaces: &v1beta1.RouteNamespaces{
+							From: helpers.GetPointer(v1beta1.NamespacesFromSelector),
+						},
+					}
+					allowedLabels := map[string]string{"app": "not-allowed"}
+					l.AllowedRouteLabelSelector = labels.SelectorFromSet(allowedLabels)
+				}),
+			},
+			name: "route not allowed via labels",
+		},
+		{
+			route: createNormalRoute(),
+			gateway: &Gateway{
+				Source: gw,
+				Valid:  true,
+				Listeners: map[string]*Listener{
+					"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
+						l.Source.AllowedRoutes = &v1beta1.AllowedRoutes{
+							Namespaces: &v1beta1.RouteNamespaces{
+								From: helpers.GetPointer(v1beta1.NamespacesFromSelector),
+							},
+						}
+						allowedLabels := map[string]string{"app": "allowed"}
+						l.AllowedRouteLabelSelector = labels.SelectorFromSet(allowedLabels)
+					}),
+				},
+			},
+			expectedSectionNameRefs: []ParentRef{
+				{
+					Idx:     0,
+					Gateway: client.ObjectKeyFromObject(gw),
+					Attachment: &ParentRefAttachmentStatus{
+						Attached: true,
+						AcceptedHostnames: map[string][]string{
+							"listener-80-1": {"foo.example.com"},
+						},
+					},
+				},
+			},
+			expectedGatewayListeners: map[string]*Listener{
+				"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
+					allowedLabels := map[string]string{"app": "allowed"}
+					l.AllowedRouteLabelSelector = labels.SelectorFromSet(allowedLabels)
+					l.Source.AllowedRoutes = &v1beta1.AllowedRoutes{
+						Namespaces: &v1beta1.RouteNamespaces{
+							From: helpers.GetPointer(v1beta1.NamespacesFromSelector),
+						},
+					}
+					l.Routes = map[types.NamespacedName]*Route{
+						client.ObjectKeyFromObject(hr): getLastNormalRoute(),
+					}
+				}),
+			},
+			name: "route allowed via labels",
+		},
+		{
+			route: createNormalRoute(),
+			gateway: &Gateway{
+				Source: gwDiffNamespace,
+				Valid:  true,
+				Listeners: map[string]*Listener{
+					"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
+						l.Source.AllowedRoutes = &v1beta1.AllowedRoutes{
+							Namespaces: &v1beta1.RouteNamespaces{
+								From: helpers.GetPointer(v1beta1.NamespacesFromSame),
+							},
+						}
+					}),
+				},
+			},
+			expectedSectionNameRefs: []ParentRef{
+				{
+					Idx:     0,
+					Gateway: client.ObjectKeyFromObject(gw),
+					Attachment: &ParentRefAttachmentStatus{
+						Attached:          false,
+						FailedCondition:   conditions.NewRouteNotAllowedByListeners(),
+						AcceptedHostnames: map[string][]string{},
+					},
+				},
+			},
+			expectedGatewayListeners: map[string]*Listener{
+				"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
+					l.Source.AllowedRoutes = &v1beta1.AllowedRoutes{
+						Namespaces: &v1beta1.RouteNamespaces{
+							From: helpers.GetPointer(v1beta1.NamespacesFromSame),
+						},
+					}
+				}),
+			},
+			name: "route not allowed via same namespace",
+		},
+		{
+			route: createNormalRoute(),
+			gateway: &Gateway{
+				Source: gw,
+				Valid:  true,
+				Listeners: map[string]*Listener{
+					"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
+						l.Source.AllowedRoutes = &v1beta1.AllowedRoutes{
+							Namespaces: &v1beta1.RouteNamespaces{
+								From: helpers.GetPointer(v1beta1.NamespacesFromSame),
+							},
+						}
+					}),
+				},
+			},
+			expectedSectionNameRefs: []ParentRef{
+				{
+					Idx:     0,
+					Gateway: client.ObjectKeyFromObject(gw),
+					Attachment: &ParentRefAttachmentStatus{
+						Attached: true,
+						AcceptedHostnames: map[string][]string{
+							"listener-80-1": {"foo.example.com"},
+						},
+					},
+				},
+			},
+			expectedGatewayListeners: map[string]*Listener{
+				"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
+					l.Source.AllowedRoutes = &v1beta1.AllowedRoutes{
+						Namespaces: &v1beta1.RouteNamespaces{
+							From: helpers.GetPointer(v1beta1.NamespacesFromSame),
+						},
+					}
+					l.Routes = map[types.NamespacedName]*Route{
+						client.ObjectKeyFromObject(hr): getLastNormalRoute(),
+					}
+				}),
+			},
+			name: "route allowed via same namespace",
+		},
+		{
+			route: createNormalRoute(),
+			gateway: &Gateway{
+				Source: gwDiffNamespace,
+				Valid:  true,
+				Listeners: map[string]*Listener{
+					"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
+						l.Source.AllowedRoutes = &v1beta1.AllowedRoutes{
+							Namespaces: &v1beta1.RouteNamespaces{
+								From: helpers.GetPointer(v1beta1.NamespacesFromAll),
+							},
+						}
+					}),
+				},
+			},
+			expectedSectionNameRefs: []ParentRef{
+				{
+					Idx:     0,
+					Gateway: client.ObjectKeyFromObject(gw),
+					Attachment: &ParentRefAttachmentStatus{
+						Attached: true,
+						AcceptedHostnames: map[string][]string{
+							"listener-80-1": {"foo.example.com"},
+						},
+					},
+				},
+			},
+			expectedGatewayListeners: map[string]*Listener{
+				"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
+					l.Source.AllowedRoutes = &v1beta1.AllowedRoutes{
+						Namespaces: &v1beta1.RouteNamespaces{
+							From: helpers.GetPointer(v1beta1.NamespacesFromAll),
+						},
+					}
+					l.Routes = map[types.NamespacedName]*Route{
+						client.ObjectKeyFromObject(hr): getLastNormalRoute(),
+					}
+				}),
+			},
+			name: "route allowed via all namespaces",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 
-			bindRouteToListeners(test.route, test.gateway)
+			namespaces := map[types.NamespacedName]*v1.Namespace{
+				{Name: "test"}: {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "test",
+						Labels: map[string]string{"app": "allowed"},
+					},
+				},
+			}
+			bindRouteToListeners(test.route, test.gateway, namespaces)
 
 			g.Expect(test.route.ParentRefs).To(Equal(test.expectedSectionNameRefs))
 			g.Expect(helpers.Diff(test.gateway.Listeners, test.expectedGatewayListeners)).To(BeEmpty())

--- a/internal/state/relationship/capturer.go
+++ b/internal/state/relationship/capturer.go
@@ -48,6 +48,10 @@ type (
 	namespaces map[types.NamespacedName]namespaceCfg
 )
 
+func (n namespaceCfg) match() bool {
+	return len(n.gateways) > 0
+}
+
 // CapturerImpl implements the Capturer interface.
 type CapturerImpl struct {
 	routesToServices      routeToServicesMap
@@ -244,8 +248,4 @@ func (c *CapturerImpl) removeGatewayLabelSelector(gatewayName types.NamespacedNa
 		delete(cfg.gateways, gatewayName)
 		c.namespaces[ns] = cfg
 	}
-}
-
-func (n namespaceCfg) match() bool {
-	return len(n.gateways) > 0
 }

--- a/internal/state/relationship/capturer.go
+++ b/internal/state/relationship/capturer.go
@@ -3,11 +3,14 @@ package relationship
 import (
 	v1 "k8s.io/api/core/v1"
 	discoveryV1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/manager/index"
+	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state/graph"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . Capturer
@@ -15,16 +18,17 @@ import (
 // Capturer captures relationships between Kubernetes objects and can be queried for whether a relationship exists
 // for a given object.
 //
-// Currently, it only captures relationships between HTTPRoutes and Services and Services and EndpointSlices,
-// but it can be extended to capture additional relationships.
 // The relationships between HTTPRoutes -> Services are many to 1,
 // so these relationships are tracked using a counter.
 // A Service relationship exists if at least one HTTPRoute references it.
-// An EndpointSlice relationship exists, if its Service owner is referenced by at least one HTTPRoute.
+// An EndpointSlice relationship exists if its Service owner is referenced by at least one HTTPRoute.
+//
+// A Namespace relationship exists if it has labels that match a Gateway listener's label selector.
 type Capturer interface {
 	Capture(obj client.Object)
-	Remove(resourceType client.Object, nsname types.NamespacedName)
-	Exists(resourceType client.Object, nsname types.NamespacedName) bool
+	Remove(resource client.Object, nsname types.NamespacedName)
+	Exists(resource client.Object, nsname types.NamespacedName) bool
+	RelationshipEnded(resource client.Object) bool
 }
 
 type (
@@ -32,21 +36,38 @@ type (
 	routeToServicesMap map[types.NamespacedName]map[types.NamespacedName]struct{}
 	// serviceRefCountMap maps Service names to the number of HTTPRoutes that reference it.
 	serviceRefCountMap map[types.NamespacedName]int
+	// listenerLabelSelectorsMap maps Gateways to the label selectors that their listeners use for allowed routes
+	listenerLabelSelectorsMap map[types.NamespacedName][]labels.Selector
+	// namespaceCfg holds information about a namespace
+	// - labels that it contains
+	// - gateways that reference it (if labels match)
+	// - whether or not it matches a listener's label selector
+	namespaceCfg struct {
+		labelMap map[string]string
+		gateways map[types.NamespacedName]struct{}
+		match    bool
+	}
+	// referencedNamespaces is a collection of namespaces in the system
+	referencedNamespaces map[types.NamespacedName]namespaceCfg
 )
 
 // CapturerImpl implements the Capturer interface.
 type CapturerImpl struct {
-	routesToServices    routeToServicesMap
-	serviceRefCount     serviceRefCountMap
-	endpointSliceOwners map[types.NamespacedName]types.NamespacedName
+	routesToServices       routeToServicesMap
+	serviceRefCount        serviceRefCountMap
+	listenerLabelSelectors listenerLabelSelectorsMap
+	referencedNamespaces   referencedNamespaces
+	endpointSliceOwners    map[types.NamespacedName]types.NamespacedName
 }
 
 // NewCapturerImpl creates a new instance of CapturerImpl.
 func NewCapturerImpl() *CapturerImpl {
 	return &CapturerImpl{
-		routesToServices:    make(map[types.NamespacedName]map[types.NamespacedName]struct{}),
-		serviceRefCount:     make(map[types.NamespacedName]int),
-		endpointSliceOwners: make(map[types.NamespacedName]types.NamespacedName),
+		routesToServices:       make(routeToServicesMap),
+		serviceRefCount:        make(serviceRefCountMap),
+		listenerLabelSelectors: make(listenerLabelSelectorsMap),
+		referencedNamespaces:   make(referencedNamespaces),
+		endpointSliceOwners:    make(map[types.NamespacedName]types.NamespacedName),
 	}
 }
 
@@ -63,29 +84,86 @@ func (c *CapturerImpl) Capture(obj client.Object) {
 				Name:      svcName,
 			}
 		}
+	case *v1beta1.Gateway:
+		var selectors []labels.Selector
+		for _, listener := range o.Spec.Listeners {
+			if selector := graph.GetAllowedRouteLabelSelector(listener); selector != nil {
+				convertedSelector, err := metav1.LabelSelectorAsSelector(selector)
+				if err == nil {
+					selectors = append(selectors, convertedSelector)
+				}
+			}
+		}
+
+		nsname := client.ObjectKeyFromObject(o)
+		if len(selectors) > 0 {
+			c.listenerLabelSelectors[nsname] = selectors
+			for ns, cfg := range c.referencedNamespaces {
+				for _, selector := range selectors {
+					if selector.Matches(labels.Set(cfg.labelMap)) {
+						cfg.match = true
+						cfg.gateways[nsname] = struct{}{}
+						break
+					}
+				}
+				c.referencedNamespaces[ns] = cfg
+			}
+		} else if _, exists := c.listenerLabelSelectors[nsname]; exists {
+			// label selectors existed previously for this gateway, so clean up any references to them
+			c.removeGatewayLabelSelector(nsname)
+		}
+	case *v1.Namespace:
+		nsLabels := o.GetLabels()
+		gateways := c.matchingGateways(nsLabels)
+		nsCfg := namespaceCfg{
+			labelMap: nsLabels,
+			match:    len(gateways) > 0,
+			gateways: gateways,
+		}
+		c.referencedNamespaces[client.ObjectKeyFromObject(o)] = nsCfg
 	}
 }
 
 // Remove removes the relationship for the given object from the CapturerImpl.
-func (c *CapturerImpl) Remove(resourceType client.Object, nsname types.NamespacedName) {
-	switch resourceType.(type) {
+func (c *CapturerImpl) Remove(resource client.Object, nsname types.NamespacedName) {
+	switch resource.(type) {
 	case *v1beta1.HTTPRoute:
 		c.deleteForRoute(nsname)
 	case *discoveryV1.EndpointSlice:
 		delete(c.endpointSliceOwners, nsname)
+	case *v1beta1.Gateway:
+		c.removeGatewayLabelSelector(nsname)
+	case *v1.Namespace:
+		delete(c.referencedNamespaces, nsname)
 	}
 }
 
 // Exists returns true if the given object has a relationship with another object.
-func (c *CapturerImpl) Exists(resourceType client.Object, nsname types.NamespacedName) bool {
-	switch resourceType.(type) {
+func (c *CapturerImpl) Exists(resource client.Object, nsname types.NamespacedName) bool {
+	switch resource.(type) {
 	case *v1.Service:
 		return c.serviceRefCount[nsname] > 0
 	case *discoveryV1.EndpointSlice:
 		svcOwner, exists := c.endpointSliceOwners[nsname]
 		return exists && c.serviceRefCount[svcOwner] > 0
+	case *v1.Namespace:
+		cfg, exists := c.referencedNamespaces[nsname]
+		return exists && cfg.match
 	}
 
+	return false
+}
+
+// RelationshipEnded checks if a relationship previously existed, but no longer does.
+func (c CapturerImpl) RelationshipEnded(resource client.Object) bool {
+	switch o := resource.(type) {
+	case *v1.Namespace:
+		if c.Exists(o, client.ObjectKeyFromObject(o)) {
+			if len(c.matchingGateways(o.GetLabels())) == 0 {
+				return true
+			}
+		}
+	}
 	return false
 }
 
@@ -154,4 +232,29 @@ func getBackendServiceNamesFromRoute(hr *v1beta1.HTTPRoute) map[types.Namespaced
 	}
 
 	return svcNames
+}
+
+// matchingGateways looks through all existing label selectors defined by listeners in a gateway,
+// and if any matches are found, returns a map of those gateways
+func (c *CapturerImpl) matchingGateways(labelMap map[string]string) map[types.NamespacedName]struct{} {
+	gateways := make(map[types.NamespacedName]struct{})
+	for gw, selectors := range c.listenerLabelSelectors {
+		for _, selector := range selectors {
+			if selector.Matches(labels.Set(labelMap)) {
+				gateways[gw] = struct{}{}
+				break
+			}
+		}
+	}
+
+	return gateways
+}
+
+func (c *CapturerImpl) removeGatewayLabelSelector(nsname types.NamespacedName) {
+	delete(c.listenerLabelSelectors, nsname)
+	for ns, cfg := range c.referencedNamespaces {
+		delete(cfg.gateways, nsname)
+		cfg.match = len(cfg.gateways) != 0
+		c.referencedNamespaces[ns] = cfg
+	}
 }

--- a/internal/state/relationship/capturer_test.go
+++ b/internal/state/relationship/capturer_test.go
@@ -319,7 +319,7 @@ var _ = Describe("Capturer", func() {
 		var gw *v1beta1.Gateway
 		var nsNoLabels, ns *v1.Namespace
 
-		BeforeEach(OncePerOrdered, func() {
+		BeforeEach(func() {
 			capturer = relationship.NewCapturerImpl()
 			gw = &v1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/state/relationship/capturer_test.go
+++ b/internal/state/relationship/capturer_test.go
@@ -427,14 +427,14 @@ var _ = Describe("Capturer", func() {
 			})
 		})
 		When("a namespace has its labels removed after being linked", func() {
-			It("reports that a relationship ended", func() {
+			It("reports that a relationship once existed", func() {
 				capturer.Capture(gw)
 				capturer.Capture(ns)
 
 				Expect(capturer.Exists(ns, client.ObjectKeyFromObject(ns))).To(BeTrue())
 
 				ns.Labels = nil
-				Expect(capturer.RelationshipEnded(ns)).To(BeTrue())
+				Expect(capturer.Exists(ns, client.ObjectKeyFromObject(ns))).To(BeTrue())
 
 				capturer.Capture(ns)
 				Expect(capturer.Exists(ns, client.ObjectKeyFromObject(ns))).To(BeFalse())

--- a/internal/state/relationship/capturer_test.go
+++ b/internal/state/relationship/capturer_test.go
@@ -7,6 +7,7 @@ import (
 	discoveryV1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/helpers"
@@ -313,23 +314,135 @@ var _ = Describe("Capturer", func() {
 				})
 			})
 		})
-		Describe("Edge cases", func() {
-			BeforeEach(func() {
-				capturer = relationship.NewCapturerImpl()
+	})
+	Describe("Capture namespace and gateway relationships", func() {
+		var gw *v1beta1.Gateway
+		var nsNoLabels, ns *v1.Namespace
+
+		BeforeEach(OncePerOrdered, func() {
+			capturer = relationship.NewCapturerImpl()
+			gw = &v1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gw",
+				},
+				Spec: v1beta1.GatewaySpec{
+					Listeners: []v1beta1.Listener{
+						{
+							AllowedRoutes: &v1beta1.AllowedRoutes{
+								Namespaces: &v1beta1.RouteNamespaces{
+									From: helpers.GetPointer(v1beta1.NamespacesFromSelector),
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "valid",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			nsNoLabels = &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "no-labels",
+				},
+			}
+			ns = &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "with-labels",
+					Labels: map[string]string{
+						"app": "valid",
+					},
+				},
+			}
+		})
+
+		When("a gateway with label selectors is created, but no namespace has been captured", func() {
+			It("does not report a relationship", func() {
+				capturer.Capture(gw)
+
+				Expect(capturer.Exists(ns, client.ObjectKeyFromObject(ns))).To(BeFalse())
 			})
-			It("Capture does not panic when passed an unsupported resource type", func() {
-				Expect(func() {
-					capturer.Capture(&v1beta1.Gateway{})
-				}).ToNot(Panic())
+		})
+		When("a namespace is created that is not linked to a listener", func() {
+			It("does not report a relationship", func() {
+				capturer.Capture(gw)
+				capturer.Capture(nsNoLabels)
+
+				Expect(capturer.Exists(nsNoLabels, client.ObjectKeyFromObject(nsNoLabels))).To(BeFalse())
 			})
-			It("Remove does not panic when passed an unsupported resource type", func() {
-				Expect(func() {
-					capturer.Remove(&v1beta1.Gateway{}, types.NamespacedName{})
-				}).ToNot(Panic())
+		})
+		When("a namespace is created that is linked to a listener", func() {
+			It("reports a relationship", func() {
+				capturer.Capture(gw)
+				capturer.Capture(ns)
+
+				Expect(capturer.Exists(ns, client.ObjectKeyFromObject(ns))).To(BeTrue())
 			})
-			It("Exist returns false if passed an unsupported resource type", func() {
-				Expect(capturer.Exists(&v1beta1.Gateway{}, types.NamespacedName{})).To(BeFalse())
+		})
+		When("a gateway with label selectors is created after a linked namespace", func() {
+			It("reports a relationship", func() {
+				capturer.Capture(ns)
+				Expect(capturer.Exists(ns, client.ObjectKeyFromObject(ns))).To(BeFalse())
+
+				capturer.Capture(gw)
+				Expect(capturer.Exists(ns, client.ObjectKeyFromObject(ns))).To(BeTrue())
 			})
+		})
+		When("label selectors are removed from gateway", func() {
+			It("does not report a relationship", func() {
+				capturer.Capture(gw)
+				capturer.Capture(ns)
+
+				Expect(capturer.Exists(ns, client.ObjectKeyFromObject(ns))).To(BeTrue())
+
+				gw.Spec.Listeners[0].AllowedRoutes = nil
+				capturer.Capture(gw)
+				Expect(capturer.Exists(ns, client.ObjectKeyFromObject(ns))).To(BeFalse())
+			})
+		})
+		When("gateway is deleted", func() {
+			It("does not report a relationship", func() {
+				capturer.Capture(gw)
+				capturer.Capture(ns)
+
+				Expect(capturer.Exists(ns, client.ObjectKeyFromObject(ns))).To(BeTrue())
+
+				capturer.Remove(gw, client.ObjectKeyFromObject(gw))
+				Expect(capturer.Exists(ns, client.ObjectKeyFromObject(ns))).To(BeFalse())
+			})
+		})
+		When("a namespace has its labels removed after being linked", func() {
+			It("reports that a relationship ended", func() {
+				capturer.Capture(gw)
+				capturer.Capture(ns)
+
+				Expect(capturer.Exists(ns, client.ObjectKeyFromObject(ns))).To(BeTrue())
+
+				ns.Labels = nil
+				Expect(capturer.RelationshipEnded(ns)).To(BeTrue())
+
+				capturer.Capture(ns)
+				Expect(capturer.Exists(ns, client.ObjectKeyFromObject(ns))).To(BeFalse())
+			})
+		})
+	})
+	Describe("Edge cases", func() {
+		BeforeEach(func() {
+			capturer = relationship.NewCapturerImpl()
+		})
+		It("Capture does not panic when passed an unsupported resource type", func() {
+			Expect(func() {
+				capturer.Capture(&v1beta1.GatewayClass{})
+			}).ToNot(Panic())
+		})
+		It("Remove does not panic when passed an unsupported resource type", func() {
+			Expect(func() {
+				capturer.Remove(&v1beta1.GatewayClass{}, types.NamespacedName{})
+			}).ToNot(Panic())
+		})
+		It("Exist returns false if passed an unsupported resource type", func() {
+			Expect(capturer.Exists(&v1beta1.GatewayClass{}, types.NamespacedName{})).To(BeFalse())
 		})
 	})
 })

--- a/internal/state/relationship/capturer_test.go
+++ b/internal/state/relationship/capturer_test.go
@@ -401,6 +401,20 @@ var _ = Describe("Capturer", func() {
 				Expect(capturer.Exists(ns, client.ObjectKeyFromObject(ns))).To(BeFalse())
 			})
 		})
+		When("gateway changes its labels", func() {
+			It("does not report a relationship", func() {
+				capturer.Capture(gw)
+				capturer.Capture(ns)
+
+				Expect(capturer.Exists(ns, client.ObjectKeyFromObject(ns))).To(BeTrue())
+
+				gw.Spec.Listeners[0].AllowedRoutes.Namespaces.Selector.MatchLabels = map[string]string{
+					"app": "new-value",
+				}
+				capturer.Capture(gw)
+				Expect(capturer.Exists(ns, client.ObjectKeyFromObject(ns))).To(BeFalse())
+			})
+		})
 		When("gateway is deleted", func() {
 			It("does not report a relationship", func() {
 				capturer.Capture(gw)

--- a/internal/state/relationship/relationshipfakes/fake_capturer.go
+++ b/internal/state/relationship/relationshipfakes/fake_capturer.go
@@ -27,6 +27,17 @@ type FakeCapturer struct {
 	existsReturnsOnCall map[int]struct {
 		result1 bool
 	}
+	RelationshipEndedStub        func(client.Object) bool
+	relationshipEndedMutex       sync.RWMutex
+	relationshipEndedArgsForCall []struct {
+		arg1 client.Object
+	}
+	relationshipEndedReturns struct {
+		result1 bool
+	}
+	relationshipEndedReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	RemoveStub        func(client.Object, types.NamespacedName)
 	removeMutex       sync.RWMutex
 	removeArgsForCall []struct {
@@ -131,6 +142,67 @@ func (fake *FakeCapturer) ExistsReturnsOnCall(i int, result1 bool) {
 	}{result1}
 }
 
+func (fake *FakeCapturer) RelationshipEnded(arg1 client.Object) bool {
+	fake.relationshipEndedMutex.Lock()
+	ret, specificReturn := fake.relationshipEndedReturnsOnCall[len(fake.relationshipEndedArgsForCall)]
+	fake.relationshipEndedArgsForCall = append(fake.relationshipEndedArgsForCall, struct {
+		arg1 client.Object
+	}{arg1})
+	stub := fake.RelationshipEndedStub
+	fakeReturns := fake.relationshipEndedReturns
+	fake.recordInvocation("RelationshipEnded", []interface{}{arg1})
+	fake.relationshipEndedMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeCapturer) RelationshipEndedCallCount() int {
+	fake.relationshipEndedMutex.RLock()
+	defer fake.relationshipEndedMutex.RUnlock()
+	return len(fake.relationshipEndedArgsForCall)
+}
+
+func (fake *FakeCapturer) RelationshipEndedCalls(stub func(client.Object) bool) {
+	fake.relationshipEndedMutex.Lock()
+	defer fake.relationshipEndedMutex.Unlock()
+	fake.RelationshipEndedStub = stub
+}
+
+func (fake *FakeCapturer) RelationshipEndedArgsForCall(i int) client.Object {
+	fake.relationshipEndedMutex.RLock()
+	defer fake.relationshipEndedMutex.RUnlock()
+	argsForCall := fake.relationshipEndedArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeCapturer) RelationshipEndedReturns(result1 bool) {
+	fake.relationshipEndedMutex.Lock()
+	defer fake.relationshipEndedMutex.Unlock()
+	fake.RelationshipEndedStub = nil
+	fake.relationshipEndedReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeCapturer) RelationshipEndedReturnsOnCall(i int, result1 bool) {
+	fake.relationshipEndedMutex.Lock()
+	defer fake.relationshipEndedMutex.Unlock()
+	fake.RelationshipEndedStub = nil
+	if fake.relationshipEndedReturnsOnCall == nil {
+		fake.relationshipEndedReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.relationshipEndedReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
+}
+
 func (fake *FakeCapturer) Remove(arg1 client.Object, arg2 types.NamespacedName) {
 	fake.removeMutex.Lock()
 	fake.removeArgsForCall = append(fake.removeArgsForCall, struct {
@@ -171,6 +243,8 @@ func (fake *FakeCapturer) Invocations() map[string][][]interface{} {
 	defer fake.captureMutex.RUnlock()
 	fake.existsMutex.RLock()
 	defer fake.existsMutex.RUnlock()
+	fake.relationshipEndedMutex.RLock()
+	defer fake.relationshipEndedMutex.RUnlock()
 	fake.removeMutex.RLock()
 	defer fake.removeMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -196,13 +196,13 @@ func (s *changeTrackingUpdater) Upsert(obj client.Object) {
 	s.assertSupportedGVK(s.extractGVK(obj))
 
 	changingUpsert := s.upsert(obj)
-	relationshipEnded := s.capturer.RelationshipEnded(obj)
+	relationshipExisted := s.capturer.Exists(obj, client.ObjectKeyFromObject(obj))
 
 	s.capturer.Capture(obj)
 
 	relationshipExists := s.capturer.Exists(obj, client.ObjectKeyFromObject(obj))
 
-	s.changed = s.changed || changingUpsert || relationshipEnded || relationshipExists
+	s.changed = s.changed || changingUpsert || relationshipExisted || relationshipExists
 }
 
 func (s *changeTrackingUpdater) delete(objType client.Object, nsname types.NamespacedName) (changed bool) {

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -128,9 +128,9 @@ type changeTrackingUpdater struct {
 	capturer relationship.Capturer
 
 	extractGVK              extractGVKFunc
-	supportedGKVs           gvkList
-	trackedUpsertDeleteGKVs gvkList
-	persistedGKVs           gvkList
+	supportedGVKs           gvkList
+	trackedUpsertDeleteGVKs gvkList
+	persistedGVKs           gvkList
 
 	changed bool
 }
@@ -141,22 +141,22 @@ func newChangeTrackingUpdater(
 	objectTypeCfgs []changeTrackingUpdaterObjectTypeCfg,
 ) *changeTrackingUpdater {
 	var (
-		supportedGKVs           gvkList
-		trackedUpsertDeleteGKVs gvkList
-		persistedGKVs           gvkList
+		supportedGVKs           gvkList
+		trackedUpsertDeleteGVKs gvkList
+		persistedGVKs           gvkList
 
 		stores = make(map[schema.GroupVersionKind]objectStore)
 	)
 
 	for _, cfg := range objectTypeCfgs {
-		supportedGKVs = append(supportedGKVs, cfg.gvk)
+		supportedGVKs = append(supportedGVKs, cfg.gvk)
 
 		if cfg.trackUpsertDelete {
-			trackedUpsertDeleteGKVs = append(trackedUpsertDeleteGKVs, cfg.gvk)
+			trackedUpsertDeleteGVKs = append(trackedUpsertDeleteGVKs, cfg.gvk)
 		}
 
 		if cfg.store != nil {
-			persistedGKVs = append(persistedGKVs, cfg.gvk)
+			persistedGVKs = append(persistedGVKs, cfg.gvk)
 			stores[cfg.gvk] = cfg.store
 		}
 	}
@@ -164,28 +164,28 @@ func newChangeTrackingUpdater(
 	return &changeTrackingUpdater{
 		store:                   newMultiObjectStore(stores, extractGVK),
 		extractGVK:              extractGVK,
-		supportedGKVs:           supportedGKVs,
-		trackedUpsertDeleteGKVs: trackedUpsertDeleteGKVs,
-		persistedGKVs:           persistedGKVs,
+		supportedGVKs:           supportedGVKs,
+		trackedUpsertDeleteGVKs: trackedUpsertDeleteGVKs,
+		persistedGVKs:           persistedGVKs,
 		capturer:                capturer,
 	}
 }
 
 func (s *changeTrackingUpdater) assertSupportedGVK(gvk schema.GroupVersionKind) {
-	if !s.supportedGKVs.contains(gvk) {
+	if !s.supportedGVKs.contains(gvk) {
 		panic(fmt.Errorf("unsupported GVK %v", gvk))
 	}
 }
 
 func (s *changeTrackingUpdater) upsert(obj client.Object) (changed bool) {
-	if !s.persistedGKVs.contains(s.extractGVK(obj)) {
+	if !s.persistedGVKs.contains(s.extractGVK(obj)) {
 		return false
 	}
 
 	oldObj, exist := s.store.get(obj, client.ObjectKeyFromObject(obj))
 	s.store.upsert(obj)
 
-	if !s.trackedUpsertDeleteGKVs.contains(s.extractGVK(obj)) {
+	if !s.trackedUpsertDeleteGVKs.contains(s.extractGVK(obj)) {
 		return false
 	}
 
@@ -196,15 +196,19 @@ func (s *changeTrackingUpdater) Upsert(obj client.Object) {
 	s.assertSupportedGVK(s.extractGVK(obj))
 
 	changingUpsert := s.upsert(obj)
+	relationshipEnded := s.capturer.RelationshipEnded(obj)
+
 	s.capturer.Capture(obj)
 
-	s.changed = s.changed || changingUpsert || s.capturer.Exists(obj, client.ObjectKeyFromObject(obj))
+	relationshipExists := s.capturer.Exists(obj, client.ObjectKeyFromObject(obj))
+
+	s.changed = s.changed || changingUpsert || relationshipEnded || relationshipExists
 }
 
 func (s *changeTrackingUpdater) delete(objType client.Object, nsname types.NamespacedName) (changed bool) {
 	objTypeGVK := s.extractGVK(objType)
 
-	if !s.persistedGKVs.contains(objTypeGVK) {
+	if !s.persistedGVKs.contains(objTypeGVK) {
 		return false
 	}
 
@@ -214,7 +218,7 @@ func (s *changeTrackingUpdater) delete(objType client.Object, nsname types.Names
 	}
 	s.store.delete(objType, nsname)
 
-	return s.trackedUpsertDeleteGKVs.contains(objTypeGVK)
+	return s.trackedUpsertDeleteGVKs.contains(objTypeGVK)
 }
 
 func (s *changeTrackingUpdater) Delete(objType client.Object, nsname types.NamespacedName) {


### PR DESCRIPTION
Problem: As a Cluster Admin I want to restrict what elements of my system have access to Gateway ingress, I want to create predictable isolation across GatewayClasses and dataplanes, I want to help App Devs by restricting Route binding so they see predictable attachments and not unintentional or unexpected traffic routing.

Conversely, I want to allow App Devs in different organizations access to my Gateway controller by specifying All namespaces, a selection, or only same namespaces are supported.

Solution: Add support for specifying AllowedRoutes in Listeners. A user can now allow/disallow routes based on namespace. Either all namespaces, same namespace, or label selectors can be used to determine which routes are allowed.

Testing: Manually verified adding/removing labels to namespaces triggers updates and sets the status properly.

Closes #475 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
