### PR TITLE
Support custom listener ports

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -13,13 +13,14 @@ List available commands:
 ```bash
 $ make
 
-build-test-image               Build conformance test image
+build-test-runner-image        Build conformance test runner image
 create-kind-cluster            Create a kind cluster
 delete-kind-cluster            Delete kind cluster
 help                           Display this help
-install-nkg                    Install NKG on configured kind cluster
+install-nkg                    Install NKG with provisioner on configured kind cluster
+prepare-nkg                    Build and load NKG container on configured kind cluster
 run-conformance-tests          Run conformance tests
-uninstall-nkg                  Uninstall NKG from configured kind cluster
+uninstall-nkg                  Uninstall NKG on configured kind cluster
 update-test-kind-config        Update kind config
 ```
 ### Step 1 - Create a kind Cluster

--- a/deploy/manifests/service/loadbalancer-aws-nlb.yaml
+++ b/deploy/manifests/service/loadbalancer-aws-nlb.yaml
@@ -7,7 +7,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 spec:
   type: LoadBalancer
-  ports:
+  ports: # Update the following ports to match your Gateway Listener ports
   - port: 80
     targetPort: 80
     protocol: TCP

--- a/deploy/manifests/service/loadbalancer-aws-nlb.yaml
+++ b/deploy/manifests/service/loadbalancer-aws-nlb.yaml
@@ -12,5 +12,9 @@ spec:
     targetPort: 80
     protocol: TCP
     name: http
+  - port: 443
+    targetPort: 443
+    protocol: TCP
+    name: https
   selector:
     app: nginx-gateway

--- a/deploy/manifests/service/loadbalancer.yaml
+++ b/deploy/manifests/service/loadbalancer.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
-  ports:
+  ports: # Update the following ports to match your Gateway Listener ports
   - port: 80
     targetPort: 80
     protocol: TCP

--- a/deploy/manifests/service/nodeport.yaml
+++ b/deploy/manifests/service/nodeport.yaml
@@ -10,5 +10,9 @@ spec:
     targetPort: 80
     protocol: TCP
     name: http
+  - port: 443
+    targetPort: 443
+    protocol: TCP
+    name: https
   selector:
     app: nginx-gateway

--- a/deploy/manifests/service/nodeport.yaml
+++ b/deploy/manifests/service/nodeport.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: nginx-gateway
 spec:
   type: NodePort 
-  ports:
+  ports: # Update the following ports to match your Gateway Listener ports
   - port: 80
     targetPort: 80
     protocol: TCP

--- a/docs/gateway-api-compatibility.md
+++ b/docs/gateway-api-compatibility.md
@@ -58,7 +58,7 @@ Fields:
     * `listeners`
         * `name` - supported.
         * `hostname` - partially supported. Wildcard hostnames like `*.example.com` are not yet supported.
-        * `port` - partially supported. Allowed values: `80` for HTTP listeners and `443` for HTTPS listeners.
+        * `port` - supported. 
         * `protocol` - partially supported. Allowed values: `HTTP`, `HTTPS`.
         * `tls`
           * `mode` - partially supported. Allowed value: `Terminate`.
@@ -87,7 +87,6 @@ Fields:
       * `Accepted/False/UnsupportedProtocol`
       * `Accepted/False/InvalidCertificateRef`
       * `Accepted/False/HostnameConflict`
-      * `Accepted/False/PortUnavailable`
       * `Accepted/False/UnsupportedValue`: Custom reason for when a value of a field in a Listener is invalid or not supported.
       * `Accepted/False/GatewayConflict`: Custom reason for when the Gateway is ignored due to a conflicting Gateway. NKG only supports a single Gateway.
       * `ResolvedRefs/True/ResolvedRefs`

--- a/docs/gateway-api-compatibility.md
+++ b/docs/gateway-api-compatibility.md
@@ -86,12 +86,12 @@ Fields:
       * `Accepted/True/Accepted`
       * `Accepted/False/UnsupportedProtocol`
       * `Accepted/False/InvalidCertificateRef`
-      * `Accepted/False/HostnameConflict`
+      * `Accepted/False/ProtocolConflict`
       * `Accepted/False/UnsupportedValue`: Custom reason for when a value of a field in a Listener is invalid or not supported.
       * `Accepted/False/GatewayConflict`: Custom reason for when the Gateway is ignored due to a conflicting Gateway. NKG only supports a single Gateway.
       * `ResolvedRefs/True/ResolvedRefs`
       * `ResolvedRefs/False/InvalidCertificateRef`
-      * `Conflicted/True/HostnameConflict`
+      * `Conflicted/True/ProtocolConflict`
       * `Conflicted/False/NoConflicts`
 
 ### HTTPRoute

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -73,7 +73,7 @@ You can gain access to NGINX Kubernetes Gateway by creating a `NodePort` Service
 
 > Important
 > 
-> The Service manifests expose NGINX Kubernetes Gateway on ports 80 and 443. If you'd like to use different ports, please
+> The Service manifests expose NGINX Kubernetes Gateway on ports 80 and 443, which exposes any Gateway [Listener](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.Listener) configured for those ports. If you'd like to use different ports in your listeners,
 > update the manifests accordingly. 
 
 ### Create a NodePort Service

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,6 +71,11 @@ This guide walks you through how to install NGINX Kubernetes Gateway on a generi
 
 You can gain access to NGINX Kubernetes Gateway by creating a `NodePort` Service or a `LoadBalancer` Service.
 
+> Important
+> 
+> The Service manifests expose NGINX Kubernetes Gateway on ports 80 and 443. If you'd like to use different ports, please
+> update the manifests accordingly. 
+
 ### Create a NodePort Service
 
 Create a Service with type `NodePort`:

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -56,6 +56,9 @@ func Start(cfg config.Config) error {
 	options := manager.Options{
 		Scheme: scheme,
 		Logger: logger,
+		// We disable the metrics server because it listens on port 8080.
+		// Once we add support for Prometheus, we can make this port configurable by the user.
+		MetricsBindAddress: "0",
 	}
 
 	eventCh := make(chan interface{})

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -56,7 +56,7 @@ func Start(cfg config.Config) error {
 	options := manager.Options{
 		Scheme: scheme,
 		Logger: logger,
-		// We disable the metrics server because it listens on port 8080.
+		// We disable the metrics server because we reserve all ports (1-65535) for the data plane.
 		// Once we add support for Prometheus, we can make this port configurable by the user.
 		MetricsBindAddress: "0",
 	}

--- a/internal/nginx/config/http/config.go
+++ b/internal/nginx/config/http/config.go
@@ -7,6 +7,7 @@ type Server struct {
 	Locations     []Location
 	IsDefaultHTTP bool
 	IsDefaultSSL  bool
+	Port          int32
 }
 
 // Location holds all configuration for an HTTP location.

--- a/internal/nginx/config/servers_template.go
+++ b/internal/nginx/config/servers_template.go
@@ -2,20 +2,20 @@ package config
 
 var serversTemplateText = `
 {{- range $s := . -}}
-	{{ if $s.IsDefaultSSL -}}
+    {{ if $s.IsDefaultSSL -}}
 server {
-	listen {{ $s.Port }} ssl default_server;
+    listen {{ $s.Port }} ssl default_server;
 
-	ssl_reject_handshake on;
+    ssl_reject_handshake on;
 }
-	{{- else if $s.IsDefaultHTTP }}
+    {{- else if $s.IsDefaultHTTP }}
 server {
-	listen {{ $s.Port }} default_server;
+    listen {{ $s.Port }} default_server;
 
-	default_type text/html;
-	return 404;
+    default_type text/html;
+    return 404;
 }
-	{{- else }}
+    {{- else }}
 server {
         {{- if $s.SSL }}
     listen {{ $s.Port }} ssl;
@@ -29,31 +29,31 @@ server {
     listen {{ $s.Port }};
         {{- end }}
 
-	server_name {{ $s.ServerName }};
+    server_name {{ $s.ServerName }};
 
-		{{ range $l := $s.Locations }}
-	location {{ if $l.Exact }}= {{ end }}{{ $l.Path }} {
-		{{ if $l.Internal -}}
-		internal;
-		{{ end }}
+        {{ range $l := $s.Locations }}
+    location {{ if $l.Exact }}= {{ end }}{{ $l.Path }} {
+        {{ if $l.Internal -}}
+        internal;
+        {{ end }}
 
-		{{- if $l.Return -}}
-		return {{ $l.Return.Code }} "{{ $l.Return.Body }}";
-		{{ end }}
+        {{- if $l.Return -}}
+        return {{ $l.Return.Code }} "{{ $l.Return.Body }}";
+        {{ end }}
 
-		{{- if $l.HTTPMatchVar -}}
-		set $http_matches {{ $l.HTTPMatchVar | printf "%q" }};
-		js_content httpmatches.redirect;
-		{{ end }}
+        {{- if $l.HTTPMatchVar -}}
+        set $http_matches {{ $l.HTTPMatchVar | printf "%q" }};
+        js_content httpmatches.redirect;
+        {{ end }}
 
-		{{- if $l.ProxyPass -}}
-		proxy_set_header Host $host;
-		proxy_pass {{ $l.ProxyPass }}$request_uri;
-		{{- end }}
-	}
-		{{ end }}
+        {{- if $l.ProxyPass -}}
+        proxy_set_header Host $host;
+        proxy_pass {{ $l.ProxyPass }}$request_uri;
+        {{- end }}
+    }
+        {{ end }}
 }
-	{{- end }}
+    {{- end }}
 {{ end }}
 server {
     listen unix:/var/lib/nginx/nginx-502-server.sock;

--- a/internal/nginx/config/servers_template.go
+++ b/internal/nginx/config/servers_template.go
@@ -1,31 +1,33 @@
 package config
 
 var serversTemplateText = `
-{{ range $s := . -}}
+{{- range $s := . -}}
 	{{ if $s.IsDefaultSSL -}}
 server {
-	listen 443 ssl default_server;
+	listen {{ $s.Port }} ssl default_server;
 
 	ssl_reject_handshake on;
 }
 	{{- else if $s.IsDefaultHTTP }}
 server {
-	listen 80 default_server;
+	listen {{ $s.Port }} default_server;
 
 	default_type text/html;
 	return 404;
 }
 	{{- else }}
 server {
-		{{- if $s.SSL }}
-	listen 443 ssl;
-	ssl_certificate {{ $s.SSL.Certificate }};
-	ssl_certificate_key {{ $s.SSL.CertificateKey }};
+        {{- if $s.SSL }}
+    listen {{ $s.Port }} ssl;
+    ssl_certificate {{ $s.SSL.Certificate }};
+    ssl_certificate_key {{ $s.SSL.CertificateKey }};
 
-	if ($ssl_server_name != $host) {
-		return 421;
-	}
-		{{- end }}
+    if ($ssl_server_name != $host) {
+        return 421;
+    }
+        {{- else }}
+    listen {{ $s.Port }};
+        {{- end }}
 
 	server_name {{ $s.ServerName }};
 

--- a/internal/nginx/config/upstreams_template.go
+++ b/internal/nginx/config/upstreams_template.go
@@ -12,5 +12,5 @@ upstream {{ $u.Name }} {
     server {{ $server.Address }};
     {{- end }}
 }
-{{ end }}
+{{ end -}}
 `

--- a/internal/state/change_processor_test.go
+++ b/internal/state/change_processor_test.go
@@ -1590,6 +1590,16 @@ var _ = Describe("ChangeProcessor", func() {
 						}
 					}),
 				),
+				Entry("listener hostnames conflict",
+					createInvalidGateway(func(gw *v1beta1.Gateway) {
+						gw.Spec.Listeners = append(gw.Spec.Listeners, v1beta1.Listener{
+							Name:     "listener-80-2",
+							Hostname: nil,
+							Port:     80,
+							Protocol: v1beta1.HTTPProtocolType,
+						})
+					}),
+				),
 			)
 		})
 	})

--- a/internal/state/conditions/conditions.go
+++ b/internal/state/conditions/conditions.go
@@ -258,16 +258,6 @@ func NewDefaultListenerConditions() []Condition {
 	}
 }
 
-// NewListenerPortUnavailable returns a Condition that indicates a port is unavailable in a Listener.
-func NewListenerPortUnavailable(msg string) Condition {
-	return Condition{
-		Type:    string(v1beta1.ListenerConditionAccepted),
-		Status:  metav1.ConditionFalse,
-		Reason:  string(v1beta1.ListenerReasonPortUnavailable),
-		Message: msg,
-	}
-}
-
 // NewListenerAccepted returns a Condition that indicates that the Listener is accepted.
 func NewListenerAccepted() Condition {
 	return Condition{

--- a/internal/state/conditions/conditions.go
+++ b/internal/state/conditions/conditions.go
@@ -317,19 +317,20 @@ func NewListenerInvalidCertificateRef(msg string) []Condition {
 	}
 }
 
-// NewListenerConflictedHostname returns Conditions that indicate that a hostname of a Listener is conflicted.
-func NewListenerConflictedHostname(msg string) []Condition {
+// NewListenerProtocolConflict returns Conditions that indicate multiple Listeners are specified with the same
+// Listener port number, but have conflicting protocol specifications.
+func NewListenerProtocolConflict(msg string) []Condition {
 	return []Condition{
 		{
 			Type:    string(v1beta1.ListenerConditionAccepted),
 			Status:  metav1.ConditionFalse,
-			Reason:  string(v1beta1.ListenerReasonHostnameConflict),
+			Reason:  string(v1beta1.ListenerReasonProtocolConflict),
 			Message: msg,
 		},
 		{
 			Type:    string(v1beta1.ListenerConditionConflicted),
 			Status:  metav1.ConditionTrue,
-			Reason:  string(v1beta1.ListenerReasonHostnameConflict),
+			Reason:  string(v1beta1.ListenerReasonProtocolConflict),
 			Message: msg,
 		},
 	}

--- a/internal/state/dataplane/configuration.go
+++ b/internal/state/dataplane/configuration.go
@@ -426,11 +426,11 @@ func (hpr *hostPathRules) buildServers() []VirtualServer {
 }
 
 // maxServerCount returns the maximum number of VirtualServers that can be built from the host path rules.
-// to calculate max # of servers we add up:
-// - # of hostnames
-// - # of https listeners - this is to account for https wildcard default servers
-// - default server - for every hostPathRules we generate 1 default server.
 func (hpr *hostPathRules) maxServerCount() int {
+	// to calculate max # of servers we add up:
+	// - # of hostnames
+	// - # of https listeners - this is to account for https wildcard default servers
+	// - default server - for every hostPathRules we generate 1 default server
 	return len(hpr.rulesPerHost) + len(hpr.httpsListeners) + 1
 }
 

--- a/internal/state/dataplane/configuration.go
+++ b/internal/state/dataplane/configuration.go
@@ -23,10 +23,8 @@ const (
 // Configuration is an intermediate representation of dataplane configuration.
 type Configuration struct {
 	// HTTPServers holds all HTTPServers.
-	// We assume that all servers are HTTP and listen on port 80.
 	HTTPServers []VirtualServer
 	// SSLServers holds all SSLServers.
-	// We assume that all SSL servers listen on port 443.
 	SSLServers []VirtualServer
 	// Upstreams holds all unique Upstreams.
 	Upstreams []Upstream
@@ -44,6 +42,8 @@ type VirtualServer struct {
 	PathRules []PathRule
 	// IsDefault indicates whether the server is the default server.
 	IsDefault bool
+	// Port is the port of the server.
+	Port int32
 }
 
 type Upstream struct {
@@ -217,14 +217,19 @@ func newBackendGroup(refs []graph.BackendRef, sourceNsName types.NamespacedName,
 }
 
 func buildServers(listeners map[string]*graph.Listener) (http, ssl []VirtualServer) {
-	rulesForProtocol := map[v1beta1.ProtocolType]*hostPathRules{
-		v1beta1.HTTPProtocolType:  newHostPathRules(),
-		v1beta1.HTTPSProtocolType: newHostPathRules(),
+	rulesForProtocol := map[v1beta1.ProtocolType]portPathRules{
+		v1beta1.HTTPProtocolType:  make(portPathRules),
+		v1beta1.HTTPSProtocolType: make(portPathRules),
 	}
 
 	for _, l := range listeners {
 		if l.Valid {
-			rules := rulesForProtocol[l.Source.Protocol]
+			rules := rulesForProtocol[l.Source.Protocol][l.Source.Port]
+			if rules == nil {
+				rules = newHostPathRules()
+				rulesForProtocol[l.Source.Protocol][l.Source.Port] = rules
+			}
+
 			rules.upsertListener(l)
 		}
 	}
@@ -233,6 +238,24 @@ func buildServers(listeners map[string]*graph.Listener) (http, ssl []VirtualServ
 	sslRules := rulesForProtocol[v1beta1.HTTPSProtocolType]
 
 	return httpRules.buildServers(), sslRules.buildServers()
+}
+
+// portPathRules keeps track of hostPathRules per port
+type portPathRules map[v1beta1.PortNumber]*hostPathRules
+
+func (p portPathRules) buildServers() []VirtualServer {
+	serverCount := 0
+	for _, rules := range p {
+		serverCount += len(rules.rulesPerHost) + len(rules.httpsListeners)
+	}
+
+	servers := make([]VirtualServer, 0, serverCount)
+
+	for _, rules := range p {
+		servers = append(servers, rules.buildServers()...)
+	}
+
+	return servers
 }
 
 type pathAndType struct {
@@ -245,6 +268,7 @@ type hostPathRules struct {
 	listenersForHost map[string]*graph.Listener
 	httpsListeners   []*graph.Listener
 	listenersExist   bool
+	port             int32
 }
 
 func newHostPathRules() *hostPathRules {
@@ -257,6 +281,7 @@ func newHostPathRules() *hostPathRules {
 
 func (hpr *hostPathRules) upsertListener(l *graph.Listener) {
 	hpr.listenersExist = true
+	hpr.port = int32(l.Source.Port)
 
 	if l.Source.Protocol == v1beta1.HTTPSProtocolType {
 		hpr.httpsListeners = append(hpr.httpsListeners, l)
@@ -336,6 +361,7 @@ func (hpr *hostPathRules) buildServers() []VirtualServer {
 		s := VirtualServer{
 			Hostname:  h,
 			PathRules: make([]PathRule, 0, len(rules)),
+			Port:      hpr.port,
 		}
 
 		l, ok := hpr.listenersForHost[h]
@@ -372,6 +398,7 @@ func (hpr *hostPathRules) buildServers() []VirtualServer {
 		if len(l.Routes) == 0 || hostname == wildcardHostname {
 			s := VirtualServer{
 				Hostname: hostname,
+				Port:     hpr.port,
 			}
 
 			if l.SecretPath != "" {
@@ -384,7 +411,10 @@ func (hpr *hostPathRules) buildServers() []VirtualServer {
 
 	// if any listeners exist, we need to generate a default server block.
 	if hpr.listenersExist {
-		servers = append(servers, VirtualServer{IsDefault: true})
+		servers = append(servers, VirtualServer{
+			IsDefault: true,
+			Port:      hpr.port,
+		})
 	}
 
 	// We sort the servers so the order is preserved after reconfiguration.

--- a/internal/state/dataplane/configuration.go
+++ b/internal/state/dataplane/configuration.go
@@ -246,7 +246,7 @@ type portPathRules map[v1beta1.PortNumber]*hostPathRules
 func (p portPathRules) buildServers() []VirtualServer {
 	serverCount := 0
 	for _, rules := range p {
-		serverCount += len(rules.rulesPerHost) + len(rules.httpsListeners)
+		serverCount += rules.maxServerCount()
 	}
 
 	servers := make([]VirtualServer, 0, serverCount)
@@ -423,6 +423,15 @@ func (hpr *hostPathRules) buildServers() []VirtualServer {
 	})
 
 	return servers
+}
+
+// maxServerCount returns the maximum number of VirtualServers that can be built from the host path rules.
+// to calculate max # of servers we add up:
+// - # of hostnames
+// - # of https listeners - this is to account for https wildcard default servers
+// - default server - for every hostPathRules we generate 1 default server.
+func (hpr *hostPathRules) maxServerCount() int {
+	return len(hpr.rulesPerHost) + len(hpr.httpsListeners) + 1
 }
 
 func buildUpstreams(

--- a/internal/state/graph/gateway_listener.go
+++ b/internal/state/graph/gateway_listener.go
@@ -340,7 +340,7 @@ func createPortConflictResolver() listenerConflictResolver {
 	portProtocolOwner := make(map[v1beta1.PortNumber]v1beta1.ProtocolType)
 	listenersByPort := make(map[v1beta1.PortNumber][]*Listener)
 
-	format := "Multiple listeners for the same port %d specify different protocols; " +
+	format := "Multiple listeners for the same port %d specify incompatible protocols; " +
 		"ensure only one protocol per port"
 
 	return func(l *Listener) {

--- a/internal/state/graph/gateway_test.go
+++ b/internal/state/graph/gateway_test.go
@@ -253,10 +253,10 @@ func TestBuildGateway(t *testing.T) {
 			"with an alphanumeric character (e.g. 'example.com', regex used for validation is " +
 			`'[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`
 
-		conflict80PortMsg = "Multiple listeners for the same port 80 specify different protocols; " +
+		conflict80PortMsg = "Multiple listeners for the same port 80 specify incompatible protocols; " +
 			"ensure only one protocol per port"
 
-		conflict443PortMsg = "Multiple listeners for the same port 443 specify different protocols; " +
+		conflict443PortMsg = "Multiple listeners for the same port 443 specify incompatible protocols; " +
 			"ensure only one protocol per port"
 
 		secretPath = "/etc/nginx/secrets/test_secret"

--- a/internal/state/graph/gateway_test.go
+++ b/internal/state/graph/gateway_test.go
@@ -143,41 +143,6 @@ func TestProcessGateways(t *testing.T) {
 func TestBuildGateway(t *testing.T) {
 	const gcName = "my-gateway-class"
 
-	listener801 := v1beta1.Listener{
-		Name:     "listener-80-1",
-		Hostname: (*v1beta1.Hostname)(helpers.GetStringPointer("foo.example.com")),
-		Port:     80,
-		Protocol: v1beta1.HTTPProtocolType,
-	}
-	listener802 := v1beta1.Listener{
-		Name:     "listener-80-2",
-		Hostname: (*v1beta1.Hostname)(helpers.GetStringPointer("bar.example.com")),
-		Port:     80,
-		Protocol: v1beta1.TCPProtocolType, // invalid protocol
-	}
-	listener803 := v1beta1.Listener{
-		Name:     "listener-80-3",
-		Hostname: (*v1beta1.Hostname)(helpers.GetStringPointer("bar.example.com")),
-		Port:     80,
-		Protocol: v1beta1.HTTPProtocolType,
-	}
-	listener804 := v1beta1.Listener{
-		Name:     "listener-80-4",
-		Hostname: (*v1beta1.Hostname)(helpers.GetStringPointer("foo.example.com")),
-		Port:     80,
-		Protocol: v1beta1.HTTPProtocolType,
-	}
-	listener805 := v1beta1.Listener{
-		Name:     "listener-80-5",
-		Port:     81, // invalid port
-		Protocol: v1beta1.HTTPProtocolType,
-	}
-	listener806 := v1beta1.Listener{
-		Name:     "listener-80-6",
-		Hostname: (*v1beta1.Hostname)(helpers.GetStringPointer("$example.com")), // invalid hostname
-		Port:     80,
-		Protocol: v1beta1.HTTPProtocolType,
-	}
 	labelSet := map[string]string{
 		"key": "value",
 	}
@@ -225,49 +190,61 @@ func TestBuildGateway(t *testing.T) {
 			},
 		},
 	}
-	// https listeners
-	listener4431 := v1beta1.Listener{
-		Name:     "listener-443-1",
-		Hostname: (*v1beta1.Hostname)(helpers.GetStringPointer("foo.example.com")),
-		Port:     443,
-		TLS:      gatewayTLSConfig,
-		Protocol: v1beta1.HTTPSProtocolType,
+
+	createListener := func(
+		name string,
+		hostname string,
+		port int,
+		protocol v1beta1.ProtocolType,
+		tls *v1beta1.GatewayTLSConfig,
+	) v1beta1.Listener {
+		return v1beta1.Listener{
+			Name:     v1beta1.SectionName(name),
+			Hostname: (*v1beta1.Hostname)(helpers.GetStringPointer(hostname)),
+			Port:     v1beta1.PortNumber(port),
+			Protocol: protocol,
+			TLS:      tls,
+		}
 	}
-	listener4432 := v1beta1.Listener{
-		Name:     "listener-443-2",
-		Hostname: (*v1beta1.Hostname)(helpers.GetStringPointer("bar.example.com")),
-		Port:     443,
-		TLS:      gatewayTLSConfig,
-		Protocol: v1beta1.HTTPSProtocolType,
+	createHTTPListener := func(name, hostname string, port int) v1beta1.Listener {
+		return createListener(name, hostname, port, v1beta1.HTTPProtocolType, nil)
 	}
-	listener4433 := v1beta1.Listener{
-		Name:     "listener-443-3",
-		Hostname: (*v1beta1.Hostname)(helpers.GetStringPointer("foo.example.com")),
-		Port:     443,
-		TLS:      gatewayTLSConfig,
-		Protocol: v1beta1.HTTPSProtocolType,
+	createTCPListener := func(name, hostname string, port int) v1beta1.Listener {
+		return createListener(name, hostname, port, v1beta1.TCPProtocolType, nil)
 	}
-	listener4434 := v1beta1.Listener{
-		Name:     "listener-443-4",
-		Hostname: (*v1beta1.Hostname)(helpers.GetStringPointer("$example.com")), // invalid hostname
-		Port:     443,
-		TLS:      gatewayTLSConfig,
-		Protocol: v1beta1.HTTPSProtocolType,
+	createHTTPSListener := func(name, hostname string, port int, tls *v1beta1.GatewayTLSConfig) v1beta1.Listener {
+		return createListener(name, hostname, port, v1beta1.HTTPSProtocolType, tls)
 	}
-	listener4435 := v1beta1.Listener{
-		Name:     "listener-443-5",
-		Hostname: (*v1beta1.Hostname)(helpers.GetStringPointer("foo.example.com")),
-		Port:     443,
-		TLS:      tlsConfigInvalidSecret, // invalid https listener; secret does not exist
-		Protocol: v1beta1.HTTPSProtocolType,
-	}
-	listener4436 := v1beta1.Listener{
-		Name:     "listener-443-6",
-		Hostname: (*v1beta1.Hostname)(helpers.GetStringPointer("foo.example.com")),
-		Port:     444, // invalid port
-		TLS:      gatewayTLSConfig,
-		Protocol: v1beta1.HTTPSProtocolType,
-	}
+	// foo http listeners
+	foo80Listener1 := createHTTPListener("foo-80-1", "foo.example.com", 80)
+	foo80Listener2 := createHTTPListener("foo-80-2", "foo.example.com", 80)
+	foo8080Listener := createHTTPListener("foo-8080", "foo.example.com", 8080)
+	foo8081Listener := createHTTPListener("foo-8081", "foo.example.com", 8081)
+
+	// foo https listeners
+	foo443Listener1 := createHTTPSListener("foo-443-1", "foo.example.com", 443, gatewayTLSConfig)
+	foo443Listener2 := createHTTPSListener("foo-443-2", "foo.example.com", 443, gatewayTLSConfig)
+	foo8443Listener := createHTTPSListener("foo-8443", "foo.example.com", 8443, gatewayTLSConfig)
+
+	// bar http listener
+	bar80Listener := createHTTPListener("bar-80", "bar.example.com", 80)
+
+	// bar https listeners
+	bar443Listener := createHTTPSListener("bar-443", "bar.example.com", 443, gatewayTLSConfig)
+	bar8443Listener := createHTTPSListener("bar-8443", "bar.example.com", 8443, gatewayTLSConfig)
+
+	// invalid listeners
+	invalidProtocolListener := createTCPListener("invalid-protocol", "bar.example.com", 80)
+	invalidPortListener := createHTTPListener("invalid-port", "invalid-port", 0)
+	invalidHostnameListener := createHTTPListener("invalid-hostname", "$example.com", 80)
+	invalidHTTPSHostnameListener := createHTTPSListener("invalid-https-hostname", "$example.com", 443, gatewayTLSConfig)
+	invalidTLSConfigListener := createHTTPSListener(
+		"invalid-tls-config",
+		"foo.example.com",
+		443,
+		tlsConfigInvalidSecret,
+	)
+	invalidHTTPSPortListener := createHTTPSListener("invalid-https-port", "foo.example.com", 0, gatewayTLSConfig)
 
 	const (
 		invalidHostnameMsg = `hostname: Invalid value: "$example.com": a lowercase RFC 1123 subdomain ` +
@@ -318,29 +295,40 @@ func TestBuildGateway(t *testing.T) {
 		name         string
 	}{
 		{
-			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{listener801}}),
+			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{foo80Listener1, foo8080Listener}}),
 			gatewayClass: validGC,
 			expected: &Gateway{
 				Source: getLastCreatedGetaway(),
 				Listeners: map[string]*Listener{
-					"listener-80-1": {
-						Source: listener801,
+					"foo-80-1": {
+						Source: foo80Listener1,
+						Valid:  true,
+						Routes: map[types.NamespacedName]*Route{},
+					},
+					"foo-8080": {
+						Source: foo8080Listener,
 						Valid:  true,
 						Routes: map[types.NamespacedName]*Route{},
 					},
 				},
 				Valid: true,
 			},
-			name: "valid http listener",
+			name: "valid http listeners",
 		},
 		{
-			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{listener4431}}),
+			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{foo443Listener1, foo8443Listener}}),
 			gatewayClass: validGC,
 			expected: &Gateway{
 				Source: getLastCreatedGetaway(),
 				Listeners: map[string]*Listener{
-					"listener-443-1": {
-						Source:     listener4431,
+					"foo-443-1": {
+						Source:     foo443Listener1,
+						Valid:      true,
+						Routes:     map[types.NamespacedName]*Route{},
+						SecretPath: secretPath,
+					},
+					"foo-8443": {
+						Source:     foo8443Listener,
 						Valid:      true,
 						Routes:     map[types.NamespacedName]*Route{},
 						SecretPath: secretPath,
@@ -348,7 +336,7 @@ func TestBuildGateway(t *testing.T) {
 				},
 				Valid: true,
 			},
-			name: "valid https listener",
+			name: "valid https listeners",
 		},
 		{
 			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{listenerAllowedRoutes}}),
@@ -388,13 +376,13 @@ func TestBuildGateway(t *testing.T) {
 			name: "http listener with invalid label selector",
 		},
 		{
-			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{listener802}}),
+			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{invalidProtocolListener}}),
 			gatewayClass: validGC,
 			expected: &Gateway{
 				Source: getLastCreatedGetaway(),
 				Listeners: map[string]*Listener{
-					"listener-80-2": {
-						Source: listener802,
+					"invalid-protocol": {
+						Source: invalidProtocolListener,
 						Valid:  false,
 						Conditions: []conditions.Condition{
 							conditions.NewListenerUnsupportedProtocol(
@@ -408,60 +396,53 @@ func TestBuildGateway(t *testing.T) {
 			name: "invalid listener protocol",
 		},
 		{
-			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{listener805}}),
+			gateway: createGateway(
+				gatewayCfg{listeners: []v1beta1.Listener{invalidPortListener, invalidHTTPSPortListener}},
+			),
 			gatewayClass: validGC,
 			expected: &Gateway{
 				Source: getLastCreatedGetaway(),
 				Listeners: map[string]*Listener{
-					"listener-80-5": {
-						Source: listener805,
+					"invalid-port": {
+						Source: invalidPortListener,
 						Valid:  false,
 						Conditions: []conditions.Condition{
-							conditions.NewListenerPortUnavailable(
-								`port: Unsupported value: 81: supported values: "80"`,
+							conditions.NewListenerUnsupportedValue(
+								`port: Invalid value: 0: port must be between 1-65535`,
+							),
+						},
+					},
+					"invalid-https-port": {
+						Source: invalidHTTPSPortListener,
+						Valid:  false,
+						Conditions: []conditions.Condition{
+							conditions.NewListenerUnsupportedValue(
+								`port: Invalid value: 0: port must be between 1-65535`,
 							),
 						},
 					},
 				},
 				Valid: true,
 			},
-			name: "invalid http listener",
+			name: "invalid ports",
 		},
 		{
-			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{listener4436}}),
+			gateway: createGateway(
+				gatewayCfg{listeners: []v1beta1.Listener{invalidHostnameListener, invalidHTTPSHostnameListener}},
+			),
 			gatewayClass: validGC,
 			expected: &Gateway{
 				Source: getLastCreatedGetaway(),
 				Listeners: map[string]*Listener{
-					"listener-443-6": {
-						Source: listener4436,
-						Valid:  false,
-						Conditions: []conditions.Condition{
-							conditions.NewListenerPortUnavailable(
-								`port: Unsupported value: 444: supported values: "443"`,
-							),
-						},
-					},
-				},
-				Valid: true,
-			},
-			name: "invalid https listener",
-		},
-		{
-			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{listener806, listener4434}}),
-			gatewayClass: validGC,
-			expected: &Gateway{
-				Source: getLastCreatedGetaway(),
-				Listeners: map[string]*Listener{
-					"listener-80-6": {
-						Source: listener806,
+					"invalid-hostname": {
+						Source: invalidHostnameListener,
 						Valid:  false,
 						Conditions: []conditions.Condition{
 							conditions.NewListenerUnsupportedValue(invalidHostnameMsg),
 						},
 					},
-					"listener-443-4": {
-						Source: listener4434,
+					"invalid-https-hostname": {
+						Source: invalidHTTPSHostnameListener,
 						Valid:  false,
 						Conditions: []conditions.Condition{
 							conditions.NewListenerUnsupportedValue(invalidHostnameMsg),
@@ -473,13 +454,13 @@ func TestBuildGateway(t *testing.T) {
 			name: "invalid hostnames",
 		},
 		{
-			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{listener4435}}),
+			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{invalidTLSConfigListener}}),
 			gatewayClass: validGC,
 			expected: &Gateway{
 				Source: getLastCreatedGetaway(),
 				Listeners: map[string]*Listener{
-					"listener-443-5": {
-						Source: listener4435,
+					"invalid-tls-config": {
+						Source: invalidTLSConfigListener,
 						Valid:  false,
 						Routes: map[types.NamespacedName]*Route{},
 						Conditions: conditions.NewListenerInvalidCertificateRef(
@@ -493,30 +474,63 @@ func TestBuildGateway(t *testing.T) {
 		},
 		{
 			gateway: createGateway(
-				gatewayCfg{listeners: []v1beta1.Listener{listener801, listener803, listener4431, listener4432}},
+				gatewayCfg{
+					listeners: []v1beta1.Listener{
+						foo80Listener1,
+						foo8080Listener,
+						foo8081Listener,
+						foo443Listener1,
+						foo8443Listener,
+						bar80Listener,
+						bar443Listener,
+						bar8443Listener,
+					},
+				},
 			),
 			gatewayClass: validGC,
 			expected: &Gateway{
 				Source: getLastCreatedGetaway(),
 				Listeners: map[string]*Listener{
-					"listener-80-1": {
-						Source: listener801,
+					"foo-80-1": {
+						Source: foo80Listener1,
 						Valid:  true,
 						Routes: map[types.NamespacedName]*Route{},
 					},
-					"listener-80-3": {
-						Source: listener803,
+					"foo-8080": {
+						Source: foo8080Listener,
 						Valid:  true,
 						Routes: map[types.NamespacedName]*Route{},
 					},
-					"listener-443-1": {
-						Source:     listener4431,
+					"foo-8081": {
+						Source: foo8081Listener,
+						Valid:  true,
+						Routes: map[types.NamespacedName]*Route{},
+					},
+					"bar-80": {
+						Source: bar80Listener,
+						Valid:  true,
+						Routes: map[types.NamespacedName]*Route{},
+					},
+					"foo-443-1": {
+						Source:     foo443Listener1,
 						Valid:      true,
 						Routes:     map[types.NamespacedName]*Route{},
 						SecretPath: secretPath,
 					},
-					"listener-443-2": {
-						Source:     listener4432,
+					"foo-8443": {
+						Source:     foo8443Listener,
+						Valid:      true,
+						Routes:     map[types.NamespacedName]*Route{},
+						SecretPath: secretPath,
+					},
+					"bar-443": {
+						Source:     bar443Listener,
+						Valid:      true,
+						Routes:     map[types.NamespacedName]*Route{},
+						SecretPath: secretPath,
+					},
+					"bar-8443": {
+						Source:     bar8443Listener,
 						Valid:      true,
 						Routes:     map[types.NamespacedName]*Route{},
 						SecretPath: secretPath,
@@ -528,33 +542,34 @@ func TestBuildGateway(t *testing.T) {
 		},
 		{
 			gateway: createGateway(
-				gatewayCfg{listeners: []v1beta1.Listener{listener801, listener804, listener4431, listener4433}},
+				gatewayCfg{
+					listeners: []v1beta1.Listener{foo80Listener1, foo80Listener2, foo443Listener1, foo443Listener2},
+				},
 			),
 			gatewayClass: validGC,
 			expected: &Gateway{
 				Source: getLastCreatedGetaway(),
 				Listeners: map[string]*Listener{
-					"listener-80-1": {
-						Source:     listener801,
+					"foo-80-1": {
+						Source:     foo80Listener1,
 						Valid:      false,
 						Routes:     map[types.NamespacedName]*Route{},
 						Conditions: conditions.NewListenerConflictedHostname(conflictedHostnamesMsg),
 					},
-					"listener-80-4": {
-						Source:     listener804,
+					"foo-80-2": {
+						Source:     foo80Listener2,
 						Valid:      false,
 						Routes:     map[types.NamespacedName]*Route{},
 						Conditions: conditions.NewListenerConflictedHostname(conflictedHostnamesMsg),
 					},
-					"listener-443-1": {
-						Source:     listener4431,
+					"foo-443-1": {
+						Source:     foo443Listener1,
 						Valid:      false,
 						Routes:     map[types.NamespacedName]*Route{},
 						Conditions: conditions.NewListenerConflictedHostname(conflictedHostnamesMsg),
 						SecretPath: "/etc/nginx/secrets/test_secret",
-					},
-					"listener-443-3": {
-						Source:     listener4433,
+					}, "foo-443-2": {
+						Source:     foo443Listener2,
 						Valid:      false,
 						Routes:     map[types.NamespacedName]*Route{},
 						Conditions: conditions.NewListenerConflictedHostname(conflictedHostnamesMsg),
@@ -566,17 +581,19 @@ func TestBuildGateway(t *testing.T) {
 			name: "collisions",
 		},
 		{
-			gateway: createGateway(gatewayCfg{
-				listeners: []v1beta1.Listener{listener801, listener4431},
-				addresses: []v1beta1.GatewayAddress{
-					{},
+			gateway: createGateway(
+				gatewayCfg{
+					listeners: []v1beta1.Listener{foo80Listener1, foo443Listener1},
+					addresses: []v1beta1.GatewayAddress{{}},
 				},
-			}),
+			),
 			gatewayClass: validGC,
 			expected: &Gateway{
-				Source:     getLastCreatedGetaway(),
-				Valid:      false,
-				Conditions: conditions.NewGatewayUnsupportedValue("spec.addresses: Forbidden: addresses are not supported"),
+				Source: getLastCreatedGetaway(),
+				Valid:  false,
+				Conditions: conditions.NewGatewayUnsupportedValue("spec." +
+					"addresses: Forbidden: addresses are not supported",
+				),
 			},
 			name: "gateway addresses are not supported",
 		},
@@ -586,7 +603,9 @@ func TestBuildGateway(t *testing.T) {
 			name:     "nil gateway",
 		},
 		{
-			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{listener801, listener802}}),
+			gateway: createGateway(
+				gatewayCfg{listeners: []v1beta1.Listener{foo80Listener1, invalidProtocolListener}},
+			),
 			gatewayClass: invalidGC,
 			expected: &Gateway{
 				Source:     getLastCreatedGetaway(),
@@ -596,7 +615,9 @@ func TestBuildGateway(t *testing.T) {
 			name: "invalid gatewayclass",
 		},
 		{
-			gateway:      createGateway(gatewayCfg{listeners: []v1beta1.Listener{listener801, listener802}}),
+			gateway: createGateway(
+				gatewayCfg{listeners: []v1beta1.Listener{foo80Listener1, invalidProtocolListener}},
+			),
 			gatewayClass: nil,
 			expected: &Gateway{
 				Source:     getLastCreatedGetaway(),

--- a/internal/state/graph/httproute_test.go
+++ b/internal/state/graph/httproute_test.go
@@ -537,6 +537,7 @@ func TestBindRouteToListeners(t *testing.T) {
 			Source: v1beta1.Listener{
 				Name:     v1beta1.SectionName(name),
 				Hostname: (*v1beta1.Hostname)(helpers.GetStringPointer("foo.example.com")),
+				Port:     80,
 			},
 			Valid:  true,
 			Routes: map[types.NamespacedName]*Route{},
@@ -758,9 +759,9 @@ func TestBindRouteToListeners(t *testing.T) {
 				Source: gw,
 				Valid:  true,
 				Listeners: map[string]*Listener{
-					"listener-80-1": createListener("listener-80-1"),
-					"listener-80-2": createModifiedListener("listener-80-2", func(l *Listener) {
-						l.Source.Hostname = nil
+					"listener-80": createListener("listener-80"),
+					"listener-8080": createModifiedListener("listener-8080", func(l *Listener) {
+						l.Source.Port = 8080
 					}),
 				},
 			},
@@ -771,26 +772,26 @@ func TestBindRouteToListeners(t *testing.T) {
 					Attachment: &ParentRefAttachmentStatus{
 						Attached: true,
 						AcceptedHostnames: map[string][]string{
-							"listener-80-1": {"foo.example.com"},
-							"listener-80-2": {"foo.example.com"},
+							"listener-80":   {"foo.example.com"},
+							"listener-8080": {"foo.example.com"},
 						},
 					},
 				},
 			},
 			expectedGatewayListeners: map[string]*Listener{
-				"listener-80-1": createModifiedListener("listener-80-1", func(l *Listener) {
+				"listener-80": createModifiedListener("listener-80", func(l *Listener) {
 					l.Routes = map[types.NamespacedName]*Route{
 						client.ObjectKeyFromObject(hr): routeWithEmptySectionName,
 					}
 				}),
-				"listener-80-2": createModifiedListener("listener-80-2", func(l *Listener) {
+				"listener-8080": createModifiedListener("listener-8080", func(l *Listener) {
 					l.Routes = map[types.NamespacedName]*Route{
 						client.ObjectKeyFromObject(hr): routeWithEmptySectionName,
 					}
-					l.Source.Hostname = nil
+					l.Source.Port = 8080
 				}),
 			},
-			name: "section name is empty",
+			name: "section name is empty; bind to multiple listeners",
 		},
 		{
 			route: routeWithEmptySectionName,

--- a/internal/state/graph/httproute_test.go
+++ b/internal/state/graph/httproute_test.go
@@ -537,7 +537,6 @@ func TestBindRouteToListeners(t *testing.T) {
 			Source: v1beta1.Listener{
 				Name:     v1beta1.SectionName(name),
 				Hostname: (*v1beta1.Hostname)(helpers.GetStringPointer("foo.example.com")),
-				Port:     80,
 			},
 			Valid:  true,
 			Routes: map[types.NamespacedName]*Route{},
@@ -759,10 +758,8 @@ func TestBindRouteToListeners(t *testing.T) {
 				Source: gw,
 				Valid:  true,
 				Listeners: map[string]*Listener{
-					"listener-80": createListener("listener-80"),
-					"listener-8080": createModifiedListener("listener-8080", func(l *Listener) {
-						l.Source.Port = 8080
-					}),
+					"listener-80":   createListener("listener-80"),
+					"listener-8080": createListener("listener-8080"),
 				},
 			},
 			expectedSectionNameRefs: []ParentRef{
@@ -788,7 +785,6 @@ func TestBindRouteToListeners(t *testing.T) {
 					l.Routes = map[types.NamespacedName]*Route{
 						client.ObjectKeyFromObject(hr): routeWithEmptySectionName,
 					}
-					l.Source.Port = 8080
 				}),
 			},
 			name: "section name is empty; bind to multiple listeners",

--- a/internal/status/statuses_test.go
+++ b/internal/status/statuses_test.go
@@ -405,7 +405,7 @@ func TestBuildGatewayStatuses(t *testing.T) {
 					"listener-invalid-1": {
 						Valid: false,
 						Conditions: []conditions.Condition{
-							conditions.NewListenerPortUnavailable("port unavailable"),
+							conditions.NewListenerUnsupportedProtocol("unsupported protocol"),
 						},
 					},
 					"listener-invalid-2": {
@@ -423,7 +423,7 @@ func TestBuildGatewayStatuses(t *testing.T) {
 					ListenerStatuses: map[string]ListenerStatus{
 						"listener-invalid-1": {
 							Conditions: []conditions.Condition{
-								conditions.NewListenerPortUnavailable("port unavailable"),
+								conditions.NewListenerUnsupportedProtocol("unsupported protocol"),
 							},
 						},
 						"listener-invalid-2": {


### PR DESCRIPTION
### Proposed changes

Problem: NKG only supported listener ports 80 and 443. This limitation prevents the conformance tests from running because the conformance tests create a base Gateway that listens on port 8080.

Solution: Allow users to specify any port between 1-65535. 

Testing: 
- Added/updated unit tests to cover new code. 
- Manually tested all examples using both 80/443 and 8080/8443. 
- Manually verified that routes can attach to multiple listeners with the same hostname as long as they specify different ports. 
- Ran conformance tests and verified that we can get past setup. 

Closes #619 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
