### PR TITLE
Fix binding to multiple listeners with empty section name

### DIFF
--- a/internal/state/graph/httproute.go
+++ b/internal/state/graph/httproute.go
@@ -338,7 +338,7 @@ func tryToAttachRouteToListeners(
 
 	attached := false
 	for _, l := range validListeners {
-		attached = attached || bind(l)
+		attached = bind(l) || attached
 	}
 
 	if !attached {

--- a/internal/state/graph/httproute_test.go
+++ b/internal/state/graph/httproute_test.go
@@ -751,6 +751,9 @@ func TestBindRouteToListeners(t *testing.T) {
 				Valid:  true,
 				Listeners: map[string]*Listener{
 					"listener-80-1": createListener("listener-80-1"),
+					"listener-80-2": createModifiedListener("listener-80-2", func(l *Listener) {
+						l.Source.Hostname = nil
+					}),
 				},
 			},
 			expectedSectionNameRefs: []ParentRef{
@@ -761,6 +764,7 @@ func TestBindRouteToListeners(t *testing.T) {
 						Attached: true,
 						AcceptedHostnames: map[string][]string{
 							"listener-80-1": {"foo.example.com"},
+							"listener-80-2": {"foo.example.com"},
 						},
 					},
 				},
@@ -770,6 +774,12 @@ func TestBindRouteToListeners(t *testing.T) {
 					l.Routes = map[types.NamespacedName]*Route{
 						client.ObjectKeyFromObject(hr): routeWithEmptySectionName,
 					}
+				}),
+				"listener-80-2": createModifiedListener("listener-80-2", func(l *Listener) {
+					l.Routes = map[types.NamespacedName]*Route{
+						client.ObjectKeyFromObject(hr): routeWithEmptySectionName,
+					}
+					l.Source.Hostname = nil
 				}),
 			},
 			name: "section name is empty",


### PR DESCRIPTION
## Proposed Changes

A refactor of the route binding logic done in #633 introduced a bug with empty section name. This PR fixes that bug. 

Problem: If an HTTPRoute has a parentRef with an empty section name, and the referenced gateway has multiple valid listeners, the route would only bind to the first listener.

Solution: Attempt to bind to every valid listener in the referenced Gateway.

Testing: Added a unit test that reproduced the issue and manually verified that a route with empty section name can attach to multiple valid listeners. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
