### PR TITLE
Fix/increase nginx timeout

### DIFF
--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -1,7 +1,8 @@
 NKG_TAG = edge
 NKG_PREFIX = nginx-kubernetes-gateway
 GATEWAY_CLASS = nginx
-SUPPORTED_FEATURES = Gateway,HTTPRoute
+SUPPORTED_FEATURES = HTTPRoute,HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,HTTPRoutePortRedirect,HTTPRouteSchemeRedirect
+EXEMPT_FEATURES = ReferenceGrant
 KIND_KUBE_CONFIG_FOLDER = $${HOME}/.kube/kind
 TAG = latest
 PREFIX = conformance-test-runner
@@ -44,7 +45,7 @@ update-test-kind-config: ## Update kind config
 .PHONY: run-conformance-tests
 run-conformance-tests: update-test-kind-config ## Run conformance tests
 	docker run --network=kind --rm -v $(KIND_KUBE_CONFIG_FOLDER):/root/.kube $(PREFIX):$(TAG) \
-		go test -v . -tags conformance -args --gateway-class=$(GATEWAY_CLASS) --supported-features=$(SUPPORTED_FEATURES)
+		go test -timeout 25m -v . -tags conformance -args --gateway-class=$(GATEWAY_CLASS) --debug --supported-features=$(SUPPORTED_FEATURES) --exempt-features=$(EXEMPT_FEATURES)
 
 .PHONY: uninstall-nkg
 uninstall-nkg: ## Uninstall NKG on configured kind cluster

--- a/conformance/tests/conformance_test.go
+++ b/conformance/tests/conformance_test.go
@@ -68,7 +68,7 @@ func TestConformance(t *testing.T) {
 // sets.Set[suite.SupportedFeature]
 // FIXME(kate-osborn): Use exported ParseSupportedFeatures function
 // https://github.com/kubernetes-sigs/gateway-api/blob/63e423cf1b837991d2747742199d90863a98b0c3/conformance/utils/suite/suite.go#L235
-// once it's released.
+// once it's released. https://github.com/nginxinc/nginx-kubernetes-gateway/issues/779
 func parseSupportedFeatures(f string) sets.Set[suite.SupportedFeature] {
 	if f == "" {
 		return nil

--- a/internal/nginx/runtime/manager.go
+++ b/internal/nginx/runtime/manager.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	pidFile        = "/etc/nginx/nginx.pid"
-	pidFileTimeout = 5 * time.Second
+	pidFileTimeout = 10 * time.Second
 )
 
 type (
@@ -81,7 +81,7 @@ func findMainProcess(
 
 	err := wait.PollUntilContextCancel(
 		ctx,
-		1*time.Second,
+		500*time.Millisecond,
 		true, /* poll immediately */
 		func(ctx context.Context) (bool, error) {
 			_, err := checkFile(pidFile)


### PR DESCRIPTION
### Proposed changes

Problems:
1. The conformance tests consistently fail during setup because NKG times out waiting for the nginx process to start.
2. The conformance test makefile command runs the incorrect set of tests and times out before running all tests.

Solutions:
1. Increase the pid timeout (i.e. the time we wait for nginx to start) to 10s. This is sufficient in my local environment.
2. Update the list of supported features and exempt features and pass them to the conformance test suite, and increase the go test timeout to 25 minutes to allow the suite to complete. I also added the debug flag to increase the verbosity of the test output. 

Testing: Ran the conformance tests locally. Confirmed that they will consistently pass setup and run to completion. 

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
