### PR TITLE
Improve provisioner docs

### DIFF
--- a/conformance/provisioner/provisioner.md
+++ b/conformance/provisioner/provisioner.md
@@ -15,9 +15,13 @@ Global Flags:
       --gatewayclass string        The name of the GatewayClass resource. Every NGINX Gateway must have a unique corresponding GatewayClass resource. (default "")
 ```
 
-Provisioner is not meant to be used in production yet (see this issue for more details
+> Note: Provisioner is not ready for production yet (see this issue for more details
 https://github.com/nginxinc/nginx-kubernetes-gateway/issues/634). However, it can be used in the Gateway API conformance
 tests, which expect a Gateway API implementation to provision an independent data plane per Gateway.
+
+> Note: Provisioner uses [this manifest](/deploy/manifests/deployment.yaml) to create an NKG static mode Deployment.
+That manifests gets included into the NKG binary during the NKG build. To customize the Deployment, modify the manifest 
+and **re-build** NKG again.
 
 How to deploy:
 

--- a/conformance/provisioner/provisioner.md
+++ b/conformance/provisioner/provisioner.md
@@ -20,7 +20,7 @@ https://github.com/nginxinc/nginx-kubernetes-gateway/issues/634). However, it ca
 tests, which expect a Gateway API implementation to provision an independent data plane per Gateway.
 
 > Note: Provisioner uses [this manifest](/deploy/manifests/deployment.yaml) to create an NKG static mode Deployment.
-That manifests gets included into the NKG binary during the NKG build. To customize the Deployment, modify the manifest 
+This manifest gets included into the NKG binary during the NKG build. To customize the Deployment, modify the manifest 
 and **re-build** NKG again.
 
 How to deploy:

--- a/conformance/provisioner/provisioner.md
+++ b/conformance/provisioner/provisioner.md
@@ -21,7 +21,7 @@ tests, which expect a Gateway API implementation to provision an independent dat
 
 > Note: Provisioner uses [this manifest](/deploy/manifests/deployment.yaml) to create an NKG static mode Deployment.
 This manifest gets included into the NKG binary during the NKG build. To customize the Deployment, modify the manifest 
-and **re-build** NKG again.
+and **re-build** NKG.
 
 How to deploy:
 


### PR DESCRIPTION
### Proposed changes

Problem:
It is not obvious that it is necessary to re-build the NKG image to customize the static mode Deployment, which the provisioner uses.

Solution:
Make the docs clearer.


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
