### PR TITLE
Add wildcard hostname support

### DIFF
--- a/docs/gateway-api-compatibility.md
+++ b/docs/gateway-api-compatibility.md
@@ -57,7 +57,7 @@ Fields:
     * `gatewayClassName` - supported.
     * `listeners`
         * `name` - supported.
-        * `hostname` - partially supported. Wildcard hostnames like `*.example.com` are not yet supported.
+        * `hostname` - supported.
         * `port` - supported. 
         * `protocol` - partially supported. Allowed values: `HTTP`, `HTTPS`.
         * `tls`
@@ -101,7 +101,7 @@ Fields:
 Fields:
 * `spec`
   * `parentRefs` - partially supported. Port not supported.
-  * `hostnames` - partially supported. Wildcard binding is not supported: a hostname like `example.com` will not bind to a listener with the hostname `*.example.com`. However, `example.com` will bind to a listener with the empty hostname.
+  * `hostnames` - supported.
   * `rules`
     * `matches`
       * `path` - partially supported. Only `PathPrefix` and `Exact` types.

--- a/examples/cafe-example/README.md
+++ b/examples/cafe-example/README.md
@@ -70,3 +70,26 @@ curl --resolve cafe.example.com:$GW_PORT:$GW_IP http://cafe.example.com:$GW_PORT
 Server address: 10.12.0.19:80
 Server name: tea-7cd44fcb4d-xfw2x
 ```
+
+## 5. Using different hostnames
+
+Traffic is allowed to `cafe.example.com` because the Gateway listener's hostname allows `*.example.com`. You can
+change an HTTPRoute's hostname to something that matches this wildcard and still pass traffic.
+
+For example, run the following command to open your editor and change the HTTPRoute's hostname to `foo.example.com`.
+
+```
+kubectl -n default edit httproute tea
+```
+
+Once changed, update the `curl` command above for the `tea` service to use the new hostname. Traffic should still pass successfully.
+
+Likewise, if you change the Gateway listener's hostname to something else, you can prevent the HTTPRoute's traffic from passing successfully.
+
+For example, run the following to open your editor and change the Gateway listener's hostname to `bar.example.com`:
+
+```
+kubectl -n default edit gateway gateway
+```
+
+Once changed, try running the same `curl` requests as above. They should be denied with a `404 Not Found`.

--- a/examples/cafe-example/gateway.yaml
+++ b/examples/cafe-example/gateway.yaml
@@ -10,3 +10,4 @@ spec:
   - name: http
     port: 80
     protocol: HTTP
+    hostname: "*.example.com"

--- a/internal/state/dataplane/configuration.go
+++ b/internal/state/dataplane/configuration.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -569,8 +568,6 @@ func convertPathType(pathType v1beta1.PathMatchType) PathType {
 }
 
 // listenerHostnameMoreSpecific returns true if host1 is more specific than host2.
-//
-// This function assumes that host1 and host2 match, either exactly or as a substring.
 func listenerHostnameMoreSpecific(host1, host2 *v1beta1.Hostname) bool {
 	var host1Str, host2Str string
 	if host1 != nil {
@@ -581,15 +578,5 @@ func listenerHostnameMoreSpecific(host1, host2 *v1beta1.Hostname) bool {
 		host2Str = string(*host2)
 	}
 
-	host1Segments := len(strings.Split(host1Str, "."))
-	host2Segments := len(strings.Split(host2Str, "."))
-	if host1Segments > host2Segments {
-		return true
-	}
-
-	if host2Segments > host1Segments {
-		return false
-	}
-
-	return len(host1Str) >= len(host2Str)
+	return graph.GetMoreSpecificHostname(host1Str, host2Str) == host1Str
 }

--- a/internal/state/dataplane/configuration_test.go
+++ b/internal/state/dataplane/configuration_test.go
@@ -1996,8 +1996,6 @@ func TestConvertPathType(t *testing.T) {
 }
 
 func TestHostnameMoreSpecific(t *testing.T) {
-	g := NewGomegaWithT(t)
-
 	tests := []struct {
 		host1     *v1beta1.Hostname
 		host2     *v1beta1.Hostname
@@ -2050,6 +2048,8 @@ func TestHostnameMoreSpecific(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.msg, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
 			g.Expect(listenerHostnameMoreSpecific(tc.host1, tc.host2)).To(Equal(tc.host1Wins))
 		})
 	}

--- a/internal/state/dataplane/configuration_test.go
+++ b/internal/state/dataplane/configuration_test.go
@@ -2029,15 +2029,29 @@ func TestHostnameMoreSpecific(t *testing.T) {
 			msg:       "host1 has value; host2 empty",
 		},
 		{
-			host1:     helpers.GetPointer(v1beta1.Hostname("example.com")),
+			host1:     helpers.GetPointer(v1beta1.Hostname("foo.bar.example.com")),
 			host2:     helpers.GetPointer(v1beta1.Hostname("foo.example.com")),
+			host1Wins: true,
+			msg:       "host1 has more segments than host2",
+		},
+		{
+			host1:     helpers.GetPointer(v1beta1.Hostname("somelongname.example.com")),
+			host2:     helpers.GetPointer(v1beta1.Hostname("foo.bar.example.com")),
+			host1Wins: false,
+			msg:       "host2 has more segments than host1",
+		},
+		{
+			host1:     helpers.GetPointer(v1beta1.Hostname("example.com")),
+			host2:     helpers.GetPointer(v1beta1.Hostname("longerexample.com")),
 			host1Wins: false,
 			msg:       "host2 longer than host1",
 		},
 	}
 
 	for _, tc := range tests {
-		g.Expect(listenerHostnameMoreSpecific(tc.host1, tc.host2)).To(Equal(tc.host1Wins), tc.msg)
+		t.Run(tc.msg, func(t *testing.T) {
+			g.Expect(listenerHostnameMoreSpecific(tc.host1, tc.host2)).To(Equal(tc.host1Wins))
+		})
 	}
 }
 

--- a/internal/state/dataplane/configuration_test.go
+++ b/internal/state/dataplane/configuration_test.go
@@ -2027,22 +2027,22 @@ func TestHostnameMoreSpecific(t *testing.T) {
 			msg:       "host1 has value; host2 empty",
 		},
 		{
-			host1:     helpers.GetPointer(v1beta1.Hostname("foo.bar.example.com")),
-			host2:     helpers.GetPointer(v1beta1.Hostname("foo.example.com")),
+			host1:     helpers.GetPointer(v1beta1.Hostname("")),
+			host2:     helpers.GetPointer(v1beta1.Hostname("example.com")),
+			host1Wins: false,
+			msg:       "host2 has value; host1 empty",
+		},
+		{
+			host1:     helpers.GetPointer(v1beta1.Hostname("foo.example.com")),
+			host2:     helpers.GetPointer(v1beta1.Hostname("*.example.com")),
 			host1Wins: true,
-			msg:       "host1 has more segments than host2",
+			msg:       "host1 more specific than host2",
 		},
 		{
-			host1:     helpers.GetPointer(v1beta1.Hostname("somelongname.example.com")),
-			host2:     helpers.GetPointer(v1beta1.Hostname("foo.bar.example.com")),
+			host1:     helpers.GetPointer(v1beta1.Hostname("*.example.com")),
+			host2:     helpers.GetPointer(v1beta1.Hostname("foo.example.com")),
 			host1Wins: false,
-			msg:       "host2 has more segments than host1",
-		},
-		{
-			host1:     helpers.GetPointer(v1beta1.Hostname("example.com")),
-			host2:     helpers.GetPointer(v1beta1.Hostname("longerexample.com")),
-			host1Wins: false,
-			msg:       "host2 longer than host1",
+			msg:       "host2 more specific than host1",
 		},
 	}
 

--- a/internal/state/graph/gateway_listener_test.go
+++ b/internal/state/graph/gateway_listener_test.go
@@ -222,7 +222,7 @@ func TestValidateListenerHostname(t *testing.T) {
 		},
 		{
 			hostname:  (*v1beta1.Hostname)(helpers.GetStringPointer("*.example.com")),
-			expectErr: true,
+			expectErr: false,
 			name:      "wildcard hostname",
 		},
 		{

--- a/internal/state/graph/httproute.go
+++ b/internal/state/graph/httproute.go
@@ -441,15 +441,14 @@ func match(listenerHost, routeHost string) bool {
 // This function assumes that the two hostnames match each other, either:
 // - Exactly
 // - One as a substring of the other
-// - Both as substrings of some parent wildcard
 func GetMoreSpecificHostname(hostname1, hostname2 string) string {
 	if hostname1 == hostname2 {
 		return hostname1
 	}
-
 	if hostname1 == "" {
 		return hostname2
-	} else if hostname2 == "" {
+	}
+	if hostname2 == "" {
 		return hostname1
 	}
 
@@ -468,25 +467,12 @@ func GetMoreSpecificHostname(hostname1, hostname2 string) string {
 		}
 
 		return hostname2
-	} else if strings.HasPrefix(hostname2, "*.") {
+	}
+	if strings.HasPrefix(hostname2, "*.") {
 		return hostname1
 	}
 
-	subdomains1 := strings.Split(hostname1, ".")
-	subdomains2 := strings.Split(hostname2, ".")
-
-	// Compare number of subdomains
-	if len(subdomains1) > len(subdomains2) {
-		return hostname1
-	} else if len(subdomains1) < len(subdomains2) {
-		return hostname2
-	}
-
-	if len(hostname1) > len(hostname2) {
-		return hostname1
-	}
-
-	return hostname2
+	return ""
 }
 
 func routeAllowedByListener(

--- a/internal/state/graph/httproute_test.go
+++ b/internal/state/graph/httproute_test.go
@@ -1217,6 +1217,7 @@ func TestBindRouteToListeners(t *testing.T) {
 func TestFindAcceptedHostnames(t *testing.T) {
 	var listenerHostnameFoo v1beta1.Hostname = "foo.example.com"
 	var listenerHostnameCafe v1beta1.Hostname = "cafe.example.com"
+	var listenerHostnameWildcard v1beta1.Hostname = "*.example.com"
 	routeHostnames := []v1beta1.Hostname{"foo.example.com", "bar.example.com"}
 
 	tests := []struct {
@@ -1254,6 +1255,30 @@ func TestFindAcceptedHostnames(t *testing.T) {
 			routeHostnames:   nil,
 			expected:         []string{wildcardHostname},
 			msg:              "both listener and route have empty hostnames",
+		},
+		{
+			listenerHostname: &listenerHostnameWildcard,
+			routeHostnames:   routeHostnames,
+			expected:         []string{"foo.example.com", "bar.example.com"},
+			msg:              "listener wildcard hostname",
+		},
+		{
+			listenerHostname: &listenerHostnameFoo,
+			routeHostnames:   []v1beta1.Hostname{"*.example.com"},
+			expected:         []string{"foo.example.com"},
+			msg:              "route wildcard hostname; specific listener hostname",
+		},
+		{
+			listenerHostname: &listenerHostnameWildcard,
+			routeHostnames:   nil,
+			expected:         []string{"*.example.com"},
+			msg:              "listener wildcard hostname; nil route hostname",
+		},
+		{
+			listenerHostname: nil,
+			routeHostnames:   []v1beta1.Hostname{"*.example.com"},
+			expected:         []string{"*.example.com"},
+			msg:              "route wildcard hostname; nil listener hostname",
 		},
 	}
 

--- a/internal/state/graph/httproute_test.go
+++ b/internal/state/graph/httproute_test.go
@@ -1280,6 +1280,12 @@ func TestFindAcceptedHostnames(t *testing.T) {
 			expected:         []string{"*.example.com"},
 			msg:              "route wildcard hostname; nil listener hostname",
 		},
+		{
+			listenerHostname: &listenerHostnameWildcard,
+			routeHostnames:   []v1beta1.Hostname{"*.bar.example.com"},
+			expected:         []string{"*.bar.example.com"},
+			msg:              "route and listener wildcard hostnames",
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/state/graph/validation.go
+++ b/internal/state/graph/validation.go
@@ -13,8 +13,13 @@ func validateHostname(hostname string) error {
 		return errors.New("cannot be empty string")
 	}
 
-	if strings.Contains(hostname, "*") {
-		return errors.New("wildcards are not supported")
+	if strings.HasPrefix(hostname, "*.") {
+		msgs := validation.IsWildcardDNS1123Subdomain(hostname)
+		if len(msgs) > 0 {
+			combined := strings.Join(msgs, ",")
+			return errors.New(combined)
+		}
+		return nil
 	}
 
 	msgs := validation.IsDNS1123Subdomain(hostname)

--- a/internal/state/graph/validation_test.go
+++ b/internal/state/graph/validation_test.go
@@ -32,6 +32,11 @@ func TestValidateHostname(t *testing.T) {
 			expectErr: true,
 			name:      "invalid hostname",
 		},
+		{
+			hostname:  "*.example.*.com",
+			expectErr: true,
+			name:      "invalid wildcard hostname",
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/state/graph/validation_test.go
+++ b/internal/state/graph/validation_test.go
@@ -24,7 +24,7 @@ func TestValidateHostname(t *testing.T) {
 		},
 		{
 			hostname:  "*.example.com",
-			expectErr: true,
+			expectErr: false,
 			name:      "wildcard hostname",
 		},
 		{


### PR DESCRIPTION
Problem: Until now, users were only able to use hostnames without wildcards, limiting their options.

Solution: We now support wildcard hostnames for HTTPRoutes and Gateway listeners.

Testing: Added unit tests and verified nginx config manually

Closes #478 

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
