### PR TITLE
Add NewListenerInvalidRouteKinds condition

### DIFF
--- a/docs/gateway-api-compatibility.md
+++ b/docs/gateway-api-compatibility.md
@@ -93,6 +93,7 @@ Fields:
       * `Programmed/False/Invalid`
       * `ResolvedRefs/True/ResolvedRefs`
       * `ResolvedRefs/False/InvalidCertificateRef`
+      * `ResolvedRefs/False/InvalidRouteKinds`
       * `Conflicted/True/ProtocolConflict`
       * `Conflicted/False/NoConflicts`
 

--- a/internal/state/conditions/conditions.go
+++ b/internal/state/conditions/conditions.go
@@ -348,6 +348,20 @@ func NewListenerInvalidCertificateRef(msg string) []Condition {
 	}
 }
 
+// NewListenerInvalidRouteKinds returns Conditions that indicate that an invalid or unsupported Route kind is
+// specified by the Listener.
+func NewListenerInvalidRouteKinds(msg string) []Condition {
+	return []Condition{
+		{
+			Type:    string(v1beta1.ListenerReasonResolvedRefs),
+			Status:  metav1.ConditionFalse,
+			Reason:  string(v1beta1.ListenerReasonInvalidRouteKinds),
+			Message: msg,
+		},
+		NewListenerNotProgrammedInvalid(msg),
+	}
+}
+
 // NewListenerProtocolConflict returns Conditions that indicate multiple Listeners are specified with the same
 // Listener port number, but have conflicting protocol specifications.
 func NewListenerProtocolConflict(msg string) []Condition {

--- a/internal/state/graph/gateway_listener.go
+++ b/internal/state/graph/gateway_listener.go
@@ -223,7 +223,7 @@ func validateListenerAllowedRouteKind(listener v1beta1.Listener) []conditions.Co
 			for _, kind := range listener.AllowedRoutes.Kinds {
 				if !validHTTPRouteKind(kind) {
 					msg := fmt.Sprintf("Unsupported route kind \"%s/%s\"", *kind.Group, kind.Kind)
-					return conditions.NewListenerUnsupportedValue(msg)
+					return conditions.NewListenerInvalidRouteKinds(msg)
 				}
 			}
 		}


### PR DESCRIPTION
### Proposed changes
Problem: The [GatewayInvalidRouteKind](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-invalid-route-kind.go) conformance test expects the ResolvedRef/False/InvalidRouteKinds condition to be set on a Listener that specifies an invalid route kind.

Solution: Add a NewListenerInvalidRouteKinds condition which is used when a Listener specifies an invalid route kind

Testing: Ran the GatewayInvalidRouteKind conformance tests. `TestConformance/GatewayInvalidRouteKind/Gateway_listener_should_have_a_false_ResolvedRefs_condition_with_reason_InvalidRouteKinds_and_HTTPRoute_must_be_put_in_the_supportedKinds` is now passing.
```
    --- FAIL: TestConformance/GatewayInvalidRouteKind (60.06s)
        --- FAIL: TestConformance/GatewayInvalidRouteKind/Gateway_listener_should_have_a_false_ResolvedRefs_condition_with_reason_InvalidRouteKinds_and_no_supportedKinds (60.02s)
        --- PASS: TestConformance/GatewayInvalidRouteKind/Gateway_listener_should_have_a_false_ResolvedRefs_condition_with_reason_InvalidRouteKinds_and_HTTPRoute_must_be_put_in_the_supportedKinds (0.00s)
```

**NOTE:** This PR does not address both failing tests, only the correct condition, as we currently do not support setting the SupportedKinds based on the listener. This will be fixed in a separate PR. See https://github.com/nginxinc/nginx-kubernetes-gateway/issues/690

Closes https://github.com/nginxinc/nginx-kubernetes-gateway/issues/774

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
