### PR TITLE
Add enhancement proposal to list of possible issue types

### DIFF
--- a/ISSUE_LIFECYCLE.md
+++ b/ISSUE_LIFECYCLE.md
@@ -20,9 +20,9 @@ lifecycle.)
 
    `bug`: The implementation of a feature is not correct.
 
-   `enhancement`:  An enhancement, tackling technical debt, documentation changes, or improving existing features. In cases
-   where the enhancement requires an [Enhancement Proposal](/docs/proposals/README.md), the additional
-   label `enhancement-proposal` will be added.
+   `enhancement`:  An enhancement, tackling technical debt, documentation changes, or improving existing features.
+
+   `enhancement-proposal`: Enhancements that require an [Enhancement Proposal](/docs/proposals/README.md).
 
    `question`: The owner converts the issue to a github discussion and engages the creator.
 


### PR DESCRIPTION
### Proposed changes

Add `enhancement-proposal` to the list of issue types in the issue lifecycle doc. 

Problem: The issue lifecycle document does not specify enhancement proposals as an issue type. It lumps enhancement proposals under enhancements.

Solution: Add enhancement proposals as an issue type. 

Testing: None

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
