### PR TITLE
Add logic for defining port in redirect based on scheme

### DIFF
--- a/internal/nginx/config/servers.go
+++ b/internal/nginx/config/servers.go
@@ -198,24 +198,25 @@ func createReturnValForRedirectFilter(filter *v1beta1.HTTPRequestRedirectFilter,
 	port := listenerPort
 	if filter.Port != nil {
 		port = int32(*filter.Port)
-	} else {
-		if filter.Scheme != nil {
-			if *filter.Scheme == "http" {
-				port = 80
-			} else if *filter.Scheme == "https" {
-				port = 443
-			}
-		}
 	}
+
+	hostnamePort := fmt.Sprintf("%s:%d", hostname, port)
 
 	scheme := "$scheme"
 	if filter.Scheme != nil {
 		scheme = *filter.Scheme
+		if filter.Port == nil {
+			// Don't specify the port in the return url if the scheme is
+			// well known and the port is not specified by the user
+			if *filter.Scheme == "http" || *filter.Scheme == "https" {
+				hostnamePort = hostname
+			}
+		}
 	}
 
 	return &http.Return{
 		Code: code,
-		Body: fmt.Sprintf("%s://%s:%d$request_uri", scheme, hostname, port),
+		Body: fmt.Sprintf("%s://%s$request_uri", scheme, hostnamePort),
 	}
 }
 

--- a/internal/nginx/config/servers.go
+++ b/internal/nginx/config/servers.go
@@ -205,10 +205,15 @@ func createReturnValForRedirectFilter(filter *v1beta1.HTTPRequestRedirectFilter,
 	scheme := "$scheme"
 	if filter.Scheme != nil {
 		scheme = *filter.Scheme
+		// Don't specify the port in the return url if the scheme is
+		// well known and the port is already set to the correct well known port
+		if (port == 80 && scheme == "http") || (port == 443 && scheme == "https") {
+			hostnamePort = hostname
+		}
 		if filter.Port == nil {
 			// Don't specify the port in the return url if the scheme is
 			// well known and the port is not specified by the user
-			if *filter.Scheme == "http" || *filter.Scheme == "https" {
+			if scheme == "http" || scheme == "https" {
 				hostnamePort = hostname
 			}
 		}

--- a/internal/nginx/config/servers.go
+++ b/internal/nginx/config/servers.go
@@ -198,6 +198,14 @@ func createReturnValForRedirectFilter(filter *v1beta1.HTTPRequestRedirectFilter,
 	port := listenerPort
 	if filter.Port != nil {
 		port = int32(*filter.Port)
+	} else {
+		if filter.Scheme != nil {
+			if *filter.Scheme == "http" {
+				port = 80
+			} else if *filter.Scheme == "https" {
+				port = 443
+			}
+		}
 	}
 
 	scheme := "$scheme"

--- a/internal/nginx/config/servers_test.go
+++ b/internal/nginx/config/servers_test.go
@@ -910,23 +910,36 @@ func TestCreateReturnValForRedirectFilter(t *testing.T) {
 				Scheme:     helpers.GetPointer("https"),
 				Hostname:   helpers.GetPointer(v1beta1.PreciseHostname("foo.example.com")),
 				Port:       (*v1beta1.PortNumber)(helpers.GetInt32Pointer(2022)),
-				StatusCode: helpers.GetPointer(101),
+				StatusCode: helpers.GetPointer(301),
 			},
 			listenerPort: listenerPortCustom,
 			expected: &http.Return{
-				Code: 101,
+				Code: 301,
 				Body: "https://foo.example.com:2022$request_uri",
 			},
 			msg: "all fields are set",
 		},
 		{
 			filter: &v1beta1.HTTPRequestRedirectFilter{
+				Scheme:     helpers.GetPointer("https"),
 				Hostname:   helpers.GetPointer(v1beta1.PreciseHostname("foo.example.com")),
-				StatusCode: helpers.GetPointer(101),
+				StatusCode: helpers.GetPointer(301),
+			},
+			listenerPort: listenerPortCustom,
+			expected: &http.Return{
+				Code: 301,
+				Body: "https://foo.example.com$request_uri",
+			},
+			msg: "listenerPort is custom, scheme is set, no port",
+		},
+		{
+			filter: &v1beta1.HTTPRequestRedirectFilter{
+				Hostname:   helpers.GetPointer(v1beta1.PreciseHostname("foo.example.com")),
+				StatusCode: helpers.GetPointer(301),
 			},
 			listenerPort: listenerPortHTTPS,
 			expected: &http.Return{
-				Code: 101,
+				Code: 301,
 				Body: "$scheme://foo.example.com:443$request_uri",
 			},
 			msg: "no scheme, listenerPort https, no port is set",
@@ -935,11 +948,11 @@ func TestCreateReturnValForRedirectFilter(t *testing.T) {
 			filter: &v1beta1.HTTPRequestRedirectFilter{
 				Scheme:     helpers.GetPointer("https"),
 				Hostname:   helpers.GetPointer(v1beta1.PreciseHostname("foo.example.com")),
-				StatusCode: helpers.GetPointer(101),
+				StatusCode: helpers.GetPointer(301),
 			},
 			listenerPort: listenerPortHTTPS,
 			expected: &http.Return{
-				Code: 101,
+				Code: 301,
 				Body: "https://foo.example.com$request_uri",
 			},
 			msg: "scheme is https, listenerPort https, no port is set",
@@ -948,27 +961,42 @@ func TestCreateReturnValForRedirectFilter(t *testing.T) {
 			filter: &v1beta1.HTTPRequestRedirectFilter{
 				Scheme:     helpers.GetPointer("http"),
 				Hostname:   helpers.GetPointer(v1beta1.PreciseHostname("foo.example.com")),
-				StatusCode: helpers.GetPointer(101),
+				StatusCode: helpers.GetPointer(301),
 			},
 			listenerPort: listenerPortHTTP,
 			expected: &http.Return{
-				Code: 101,
+				Code: 301,
 				Body: "http://foo.example.com$request_uri",
 			},
 			msg: "scheme is http, listenerPort http, no port is set",
 		},
 		{
 			filter: &v1beta1.HTTPRequestRedirectFilter{
-				Scheme:     helpers.GetPointer("custom"),
+				Scheme:     helpers.GetPointer("http"),
 				Hostname:   helpers.GetPointer(v1beta1.PreciseHostname("foo.example.com")),
-				StatusCode: helpers.GetPointer(101),
+				Port:       (*v1beta1.PortNumber)(helpers.GetInt32Pointer(80)),
+				StatusCode: helpers.GetPointer(301),
 			},
-			listenerPort: listenerPortHTTP,
+			listenerPort: listenerPortCustom,
 			expected: &http.Return{
-				Code: 101,
-				Body: "custom://foo.example.com:80$request_uri",
+				Code: 301,
+				Body: "http://foo.example.com$request_uri",
 			},
-			msg: "scheme is custom, listenerPort http, no port is set",
+			msg: "scheme is http, port http",
+		},
+		{
+			filter: &v1beta1.HTTPRequestRedirectFilter{
+				Scheme:     helpers.GetPointer("https"),
+				Hostname:   helpers.GetPointer(v1beta1.PreciseHostname("foo.example.com")),
+				Port:       (*v1beta1.PortNumber)(helpers.GetInt32Pointer(443)),
+				StatusCode: helpers.GetPointer(301),
+			},
+			listenerPort: listenerPortCustom,
+			expected: &http.Return{
+				Code: 301,
+				Body: "https://foo.example.com$request_uri",
+			},
+			msg: "scheme is https, port https",
 		},
 	}
 

--- a/internal/nginx/config/servers_test.go
+++ b/internal/nginx/config/servers_test.go
@@ -913,6 +913,42 @@ func TestCreateReturnValForRedirectFilter(t *testing.T) {
 			},
 			msg: "all fields are set",
 		},
+		{
+			filter: &v1beta1.HTTPRequestRedirectFilter{
+				Scheme:     helpers.GetStringPointer("https"),
+				Hostname:   (*v1beta1.PreciseHostname)(helpers.GetStringPointer("foo.example.com")),
+				StatusCode: helpers.GetIntPointer(101),
+			},
+			expected: &http.Return{
+				Code: 101,
+				Body: "https://foo.example.com:443$request_uri",
+			},
+			msg: "scheme is https, no port is set",
+		},
+		{
+			filter: &v1beta1.HTTPRequestRedirectFilter{
+				Scheme:     helpers.GetStringPointer("http"),
+				Hostname:   (*v1beta1.PreciseHostname)(helpers.GetStringPointer("foo.example.com")),
+				StatusCode: helpers.GetIntPointer(101),
+			},
+			expected: &http.Return{
+				Code: 101,
+				Body: "http://foo.example.com:80$request_uri",
+			},
+			msg: "scheme is http, no port is set",
+		},
+		{
+			filter: &v1beta1.HTTPRequestRedirectFilter{
+				Scheme:     helpers.GetStringPointer("custom"),
+				Hostname:   (*v1beta1.PreciseHostname)(helpers.GetStringPointer("foo.example.com")),
+				StatusCode: helpers.GetIntPointer(101),
+			},
+			expected: &http.Return{
+				Code: 101,
+				Body: "custom://foo.example.com:123$request_uri",
+			},
+			msg: "scheme is custom, no port is set",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### Proposed changes
Problem: The port in the location header for an HTTPRoute with a requestRedirect filter must be set based on the rules in [the spec](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPRequestRedirectFilter)

We're missing the case where scheme is set to a well-known (http or https) value, but no port is specified. In these cases, we should set the port in the redirect location to 80 for scheme==http, and 443 for scheme==https.

Additionally, when the port is the well known port associated with the scheme, we should not actually include the port in the redirect location. This means that we should ONLY include the port in the redirect url if the scheme is unset, or if the port is specified in the filter to something other than 80 or 443.

Solution: Remove the port in redirect location if it corresponds to the specified scheme.

Testing: Added unit-tests, confirmed the [HTTPRouteRedirectScheme](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-redirect-scheme.go) and [HTTPRouteRedirectPortAndScheme](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-redirect-port-and-scheme.go) conformance tests are now passing

Closes https://github.com/nginxinc/nginx-kubernetes-gateway/issues/795

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
