### PR TITLE
Set GatewayClass status for ignored GatewayClasses

### DIFF
--- a/cmd/gateway/commands.go
+++ b/cmd/gateway/commands.go
@@ -193,6 +193,7 @@ func createProvisionerModeCommand() *cobra.Command {
 			return provisioner.StartManager(provisioner.Config{
 				Logger:           logger,
 				GatewayClassName: gatewayClassName.value,
+				GatewayCtlrName:  gatewayCtlrName.value,
 			})
 		},
 	}

--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -1,7 +1,7 @@
 NKG_TAG = edge
 NKG_PREFIX = nginx-kubernetes-gateway
 GATEWAY_CLASS = nginx
-SUPPORTED_FEATURES = HTTPRoute,HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,HTTPRoutePortRedirect,HTTPRouteSchemeRedirect
+SUPPORTED_FEATURES = HTTPRoute,HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,HTTPRoutePortRedirect,HTTPRouteSchemeRedirect,GatewayClassObservedGenerationBump
 KIND_KUBE_CONFIG=$${HOME}/.kube/kind/config
 TAG = latest
 PREFIX = conformance-test-runner

--- a/docs/gateway-api-compatibility.md
+++ b/docs/gateway-api-compatibility.md
@@ -43,7 +43,10 @@ Fields:
     * `parametersRef` - not supported.
     * `description` - supported.
 * `status`
-    * `conditions` - partially supported.
+    * `conditions` - supported (Condition/Status/Reason):
+      * `Accepted/True/Accepted`
+      * `Accepted/False/InvalidParameters`
+      * `Accepted/False/GatewayClassConflict`: Custom reason for when the GatewayClass references this controller, but a different GatewayClass name is provided to the controller via the command-line argument.
 
 ### Gateway
 

--- a/internal/events/handler.go
+++ b/internal/events/handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-logr/logr"
 	apiv1 "k8s.io/api/core/v1"
 	discoveryV1 "k8s.io/api/discovery/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/nginx/config"
@@ -48,6 +49,8 @@ type EventHandlerConfig struct {
 	StatusUpdater status.Updater
 	// Logger is the logger to be used by the EventHandler.
 	Logger logr.Logger
+	// ControllerName is the name of this controller.
+	ControllerName string
 }
 
 // EventHandlerImpl implements EventHandler.
@@ -121,7 +124,11 @@ func (h *EventHandlerImpl) updateNginx(ctx context.Context, conf dataplane.Confi
 func (h *EventHandlerImpl) propagateUpsert(e *UpsertEvent) {
 	switch r := e.Resource.(type) {
 	case *v1beta1.GatewayClass:
-		h.cfg.Processor.CaptureUpsertChange(r)
+		if string(r.Spec.ControllerName) != h.cfg.ControllerName {
+			h.cfg.Processor.CaptureDeleteChange(r, client.ObjectKeyFromObject(r))
+		} else {
+			h.cfg.Processor.CaptureUpsertChange(r)
+		}
 	case *v1beta1.Gateway:
 		h.cfg.Processor.CaptureUpsertChange(r)
 	case *v1beta1.HTTPRoute:

--- a/internal/events/handler.go
+++ b/internal/events/handler.go
@@ -7,7 +7,6 @@ import (
 	"github.com/go-logr/logr"
 	apiv1 "k8s.io/api/core/v1"
 	discoveryV1 "k8s.io/api/discovery/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/nginx/config"
@@ -49,8 +48,6 @@ type EventHandlerConfig struct {
 	StatusUpdater status.Updater
 	// Logger is the logger to be used by the EventHandler.
 	Logger logr.Logger
-	// ControllerName is the name of this controller.
-	ControllerName string
 }
 
 // EventHandlerImpl implements EventHandler.
@@ -124,11 +121,7 @@ func (h *EventHandlerImpl) updateNginx(ctx context.Context, conf dataplane.Confi
 func (h *EventHandlerImpl) propagateUpsert(e *UpsertEvent) {
 	switch r := e.Resource.(type) {
 	case *v1beta1.GatewayClass:
-		if string(r.Spec.ControllerName) != h.cfg.ControllerName {
-			h.cfg.Processor.CaptureDeleteChange(r, client.ObjectKeyFromObject(r))
-		} else {
-			h.cfg.Processor.CaptureUpsertChange(r)
-		}
+		h.cfg.Processor.CaptureUpsertChange(r)
 	case *v1beta1.Gateway:
 		h.cfg.Processor.CaptureUpsertChange(r)
 	case *v1beta1.HTTPRoute:

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -80,9 +80,7 @@ func Start(cfg config.Config) error {
 		{
 			objectType: &gatewayv1beta1.GatewayClass{},
 			options: []controller.Option{
-				controller.WithNamespacedNameFilter(filter.CreateSingleResourceFilter(
-					types.NamespacedName{Name: cfg.GatewayClassName},
-				)),
+				controller.WithK8sPredicate(predicate.GatewayClassPredicate{ControllerName: cfg.GatewayCtlrName}),
 			},
 		},
 		{

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -175,6 +175,7 @@ func Start(cfg config.Config) error {
 		NginxFileMgr:        nginxFileMgr,
 		NginxRuntimeMgr:     nginxRuntimeMgr,
 		StatusUpdater:       statusUpdater,
+		ControllerName:      cfg.GatewayCtlrName,
 	})
 
 	objects, objectLists := prepareFirstEventBatchPreparerArgs(cfg.GatewayClassName, cfg.GatewayNsName)

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -175,7 +175,6 @@ func Start(cfg config.Config) error {
 		NginxFileMgr:        nginxFileMgr,
 		NginxRuntimeMgr:     nginxRuntimeMgr,
 		StatusUpdater:       statusUpdater,
-		ControllerName:      cfg.GatewayCtlrName,
 	})
 
 	objects, objectLists := prepareFirstEventBatchPreparerArgs(cfg.GatewayClassName, cfg.GatewayNsName)

--- a/internal/manager/predicate/gatewayclass.go
+++ b/internal/manager/predicate/gatewayclass.go
@@ -29,14 +29,19 @@ func (gcp GatewayClassPredicate) Create(e event.CreateEvent) bool {
 
 // Update implements default UpdateEvent filter for validating a GatewayClass controllerName.
 func (gcp GatewayClassPredicate) Update(e event.UpdateEvent) bool {
-	if e.ObjectNew == nil {
-		return false
+	if e.ObjectOld != nil {
+		gcOld, ok := e.ObjectOld.(*v1beta1.GatewayClass)
+		if ok {
+			return string(gcOld.Spec.ControllerName) == gcp.ControllerName
+		}
 	}
 
-	gc, ok := e.ObjectNew.(*v1beta1.GatewayClass)
-	if !ok {
-		return false
+	if e.ObjectNew != nil {
+		gcNew, ok := e.ObjectNew.(*v1beta1.GatewayClass)
+		if ok {
+			return string(gcNew.Spec.ControllerName) == gcp.ControllerName
+		}
 	}
 
-	return string(gc.Spec.ControllerName) == gcp.ControllerName
+	return false
 }

--- a/internal/manager/predicate/gatewayclass.go
+++ b/internal/manager/predicate/gatewayclass.go
@@ -31,15 +31,15 @@ func (gcp GatewayClassPredicate) Create(e event.CreateEvent) bool {
 func (gcp GatewayClassPredicate) Update(e event.UpdateEvent) bool {
 	if e.ObjectOld != nil {
 		gcOld, ok := e.ObjectOld.(*v1beta1.GatewayClass)
-		if ok {
-			return string(gcOld.Spec.ControllerName) == gcp.ControllerName
+		if ok && string(gcOld.Spec.ControllerName) == gcp.ControllerName {
+			return true
 		}
 	}
 
 	if e.ObjectNew != nil {
 		gcNew, ok := e.ObjectNew.(*v1beta1.GatewayClass)
-		if ok {
-			return string(gcNew.Spec.ControllerName) == gcp.ControllerName
+		if ok && string(gcNew.Spec.ControllerName) == gcp.ControllerName {
+			return true
 		}
 	}
 

--- a/internal/manager/predicate/gatewayclass.go
+++ b/internal/manager/predicate/gatewayclass.go
@@ -1,0 +1,42 @@
+package predicate
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+// GatewayClassPredicate implements a predicate function based on the controllerName of a GatewayClass.
+// This predicate will skip events for GatewayClasses that don't reference this controller.
+type GatewayClassPredicate struct {
+	predicate.Funcs
+	ControllerName string
+}
+
+// Create implements default CreateEvent filter for validating a GatewayClass controllerName.
+func (gcp GatewayClassPredicate) Create(e event.CreateEvent) bool {
+	if e.Object == nil {
+		return false
+	}
+
+	gc, ok := e.Object.(*v1beta1.GatewayClass)
+	if !ok {
+		return false
+	}
+
+	return string(gc.Spec.ControllerName) == gcp.ControllerName
+}
+
+// Update implements default UpdateEvent filter for validating a GatewayClass controllerName.
+func (gcp GatewayClassPredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectNew == nil {
+		return false
+	}
+
+	gc, ok := e.ObjectNew.(*v1beta1.GatewayClass)
+	if !ok {
+		return false
+	}
+
+	return string(gc.Spec.ControllerName) == gcp.ControllerName
+}

--- a/internal/manager/predicate/gatewayclass_test.go
+++ b/internal/manager/predicate/gatewayclass_test.go
@@ -30,4 +30,5 @@ func TestGatewayClassPredicate(t *testing.T) {
 	g.Expect(p.Create(event.CreateEvent{Object: gc2})).To(BeFalse())
 	g.Expect(p.Update(event.UpdateEvent{ObjectOld: gc, ObjectNew: gc2})).To(BeTrue())
 	g.Expect(p.Update(event.UpdateEvent{ObjectOld: gc2, ObjectNew: gc})).To(BeTrue())
+	g.Expect(p.Update(event.UpdateEvent{ObjectOld: gc2, ObjectNew: gc2})).To(BeFalse())
 }

--- a/internal/manager/predicate/gatewayclass_test.go
+++ b/internal/manager/predicate/gatewayclass_test.go
@@ -29,4 +29,5 @@ func TestGatewayClassPredicate(t *testing.T) {
 	}
 	g.Expect(p.Create(event.CreateEvent{Object: gc2})).To(BeFalse())
 	g.Expect(p.Update(event.UpdateEvent{ObjectOld: gc, ObjectNew: gc2})).To(BeTrue())
+	g.Expect(p.Update(event.UpdateEvent{ObjectOld: gc2, ObjectNew: gc})).To(BeTrue())
 }

--- a/internal/manager/predicate/gatewayclass_test.go
+++ b/internal/manager/predicate/gatewayclass_test.go
@@ -3,11 +3,14 @@ package predicate
 import (
 	"testing"
 
+	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func TestGatewayClassPredicate(t *testing.T) {
+	g := NewGomegaWithT(t)
+
 	p := GatewayClassPredicate{ControllerName: "nginx-ctlr"}
 
 	gc := &v1beta1.GatewayClass{
@@ -16,18 +19,10 @@ func TestGatewayClassPredicate(t *testing.T) {
 		},
 	}
 
-	if !p.Create(event.CreateEvent{Object: gc}) {
-		t.Error("GatewayClassPredicate.Create() returned false; expected true")
-	}
-	if !p.Update(event.UpdateEvent{ObjectNew: gc}) {
-		t.Error("GatewayClassPredicate.Update() returned false; expected true")
-	}
+	g.Expect(p.Create(event.CreateEvent{Object: gc})).To(BeTrue())
+	g.Expect(p.Update(event.UpdateEvent{ObjectNew: gc})).To(BeTrue())
 
 	gc.Spec.ControllerName = "unknown"
-	if p.Create(event.CreateEvent{Object: gc}) {
-		t.Error("GatewayClassPredicate.Create() returned true; expected false")
-	}
-	if p.Update(event.UpdateEvent{ObjectNew: gc}) {
-		t.Error("GatewayClassPredicate.Update() returned true; expected false")
-	}
+	g.Expect(p.Create(event.CreateEvent{Object: gc})).To(BeFalse())
+	g.Expect(p.Update(event.UpdateEvent{ObjectNew: gc})).To(BeFalse())
 }

--- a/internal/manager/predicate/gatewayclass_test.go
+++ b/internal/manager/predicate/gatewayclass_test.go
@@ -1,0 +1,33 @@
+package predicate
+
+import (
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+func TestGatewayClassPredicate(t *testing.T) {
+	p := GatewayClassPredicate{ControllerName: "nginx-ctlr"}
+
+	gc := &v1beta1.GatewayClass{
+		Spec: v1beta1.GatewayClassSpec{
+			ControllerName: "nginx-ctlr",
+		},
+	}
+
+	if !p.Create(event.CreateEvent{Object: gc}) {
+		t.Error("GatewayClassPredicate.Create() returned false; expected true")
+	}
+	if !p.Update(event.UpdateEvent{ObjectNew: gc}) {
+		t.Error("GatewayClassPredicate.Update() returned false; expected true")
+	}
+
+	gc.Spec.ControllerName = "unknown"
+	if p.Create(event.CreateEvent{Object: gc}) {
+		t.Error("GatewayClassPredicate.Create() returned true; expected false")
+	}
+	if p.Update(event.UpdateEvent{ObjectNew: gc}) {
+		t.Error("GatewayClassPredicate.Update() returned true; expected false")
+	}
+}

--- a/internal/manager/predicate/gatewayclass_test.go
+++ b/internal/manager/predicate/gatewayclass_test.go
@@ -22,7 +22,11 @@ func TestGatewayClassPredicate(t *testing.T) {
 	g.Expect(p.Create(event.CreateEvent{Object: gc})).To(BeTrue())
 	g.Expect(p.Update(event.UpdateEvent{ObjectNew: gc})).To(BeTrue())
 
-	gc.Spec.ControllerName = "unknown"
-	g.Expect(p.Create(event.CreateEvent{Object: gc})).To(BeFalse())
-	g.Expect(p.Update(event.UpdateEvent{ObjectNew: gc})).To(BeFalse())
+	gc2 := &v1beta1.GatewayClass{
+		Spec: v1beta1.GatewayClassSpec{
+			ControllerName: "unknown",
+		},
+	}
+	g.Expect(p.Create(event.CreateEvent{Object: gc2})).To(BeFalse())
+	g.Expect(p.Update(event.UpdateEvent{ObjectOld: gc, ObjectNew: gc2})).To(BeTrue())
 }

--- a/internal/manager/predicate/service_test.go
+++ b/internal/manager/predicate/service_test.go
@@ -3,6 +3,7 @@ package predicate
 import (
 	"testing"
 
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -224,34 +225,24 @@ func TestServicePortsChangedPredicate_Update(t *testing.T) {
 	p := ServicePortsChangedPredicate{}
 
 	for _, tc := range testcases {
-		update := p.Update(event.UpdateEvent{
-			ObjectOld: tc.objectOld,
-			ObjectNew: tc.objectNew,
-		})
+		t.Run(tc.msg, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			update := p.Update(event.UpdateEvent{
+				ObjectOld: tc.objectOld,
+				ObjectNew: tc.objectNew,
+			})
 
-		if update != tc.expUpdate {
-			t.Errorf(
-				"ServicePortsChangedPredicate.Update() mismatch for %q; got %t, expected %t",
-				tc.msg,
-				update,
-				tc.expUpdate,
-			)
-		}
+			g.Expect(update).To(Equal(tc.expUpdate))
+		})
 	}
 }
 
 func TestServicePortsChangedPredicate(t *testing.T) {
+	g := NewGomegaWithT(t)
+
 	p := ServicePortsChangedPredicate{}
 
-	if !p.Delete(event.DeleteEvent{Object: &v1.Service{}}) {
-		t.Errorf("ServicePortsChangedPredicate.Delete() returned false; expected true")
-	}
-
-	if !p.Create(event.CreateEvent{Object: &v1.Service{}}) {
-		t.Errorf("ServicePortsChangedPredicate.Create() returned false; expected true")
-	}
-
-	if !p.Generic(event.GenericEvent{Object: &v1.Service{}}) {
-		t.Errorf("ServicePortsChangedPredicate.Generic() returned false; expected true")
-	}
+	g.Expect(p.Delete(event.DeleteEvent{Object: &v1.Service{}})).To(BeTrue())
+	g.Expect(p.Create(event.CreateEvent{Object: &v1.Service{}})).To(BeTrue())
+	g.Expect(p.Generic(event.GenericEvent{Object: &v1.Service{}})).To(BeTrue())
 }

--- a/internal/provisioner/manager.go
+++ b/internal/provisioner/manager.go
@@ -7,7 +7,6 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	ctlr "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,7 +16,7 @@ import (
 	embeddedfiles "github.com/nginxinc/nginx-kubernetes-gateway"
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/controller"
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/events"
-	"github.com/nginxinc/nginx-kubernetes-gateway/internal/manager/filter"
+	"github.com/nginxinc/nginx-kubernetes-gateway/internal/manager/predicate"
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/status"
 )
 
@@ -25,6 +24,7 @@ import (
 type Config struct {
 	Logger           logr.Logger
 	GatewayClassName string
+	GatewayCtlrName  string
 }
 
 // StartManager starts a Manager for the provisioner mode, which provisions
@@ -60,9 +60,7 @@ func StartManager(cfg Config) error {
 		{
 			objectType: &gatewayv1beta1.GatewayClass{},
 			options: []controller.Option{
-				controller.WithNamespacedNameFilter(
-					filter.CreateSingleResourceFilter(types.NamespacedName{Name: cfg.GatewayClassName}),
-				),
+				controller.WithK8sPredicate(predicate.GatewayClassPredicate{ControllerName: cfg.GatewayCtlrName}),
 			},
 		},
 		{

--- a/internal/state/conditions/conditions.go
+++ b/internal/state/conditions/conditions.go
@@ -8,6 +8,15 @@ import (
 )
 
 const (
+	// GatewayClassReasonGatewayClassConflict indicates there are multiple GatewayClass resources
+	// that reference this controller, and we ignored the resource in question and picked the
+	// GatewayClass that is referenced in the command-line argument.
+	// This reason is used with GatewayClassConditionAccepted (false).
+	GatewayClassReasonGatewayClassConflict v1beta1.GatewayClassConditionReason = "GatewayClassConflict"
+
+	// GatewayClassMessageGatewayClassConflict is a message that describes GatewayClassReasonGatewayClassConflict.
+	GatewayClassMessageGatewayClassConflict = "The resource is ignored due to a conflicting GatewayClass resource"
+
 	// ListenerReasonUnsupportedValue is used with the "Accepted" condition when a value of a field in a Listener
 	// is invalid or not supported.
 	ListenerReasonUnsupportedValue v1beta1.ListenerConditionReason = "UnsupportedValue"
@@ -424,6 +433,17 @@ func NewDefaultGatewayClassConditions() []Condition {
 			Reason:  string(v1beta1.GatewayClassReasonAccepted),
 			Message: "GatewayClass is accepted",
 		},
+	}
+}
+
+// NewGatewayClassConflict returns a Condition that indicates that the GatewayClass is not accepted
+// due to a conflict with another GatewayClass.
+func NewGatewayClassConflict() Condition {
+	return Condition{
+		Type:    string(v1beta1.GatewayClassConditionStatusAccepted),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(GatewayClassReasonGatewayClassConflict),
+		Message: GatewayClassMessageGatewayClassConflict,
 	}
 }
 

--- a/internal/state/graph/gatewayclass.go
+++ b/internal/state/graph/gatewayclass.go
@@ -28,7 +28,7 @@ type processedGatewayClasses struct {
 // processGatewayClasses returns the "Winner" GatewayClass, which is defined in
 // the command-line argument and references this controller, and a list of "Ignored" GatewayClasses
 // that reference this controller, but are not named in the command-line argument.
-// Also returns a boolean that says whether or not the GatewayClasa defined
+// Also returns a boolean that says whether or not the GatewayClass defined
 // in the command-line argument exists, regardless of which controller it references.
 func processGatewayClasses(
 	gcs map[types.NamespacedName]*v1beta1.GatewayClass,

--- a/internal/state/graph/gatewayclass.go
+++ b/internal/state/graph/gatewayclass.go
@@ -1,7 +1,9 @@
 package graph
 
 import (
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state/conditions"
@@ -17,13 +19,40 @@ type GatewayClass struct {
 	Valid bool
 }
 
-func gatewayClassBelongsToController(gc *v1beta1.GatewayClass, controllerName string) bool {
-	// if GatewayClass doesn't exist, we assume it belongs to the controller
-	if gc == nil {
-		return true
+// processedGatewayClasses holds the resources that belong to NKG.
+type processedGatewayClasses struct {
+	Winner  *v1beta1.GatewayClass
+	Ignored map[types.NamespacedName]*v1beta1.GatewayClass
+}
+
+// processGatewayClasses returns the "Winner" GatewayClass, which is defined in
+// the command-line argument and references this controller, and a list of "Ignored" GatewayClasses
+// that reference this controller, but are not named in the command-line argument.
+// Also returns a boolean that says whether or not the GatewayClasa defined
+// in the command-line argument exists, regardless of which controller it references.
+func processGatewayClasses(
+	gcs map[types.NamespacedName]*v1beta1.GatewayClass,
+	gcName string,
+	controllerName string,
+) (processedGatewayClasses, bool) {
+	processedGwClasses := processedGatewayClasses{}
+
+	var gcExists bool
+	for _, gc := range gcs {
+		if gc.Name == gcName {
+			gcExists = true
+			if string(gc.Spec.ControllerName) == controllerName {
+				processedGwClasses.Winner = gc
+			}
+		} else if string(gc.Spec.ControllerName) == controllerName {
+			if processedGwClasses.Ignored == nil {
+				processedGwClasses.Ignored = make(map[types.NamespacedName]*v1beta1.GatewayClass)
+			}
+			processedGwClasses.Ignored[client.ObjectKeyFromObject(gc)] = gc
+		}
 	}
 
-	return string(gc.Spec.ControllerName) == controllerName
+	return processedGwClasses, gcExists
 }
 
 func buildGatewayClass(gc *v1beta1.GatewayClass) *GatewayClass {

--- a/internal/state/graph/gatewayclass_test.go
+++ b/internal/state/graph/gatewayclass_test.go
@@ -4,11 +4,118 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/helpers"
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/state/conditions"
 )
+
+func TestProcessGatewayClasses(t *testing.T) {
+	gcName := "test-gc"
+	ctlrName := "test-ctlr"
+	winner := &v1beta1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: gcName,
+		},
+		Spec: v1beta1.GatewayClassSpec{
+			ControllerName: v1beta1.GatewayController(ctlrName),
+		},
+	}
+	ignored := &v1beta1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-gc-ignored",
+		},
+		Spec: v1beta1.GatewayClassSpec{
+			ControllerName: v1beta1.GatewayController(ctlrName),
+		},
+	}
+
+	tests := []struct {
+		expected processedGatewayClasses
+		gcs      map[types.NamespacedName]*v1beta1.GatewayClass
+		name     string
+		exists   bool
+	}{
+		{
+			gcs:      nil,
+			expected: processedGatewayClasses{},
+			name:     "no gatewayclasses",
+		},
+		{
+			gcs: map[types.NamespacedName]*v1beta1.GatewayClass{
+				{Name: gcName}: winner,
+			},
+			expected: processedGatewayClasses{
+				Winner: winner,
+			},
+			exists: true,
+			name:   "one valid gatewayclass",
+		},
+		{
+			gcs: map[types.NamespacedName]*v1beta1.GatewayClass{
+				{Name: gcName}: {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: gcName,
+					},
+					Spec: v1beta1.GatewayClassSpec{
+						ControllerName: v1beta1.GatewayController("not ours"),
+					},
+				},
+			},
+			expected: processedGatewayClasses{},
+			exists:   true,
+			name:     "one valid gatewayclass, but references wrong controller",
+		},
+		{
+			gcs: map[types.NamespacedName]*v1beta1.GatewayClass{
+				{Name: ignored.Name}: ignored,
+			},
+			expected: processedGatewayClasses{
+				Ignored: map[types.NamespacedName]*v1beta1.GatewayClass{
+					client.ObjectKeyFromObject(ignored): ignored,
+				},
+			},
+			name: "one non-referenced gatewayclass with our controller",
+		},
+		{
+			gcs: map[types.NamespacedName]*v1beta1.GatewayClass{
+				{Name: "completely ignored"}: {
+					Spec: v1beta1.GatewayClassSpec{
+						ControllerName: v1beta1.GatewayController("not ours"),
+					},
+				},
+			},
+			expected: processedGatewayClasses{},
+			name:     "one non-referenced gatewayclass without our controller",
+		},
+		{
+			gcs: map[types.NamespacedName]*v1beta1.GatewayClass{
+				{Name: gcName}:       winner,
+				{Name: ignored.Name}: ignored,
+			},
+			expected: processedGatewayClasses{
+				Winner: winner,
+				Ignored: map[types.NamespacedName]*v1beta1.GatewayClass{
+					client.ObjectKeyFromObject(ignored): ignored,
+				},
+			},
+			exists: true,
+			name:   "one valid gateway class and non-referenced gatewayclass",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			result, exists := processGatewayClasses(test.gcs, gcName, ctlrName)
+			g.Expect(helpers.Diff(test.expected, result)).To(BeEmpty())
+			g.Expect(exists).To(Equal(test.exists))
+		})
+	}
+}
 
 func TestBuildGatewayClass(t *testing.T) {
 	validGC := &v1beta1.GatewayClass{}
@@ -56,58 +163,6 @@ func TestBuildGatewayClass(t *testing.T) {
 
 			result := buildGatewayClass(test.gc)
 			g.Expect(helpers.Diff(test.expected, result)).To(BeEmpty())
-		})
-	}
-}
-
-func TestGatewayClassBelongsToController(t *testing.T) {
-	const controllerName = "my.controller"
-
-	tests := []struct {
-		gc       *v1beta1.GatewayClass
-		name     string
-		expected bool
-	}{
-		{
-			gc: &v1beta1.GatewayClass{
-				Spec: v1beta1.GatewayClassSpec{
-					ControllerName: controllerName,
-				},
-			},
-			expected: true,
-			name:     "normal gatewayclass",
-		},
-		{
-			gc:       nil,
-			expected: true,
-			name:     "no gatewayclass",
-		},
-		{
-			gc: &v1beta1.GatewayClass{
-				Spec: v1beta1.GatewayClassSpec{
-					ControllerName: "some.controller",
-				},
-			},
-			expected: false,
-			name:     "wrong controller name",
-		},
-		{
-			gc: &v1beta1.GatewayClass{
-				Spec: v1beta1.GatewayClassSpec{
-					ControllerName: "",
-				},
-			},
-			expected: false,
-			name:     "empty controller name",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
-
-			result := gatewayClassBelongsToController(test.gc, controllerName)
-			g.Expect(result).To(Equal(test.expected))
 		})
 	}
 }

--- a/internal/state/graph/graph.go
+++ b/internal/state/graph/graph.go
@@ -25,6 +25,10 @@ type Graph struct {
 	GatewayClass *GatewayClass
 	// Gateway holds the winning Gateway resource.
 	Gateway *Gateway
+	// IgnoredGatewayClasses holds the ignored GatewayClass resources, which reference NGINX Gateway in the
+	// controllerName, but are not configured via the NGINX Gateway CLI argument. It doesn't hold the GatewayClass
+	// resources that do not belong to the NGINX Gateway.
+	IgnoredGatewayClasses map[types.NamespacedName]*v1beta1.GatewayClass
 	// IgnoredGateways holds the ignored Gateway resources, which belong to the NGINX Gateway (based on the
 	// GatewayClassName field of the resource) but ignored. It doesn't hold the Gateway resources that do not belong to
 	// the NGINX Gateway.
@@ -41,16 +45,14 @@ func BuildGraph(
 	secretMemoryMgr secrets.SecretDiskMemoryManager,
 	validators validation.Validators,
 ) *Graph {
-	gatewayClass := state.GatewayClasses[types.NamespacedName{Name: gcName}]
-
-	if !gatewayClassBelongsToController(gatewayClass, controllerName) {
+	processedGwClasses, gcExists := processGatewayClasses(state.GatewayClasses, gcName, controllerName)
+	if gcExists && processedGwClasses.Winner == nil {
+		// configured GatewayClass does not reference this controller
 		return &Graph{}
 	}
-
-	gc := buildGatewayClass(gatewayClass)
+	gc := buildGatewayClass(processedGwClasses.Winner)
 
 	processedGws := processGateways(state.Gateways, gcName)
-
 	gw := buildGateway(processedGws.Winner, secretMemoryMgr, gc, state.ReferenceGrants)
 
 	routes := buildRoutesForGateways(validators.HTTPFieldsValidator, state.HTTPRoutes, processedGws.GetAllNsNames())
@@ -58,10 +60,11 @@ func BuildGraph(
 	addBackendRefsToRouteRules(routes, state.Services)
 
 	g := &Graph{
-		GatewayClass:    gc,
-		Gateway:         gw,
-		Routes:          routes,
-		IgnoredGateways: processedGws.Ignored,
+		GatewayClass:          gc,
+		Gateway:               gw,
+		Routes:                routes,
+		IgnoredGatewayClasses: processedGwClasses.Ignored,
+		IgnoredGateways:       processedGws.Ignored,
 	}
 
 	return g

--- a/internal/status/updater.go
+++ b/internal/status/updater.go
@@ -83,16 +83,14 @@ func (upd *updaterImpl) Update(ctx context.Context, statuses Statuses) {
 	// FIXME(pleshakov) Merge the new Conditions in the status with the existing Conditions
 	// https://github.com/nginxinc/nginx-kubernetes-gateway/issues/558
 
-	if upd.cfg.UpdateGatewayClassStatus && statuses.GatewayClassStatus != nil {
-		upd.update(
-			ctx,
-			types.NamespacedName{Name: upd.cfg.GatewayClassName},
-			&v1beta1.GatewayClass{},
-			func(object client.Object) {
+	if upd.cfg.UpdateGatewayClassStatus {
+		for nsname, gcs := range statuses.GatewayClassStatuses {
+			upd.update(ctx, nsname, &v1beta1.GatewayClass{}, func(object client.Object) {
 				gc := object.(*v1beta1.GatewayClass)
-				gc.Status = prepareGatewayClassStatus(*statuses.GatewayClassStatus, upd.cfg.Clock.Now())
+				gc.Status = prepareGatewayClassStatus(gcs, upd.cfg.Clock.Now())
 			},
-		)
+			)
+		}
 	}
 
 	for nsname, gs := range statuses.GatewayStatuses {

--- a/internal/status/updater_test.go
+++ b/internal/status/updater_test.go
@@ -71,9 +71,11 @@ var _ = Describe("Updater", func() {
 
 			createStatuses = func(gens generations) status.Statuses {
 				return status.Statuses{
-					GatewayClassStatus: &status.GatewayClassStatus{
-						ObservedGeneration: gens.gatewayClass,
-						Conditions:         status.CreateTestConditions("Test"),
+					GatewayClassStatuses: status.GatewayClassStatuses{
+						{Name: gcName}: {
+							ObservedGeneration: gens.gatewayClass,
+							Conditions:         status.CreateTestConditions("Test"),
+						},
 					},
 					GatewayStatuses: status.GatewayStatuses{
 						{Namespace: "test", Name: "gateway"}: {
@@ -441,9 +443,11 @@ var _ = Describe("Updater", func() {
 			updater.Update(
 				context.Background(),
 				status.Statuses{
-					GatewayClassStatus: &status.GatewayClassStatus{
-						ObservedGeneration: 1,
-						Conditions:         status.CreateTestConditions("Test"),
+					GatewayClassStatuses: status.GatewayClassStatuses{
+						{Name: gcName}: {
+							ObservedGeneration: 1,
+							Conditions:         status.CreateTestConditions("Test"),
+						},
 					},
 				},
 			)


### PR DESCRIPTION
Problem: It is expected that any GatewayClass that references our controller should have its status set properly, even if not used by our controller.

Solution: Both the provisioner and controller will now add Accepted status False and ObservedGeneration to any GatewayClass that references our controller but is not configured to be used by our controller.

Testing: Conformance test now passes. Controller will also properly set statuses when not using provisioner.

Closes #775

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
