### PR TITLE
Support cross-namespace BackendRefs in HTTPRoutes

### DIFF
--- a/docs/gateway-api-compatibility.md
+++ b/docs/gateway-api-compatibility.md
@@ -12,7 +12,7 @@ This document describes which Gateway API resources NGINX Kubernetes Gateway sup
 | [TLSRoute](#tlsroute) | Not supported |
 | [TCPRoute](#tcproute) | Not supported |
 | [UDPRoute](#udproute) | Not supported |
-| [ReferenceGrant](#referencegrant) |  Partially supported |
+| [ReferenceGrant](#referencegrant) |  Supported |
 | [Custom policies](#custom-policies) | Not supported |
 
 ## Terminology
@@ -152,19 +152,18 @@ Fields:
 
 ### ReferenceGrant
 
-> Status: Partially supported.
-
-NKG only supports ReferenceGrants that permit Gateways to reference Secrets. 
+> Status: Supported.
+> Support Level: Core
 
 Fields:
 * `spec`
   * `to`
     * `group` - supported.
-    * `kind` - partially supported. Only `Secret`.
+    * `kind` - supports `Secret` and `Service`.
     * `name`- supported.
   * `from`
     * `group` - supported.
-    * `kind` - partially supported. Only `Gateway`.
+    * `kind` - supports `Gateway` and `HTTPRoute`.
     * `namespace`- supported.
 
 ### Custom Policies

--- a/examples/cross-namespace-routing/README.md
+++ b/examples/cross-namespace-routing/README.md
@@ -101,7 +101,6 @@ curl --resolve cafe.example.com:$GW_PORT:$GW_IP http://cafe.example.com:$GW_PORT
 </html>
 ```
 
-
 You can also check the conditions of the HTTPRoutes `coffee` and `tea` to verify that the reference is not permitted:
 
 ```

--- a/examples/cross-namespace-routing/README.md
+++ b/examples/cross-namespace-routing/README.md
@@ -1,0 +1,129 @@
+# Example
+
+In this example, we expand on the simple [cafe-example](../cafe-example) by using a ReferenceGrant to route to backends
+in a different namespace from our HTTPRoutes.
+
+## Running the Example
+
+## 1. Deploy NGINX Kubernetes Gateway
+
+1. Follow the [installation instructions](/docs/installation.md) to deploy NGINX Gateway.
+
+1. Save the public IP address of NGINX Kubernetes Gateway into a shell variable:
+
+   ```
+   GW_IP=XXX.YYY.ZZZ.III
+   ```
+
+1. Save the port of NGINX Kubernetes Gateway:
+
+   ```
+   GW_PORT=<port number>
+   ```
+
+## 2. Deploy the Cafe Application
+
+1. Create the cafe namespace and cafe application:
+
+   ```
+   kubectl apply -f cafe-ns-and-app.yaml
+   ```
+
+1. Check that the Pods are running in the `cafe` namespace:
+
+   ```
+   kubectl -n cafe get pods
+   NAME                      READY   STATUS    RESTARTS   AGE
+   coffee-6f4b79b975-2sb28   1/1     Running   0          12s
+   tea-6fb46d899f-fm7zr      1/1     Running   0          12s
+   ```
+
+## 3. Configure Routing
+
+1. Create the `Gateway`:
+
+   ```
+   kubectl apply -f gateway.yaml
+   ```
+
+1. Create the `HTTPRoute` resources:
+
+   ```
+   kubectl apply -f cafe-routes.yaml
+   ```
+1. Create the `ReferenceGrant`:
+
+   ```
+   kubectl apply -f reference-grant.yaml
+   ```
+   This ReferenceGrant allows all HTTPRoutes in the `default` namespace to reference all Services in the `cafe`
+   namespace.
+
+## 4. Test the Application
+
+To access the application, we will use `curl` to send requests to the `coffee` and `tea` Services.
+
+To get coffee:
+
+```
+curl --resolve cafe.example.com:$GW_PORT:$GW_IP http://cafe.example.com:$GW_PORT/coffee
+Server address: 10.12.0.18:80
+Server name: coffee-7586895968-r26zn
+```
+
+To get tea:
+
+```
+curl --resolve cafe.example.com:$GW_PORT:$GW_IP http://cafe.example.com:$GW_PORT/tea
+Server address: 10.12.0.19:80
+Server name: tea-7cd44fcb4d-xfw2x
+```
+
+## 5. Remove the ReferenceGrant
+
+To restrict access to Services in the `cafe` Namespace, we can delete the ReferenceGrant we created in
+Step 3:
+
+```
+kubectl delete -f reference-grant.yaml
+```
+
+Now, if we try to access the application over HTTPS, we will get an internal server error:
+```
+curl --resolve cafe.example.com:$GW_PORT:$GW_IP http://cafe.example.com:$GW_PORT/tea
+
+<html>
+<head><title>500 Internal Server Error</title></head>
+<body>
+<center><h1>500 Internal Server Error</h1></center>
+<hr><center>nginx/1.25.1</center>
+</body>
+</html>
+```
+
+
+You can also check the conditions of the HTTPRoutes `coffee` and `tea` to verify the that the reference is not permitted:
+
+```
+kubectl describe httproute coffee
+
+Condtions:
+      Message:               Backend ref to Service cafe/coffee not permitted by any ReferenceGrant
+      Observed Generation:   1
+      Reason:                RefNotPermitted
+      Status:                False
+      Type:                  ResolvedRefs
+      Controller Name:       k8s-gateway.nginx.org/nginx-gateway-controller
+```
+
+```
+kubectl describe httproute tea
+
+Condtions:
+      Message:               Backend ref to Service cafe/tea not permitted by any ReferenceGrant
+      Observed Generation:   1
+      Reason:                RefNotPermitted
+      Status:                False
+      Type:                  ResolvedRefs
+      Controller Name:       k8s-gateway.nginx.org/nginx-gateway-controller
+```

--- a/examples/cross-namespace-routing/README.md
+++ b/examples/cross-namespace-routing/README.md
@@ -102,7 +102,7 @@ curl --resolve cafe.example.com:$GW_PORT:$GW_IP http://cafe.example.com:$GW_PORT
 ```
 
 
-You can also check the conditions of the HTTPRoutes `coffee` and `tea` to verify the that the reference is not permitted:
+You can also check the conditions of the HTTPRoutes `coffee` and `tea` to verify that the reference is not permitted:
 
 ```
 kubectl describe httproute coffee

--- a/examples/cross-namespace-routing/README.md
+++ b/examples/cross-namespace-routing/README.md
@@ -88,7 +88,7 @@ Step 3:
 kubectl delete -f reference-grant.yaml
 ```
 
-Now, if we try to access the application over HTTPS, we will get an internal server error:
+Now, if we try to access the application over HTTP, we will get an internal server error:
 ```
 curl --resolve cafe.example.com:$GW_PORT:$GW_IP http://cafe.example.com:$GW_PORT/tea
 

--- a/examples/cross-namespace-routing/cafe-ns-and-app.yaml
+++ b/examples/cross-namespace-routing/cafe-ns-and-app.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cafe
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coffee
+  namespace: cafe
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: coffee
+  template:
+    metadata:
+      labels:
+        app: coffee
+    spec:
+      containers:
+      - name: coffee
+        image: nginxdemos/nginx-hello:plain-text
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coffee
+  namespace: cafe
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: coffee
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tea
+  namespace: cafe
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tea
+  template:
+    metadata:
+      labels:
+        app: tea
+    spec:
+      containers:
+      - name: tea
+        image: nginxdemos/nginx-hello:plain-text
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tea
+  namespace: cafe
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: tea

--- a/examples/cross-namespace-routing/cafe-routes.yaml
+++ b/examples/cross-namespace-routing/cafe-routes.yaml
@@ -1,0 +1,39 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: coffee
+spec:
+  parentRefs:
+  - name: gateway
+    sectionName: http
+  hostnames:
+  - "cafe.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /coffee
+    backendRefs:
+    - name: coffee
+      namespace: cafe
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: tea
+spec:
+  parentRefs:
+  - name: gateway
+    sectionName: http
+  hostnames:
+  - "cafe.example.com"
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /tea
+    backendRefs:
+    - name: tea
+      namespace: cafe
+      port: 80

--- a/examples/cross-namespace-routing/gateway.yaml
+++ b/examples/cross-namespace-routing/gateway.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: gateway
+  labels:
+    domain: k8s-gateway.nginx.org
+spec:
+  gatewayClassName: nginx
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+    hostname: "*.example.com"

--- a/examples/cross-namespace-routing/reference-grant.yaml
+++ b/examples/cross-namespace-routing/reference-grant.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: access-to-cafe-services
+  namespace: cafe
+spec:
+  to:
+  - group: ""
+    kind: Service
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: default

--- a/examples/https-termination/README.md
+++ b/examples/https-termination/README.md
@@ -164,6 +164,8 @@ curl: (7) Failed to connect to cafe.example.com port 443 after 0 ms: Connection 
 You can also check the conditions of the Gateway `https` Listener to verify the that the reference is not permitted:
 
 ```
+ kubectl describe gateway gateway
+
  Name:                    https
  Conditions:
    Last Transition Time:  2023-06-26T20:23:56Z

--- a/examples/https-termination/reference-grant.yaml
+++ b/examples/https-termination/reference-grant.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
-  name: allow-default-to-cafe-secret
+  name: access-to-cafe-secret
   namespace: certificate
 spec:
   to:

--- a/internal/state/graph/backend_refs_test.go
+++ b/internal/state/graph/backend_refs_test.go
@@ -18,12 +18,12 @@ import (
 func getNormalRef() v1beta1.BackendRef {
 	return v1beta1.BackendRef{
 		BackendObjectReference: v1beta1.BackendObjectReference{
-			Kind:      (*v1beta1.Kind)(helpers.GetStringPointer("Service")),
+			Kind:      helpers.GetPointer[v1beta1.Kind]("Service"),
 			Name:      "service1",
-			Namespace: (*v1beta1.Namespace)(helpers.GetStringPointer("test")),
-			Port:      (*v1beta1.PortNumber)(helpers.GetInt32Pointer(80)),
+			Namespace: helpers.GetPointer[v1beta1.Namespace]("test"),
+			Port:      helpers.GetPointer[v1beta1.PortNumber](80),
 		},
-		Weight: helpers.GetInt32Pointer(5),
+		Weight: helpers.GetPointer[int32](5),
 	}
 }
 
@@ -95,7 +95,7 @@ func TestValidateBackendRef(t *testing.T) {
 			To: []v1beta1.ReferenceGrantTo{
 				{
 					Kind: "Service",
-					Name: helpers.GetPointer(v1beta1.ObjectName("service1")),
+					Name: helpers.GetPointer[v1beta1.ObjectName]("service1"),
 				},
 			},
 			From: []v1beta1.ReferenceGrantFrom{
@@ -142,7 +142,7 @@ func TestValidateBackendRef(t *testing.T) {
 		{
 			name: "normal case with backend ref allowed by specific reference grant",
 			ref: getModifiedRef(func(backend v1beta1.BackendRef) v1beta1.BackendRef {
-				backend.Namespace = (*v1beta1.Namespace)(helpers.GetStringPointer("cross-ns"))
+				backend.Namespace = helpers.GetPointer[v1beta1.Namespace]("cross-ns")
 				return backend
 			}),
 			refGrants: map[types.NamespacedName]*v1beta1.ReferenceGrant{
@@ -153,7 +153,7 @@ func TestValidateBackendRef(t *testing.T) {
 		{
 			name: "normal case with backend ref allowed by all-in-namespace reference grant",
 			ref: getModifiedRef(func(backend v1beta1.BackendRef) v1beta1.BackendRef {
-				backend.Namespace = (*v1beta1.Namespace)(helpers.GetStringPointer("cross-ns"))
+				backend.Namespace = helpers.GetPointer[v1beta1.Namespace]("cross-ns")
 				return backend
 			}),
 			refGrants: map[types.NamespacedName]*v1beta1.ReferenceGrant{
@@ -175,7 +175,7 @@ func TestValidateBackendRef(t *testing.T) {
 		{
 			name: "not a service kind",
 			ref: getModifiedRef(func(backend v1beta1.BackendRef) v1beta1.BackendRef {
-				backend.Kind = (*v1beta1.Kind)(helpers.GetStringPointer("NotService"))
+				backend.Kind = helpers.GetPointer[v1beta1.Kind]("NotService")
 				return backend
 			}),
 			expectedValid: false,
@@ -186,7 +186,7 @@ func TestValidateBackendRef(t *testing.T) {
 		{
 			name: "backend ref not allowed by reference grant",
 			ref: getModifiedRef(func(backend v1beta1.BackendRef) v1beta1.BackendRef {
-				backend.Namespace = (*v1beta1.Namespace)(helpers.GetStringPointer("invalid"))
+				backend.Namespace = helpers.GetPointer[v1beta1.Namespace]("invalid")
 				return backend
 			}),
 			expectedValid: false,

--- a/internal/state/graph/gateway.go
+++ b/internal/state/graph/gateway.go
@@ -94,7 +94,7 @@ func buildGateway(
 	gw *v1beta1.Gateway,
 	secretMemoryMgr secrets.SecretDiskMemoryManager,
 	gc *GatewayClass,
-	refGrants map[types.NamespacedName]*v1beta1.ReferenceGrant,
+	refGrantResolver *referenceGrantResolver,
 ) *Gateway {
 	if gw == nil {
 		return nil
@@ -112,7 +112,7 @@ func buildGateway(
 
 	return &Gateway{
 		Source:    gw,
-		Listeners: buildListeners(gw, secretMemoryMgr, refGrants),
+		Listeners: buildListeners(gw, secretMemoryMgr, refGrantResolver),
 		Valid:     true,
 	}
 }

--- a/internal/state/graph/gateway_test.go
+++ b/internal/state/graph/gateway_test.go
@@ -744,7 +744,8 @@ func TestBuildGateway(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
-			result := buildGateway(test.gateway, secretMemoryMgr, test.gatewayClass, test.refGrants)
+			resolver := newReferenceGrantResolver(test.refGrants)
+			result := buildGateway(test.gateway, secretMemoryMgr, test.gatewayClass, resolver)
 			g.Expect(helpers.Diff(test.expected, result)).To(BeEmpty())
 		})
 	}

--- a/internal/state/graph/graph.go
+++ b/internal/state/graph/graph.go
@@ -53,11 +53,13 @@ func BuildGraph(
 	gc := buildGatewayClass(processedGwClasses.Winner)
 
 	processedGws := processGateways(state.Gateways, gcName)
-	gw := buildGateway(processedGws.Winner, secretMemoryMgr, gc, state.ReferenceGrants)
+
+	refGrantResolver := newReferenceGrantResolver(state.ReferenceGrants)
+	gw := buildGateway(processedGws.Winner, secretMemoryMgr, gc, refGrantResolver)
 
 	routes := buildRoutesForGateways(validators.HTTPFieldsValidator, state.HTTPRoutes, processedGws.GetAllNsNames())
 	bindRoutesToListeners(routes, gw, state.Namespaces)
-	addBackendRefsToRouteRules(routes, state.Services)
+	addBackendRefsToRouteRules(routes, refGrantResolver, state.Services)
 
 	g := &Graph{
 		GatewayClass:          gc,

--- a/internal/state/graph/reference_grant.go
+++ b/internal/state/graph/reference_grant.go
@@ -5,59 +5,131 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func refGrantAllowsGatewayToSecret(
-	refGrants map[types.NamespacedName]*v1beta1.ReferenceGrant,
-	gwNs string,
-	secretNsName types.NamespacedName,
-) bool {
-	for nsname, grant := range refGrants {
-		if nsname.Namespace != secretNsName.Namespace {
-			continue
-		}
+// referenceGrantResolver resolves references from one resource to another.
+type referenceGrantResolver struct {
+	allowed map[allowedReference]struct{}
+}
 
-		if fromIncludesGatewayNs(grant.Spec.From, gwNs) && toIncludesSecret(grant.Spec.To, secretNsName.Name) {
+// allowedReference represents an allowed reference from one resource to another.
+type allowedReference struct {
+	to   toResource
+	from fromResource
+}
+
+// toResource represents the resource that the ReferenceGrant is granting access to.
+// Maps to the v1beta1.ReferenceGrantTo.
+type toResource struct {
+	// if group is core, this should be set to "".
+	group     string
+	kind      string
+	name      string
+	namespace string
+}
+
+// fromResource represents the resource that the ReferenceGrant is granting access from.
+// Maps to the v1beta1.ReferenceGrantFrom.
+type fromResource struct {
+	group     string
+	kind      string
+	namespace string
+}
+
+// The following functions are helper functions that create toResources and fromResources for the ReferenceGrant
+// resources that we support. Use these functions when calling refAllowed instead of creating your own toResource and
+// fromResource.
+
+func toSecret(nsname types.NamespacedName) toResource {
+	return toResource{
+		kind:      "Secret",
+		name:      nsname.Name,
+		namespace: nsname.Namespace,
+	}
+}
+
+func toService(nsname types.NamespacedName) toResource {
+	return toResource{
+		kind:      "Service",
+		name:      nsname.Name,
+		namespace: nsname.Namespace,
+	}
+}
+
+func fromGateway(namespace string) fromResource {
+	return fromResource{
+		group:     v1beta1.GroupName,
+		kind:      "Gateway",
+		namespace: namespace,
+	}
+}
+
+func fromHTTPRoute(namespace string) fromResource {
+	return fromResource{
+		group:     v1beta1.GroupName,
+		kind:      "HTTPRoute",
+		namespace: namespace,
+	}
+}
+
+// newReferenceGrantResolver creates a new referenceGrantResolver.
+func newReferenceGrantResolver(refGrants map[types.NamespacedName]*v1beta1.ReferenceGrant) *referenceGrantResolver {
+	allowed := make(map[allowedReference]struct{})
+
+	for nsname, grant := range refGrants {
+		for _, to := range grant.Spec.To {
+			for _, from := range grant.Spec.From {
+
+				toName := ""
+				if to.Name != nil {
+					toName = string(*to.Name)
+				}
+
+				toGroup := string(to.Group)
+				if toGroup == "core" {
+					toGroup = ""
+				}
+
+				ar := allowedReference{
+					to: toResource{
+						group:     toGroup,
+						kind:      string(to.Kind),
+						name:      toName,
+						namespace: nsname.Namespace,
+					},
+					from: fromResource{
+						group:     string(from.Group),
+						kind:      string(from.Kind),
+						namespace: string(from.Namespace),
+					},
+				}
+
+				allowed[ar] = struct{}{}
+			}
+		}
+	}
+
+	return &referenceGrantResolver{allowed: allowed}
+}
+
+// refAllowed returns whether the reference from the fromResource to the toResource is allowed by a ReferenceGrant.
+func (r *referenceGrantResolver) refAllowed(to toResource, from fromResource) bool {
+	specificKey := allowedReference{
+		to:   to,
+		from: from,
+	}
+
+	// omit name field to check for reference grants that allow access to all a particular kind in the namespace
+	allInNamespaceKey := allowedReference{
+		to: toResource{
+			kind:      to.kind,
+			namespace: to.namespace,
+		},
+		from: from,
+	}
+
+	for _, key := range []allowedReference{specificKey, allInNamespaceKey} {
+		if _, ok := r.allowed[key]; ok {
 			return true
 		}
-	}
-
-	return false
-}
-
-func fromIncludesGatewayNs(fromList []v1beta1.ReferenceGrantFrom, gwNs string) bool {
-	for _, from := range fromList {
-		if from.Group != v1beta1.GroupName {
-			continue
-		}
-
-		if from.Kind != "Gateway" {
-			continue
-		}
-
-		if string(from.Namespace) != gwNs {
-			continue
-		}
-
-		return true
-	}
-
-	return false
-}
-
-func toIncludesSecret(toList []v1beta1.ReferenceGrantTo, secretName string) bool {
-	for _, to := range toList {
-		if to.Group != "" && to.Group != "core" {
-			continue
-		}
-
-		if to.Kind != "Secret" {
-			continue
-		}
-
-		if to.Name != nil && string(*to.Name) != secretName {
-			continue
-		}
-
-		return true
 	}
 
 	return false

--- a/internal/state/graph/reference_grant.go
+++ b/internal/state/graph/reference_grant.go
@@ -117,7 +117,8 @@ func (r *referenceGrantResolver) refAllowed(to toResource, from fromResource) bo
 		from: from,
 	}
 
-	// omit name field to check for ReferenceGrants that allow access to all resources of the particular kind in the namespace
+	// omit name field to check for ReferenceGrants that allow access to all resources
+	// of the particular kind in the namespace
 	allInNamespaceKey := allowedReference{
 		to: toResource{
 			kind:      to.kind,

--- a/internal/state/graph/reference_grant.go
+++ b/internal/state/graph/reference_grant.go
@@ -117,7 +117,7 @@ func (r *referenceGrantResolver) refAllowed(to toResource, from fromResource) bo
 		from: from,
 	}
 
-	// omit name field to check for reference grants that allow access to all a particular kind in the namespace
+	// omit name field to check for ReferenceGrants that allow access to all resources of the particular kind in the namespace
 	allInNamespaceKey := allowedReference{
 		to: toResource{
 			kind:      to.kind,

--- a/internal/state/graph/reference_grant_test.go
+++ b/internal/state/graph/reference_grant_test.go
@@ -148,6 +148,12 @@ func TestReferenceGrantResolver(t *testing.T) {
 			from:    normalFrom,
 			allowed: true,
 		},
+		{
+			msg:     "allowed; matches specific reference grant with explicit 'core' group name",
+			to:      toResource{kind: "Secret", name: secretNsName.Name, namespace: "explicit-core-group"},
+			from:    normalFrom,
+			allowed: true,
+		},
 	}
 
 	resolver := newReferenceGrantResolver(refGrants)

--- a/internal/state/graph/reference_grant_test.go
+++ b/internal/state/graph/reference_grant_test.go
@@ -4,23 +4,18 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/helpers"
 )
 
-func TestRefGrantAllowsGatewayToSecret(t *testing.T) {
+func TestReferenceGrantResolver(t *testing.T) {
 	gwNs := "gw-ns"
 	secretNsName := types.NamespacedName{Namespace: "test", Name: "certificate"}
 
 	getNormalRefGrant := func() *v1beta1.ReferenceGrant {
 		return &v1beta1.ReferenceGrant{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "rg",
-				Namespace: "test",
-			},
 			Spec: v1beta1.ReferenceGrantSpec{
 				From: []v1beta1.ReferenceGrantFrom{
 					{
@@ -31,9 +26,8 @@ func TestRefGrantAllowsGatewayToSecret(t *testing.T) {
 				},
 				To: []v1beta1.ReferenceGrantTo{
 					{
-						Group: "core",
-						Kind:  "Secret",
-						Name:  helpers.GetPointer(v1beta1.ObjectName(secretNsName.Name)),
+						Kind: "Secret",
+						Name: helpers.GetPointer(v1beta1.ObjectName(secretNsName.Name)),
 					},
 				},
 			},
@@ -46,156 +40,170 @@ func TestRefGrantAllowsGatewayToSecret(t *testing.T) {
 		return rg
 	}
 
+	refGrants := map[types.NamespacedName]*v1beta1.ReferenceGrant{
+		{Namespace: "test", Name: "valid"}: createModifiedRefGrant(func(rg *v1beta1.ReferenceGrant) {
+			rg.Spec.To = []v1beta1.ReferenceGrantTo{
+				{
+					Kind: "Secret",
+					Name: helpers.GetPointer(v1beta1.ObjectName("wrong-name1")),
+				},
+				{
+					Kind: "Secret",
+					Name: helpers.GetPointer(v1beta1.ObjectName("wrong-name2")),
+				},
+				{
+					Kind: "Secret",
+					Name: helpers.GetPointer(v1beta1.ObjectName(secretNsName.Name)), // matches
+				},
+			}
+		}),
+		{Namespace: "explicit-core-group", Name: "valid"}: createModifiedRefGrant(func(rg *v1beta1.ReferenceGrant) {
+			rg.Spec.To[0].Group = "core"
+		}),
+		{Namespace: "all-in-namespace", Name: "valid"}: createModifiedRefGrant(func(rg *v1beta1.ReferenceGrant) {
+			rg.Spec.To[0].Name = nil
+			rg.Spec.From = []v1beta1.ReferenceGrantFrom{
+				{
+					Group:     v1beta1.GroupName,
+					Kind:      "Gateway",
+					Namespace: "wrong-ns1",
+				},
+				{
+					Group:     v1beta1.GroupName,
+					Kind:      "Gateway",
+					Namespace: "wrong-ns2",
+				},
+				{
+					Group:     v1beta1.GroupName,
+					Kind:      "Gateway",
+					Namespace: v1beta1.Namespace(gwNs), // matches
+				},
+			}
+		}),
+	}
+
 	tests := []struct {
-		refGrants map[types.NamespacedName]*v1beta1.ReferenceGrant
-		msg       string
-		allowed   bool
+		overrideTo   *toResource
+		overrideFrom *fromResource
+		msg          string
+		allowed      bool
 	}{
 		{
-			msg: "allowed; specific ref grant exists",
-			refGrants: map[types.NamespacedName]*v1beta1.ReferenceGrant{
-				{Namespace: "wrong-ns", Name: "rg"}: createModifiedRefGrant(func(rg *v1beta1.ReferenceGrant) {
-					rg.Namespace = "wrong-ns"
-				}),
-				{Namespace: "test", Name: "wrong-to-kind"}: createModifiedRefGrant(func(rg *v1beta1.ReferenceGrant) {
-					rg.Spec.To[0].Kind = "WrongKind"
-					rg.Name = "wrong-to-kind"
-				}),
-				{Namespace: "test", Name: "rg"}: getNormalRefGrant(),
+			msg:        "wrong 'to' kind",
+			overrideTo: &toResource{kind: "WrongKind", name: secretNsName.Name, namespace: secretNsName.Namespace},
+			allowed:    false,
+		},
+		{
+			msg: "wrong 'to' group",
+			overrideTo: &toResource{
+				group:     "wrong.group",
+				kind:      "Secret",
+				name:      secretNsName.Name,
+				namespace: secretNsName.Namespace,
 			},
+			allowed: false,
+		},
+		{
+			msg:        "wrong 'to' name",
+			overrideTo: &toResource{kind: "Secret", name: "wrong-name", namespace: secretNsName.Namespace},
+			allowed:    false,
+		},
+		{
+			msg:          "wrong 'from' kind",
+			overrideFrom: &fromResource{group: v1beta1.GroupName, kind: "WrongKind", namespace: gwNs},
+			allowed:      false,
+		},
+		{
+			msg:          "wrong 'from' group",
+			overrideFrom: &fromResource{group: "wrong.group", kind: "Gateway", namespace: gwNs},
+
+			allowed: false,
+		},
+		{
+			msg:          "wrong 'from' namespace",
+			overrideFrom: &fromResource{group: v1beta1.GroupName, kind: "Gateway", namespace: "wrong-ns"},
+			allowed:      false,
+		},
+		{
+			msg:     "allowed; matches specific reference grant",
 			allowed: true,
 		},
 		{
-			msg: "allowed; all-namespace ref grant exists",
-			refGrants: map[types.NamespacedName]*v1beta1.ReferenceGrant{
-				{Namespace: "test", Name: "rg"}: createModifiedRefGrant(func(rg *v1beta1.ReferenceGrant) {
-					rg.Spec.To[0].Name = nil
-				}),
-			},
-			allowed: true,
-		},
-		{
-			msg: "allowed; implicit 'to' Group",
-			refGrants: map[types.NamespacedName]*v1beta1.ReferenceGrant{
-				{Namespace: "test", Name: "rg"}: createModifiedRefGrant(func(rg *v1beta1.ReferenceGrant) {
-					rg.Spec.To[0].Group = ""
-				}),
-			},
-			allowed: true,
-		},
-		{
-			msg: "allowed; one matching 'to' ref",
-			refGrants: map[types.NamespacedName]*v1beta1.ReferenceGrant{
-				{Namespace: "test", Name: "rg"}: createModifiedRefGrant(func(rg *v1beta1.ReferenceGrant) {
-					rg.Spec.To = []v1beta1.ReferenceGrantTo{
-						{
-							Group: "wrong.group",
-						},
-						{
-							Kind: "WrongKind",
-						},
-						{
-							Group: "core",
-							Kind:  "Secret",
-							Name:  helpers.GetPointer(v1beta1.ObjectName(secretNsName.Name)),
-						},
-					}
-				}),
-			},
-			allowed: true,
-		},
-		{
-			msg: "allowed; one matching 'from' ref",
-			refGrants: map[types.NamespacedName]*v1beta1.ReferenceGrant{
-				{Namespace: "test", Name: "rg"}: createModifiedRefGrant(func(rg *v1beta1.ReferenceGrant) {
-					rg.Spec.From = []v1beta1.ReferenceGrantFrom{
-						{
-							Group: "wrong.group",
-						},
-						{
-							Kind: "WrongKind",
-						},
-						{
-							Group:     "gateway.networking.k8s.io",
-							Kind:      "Gateway",
-							Namespace: v1beta1.Namespace(gwNs),
-						},
-					}
-				}),
-			},
-			allowed: true,
-		},
-		{
-			msg: "not allowed; no ref group in secret namespace",
-			refGrants: map[types.NamespacedName]*v1beta1.ReferenceGrant{
-				{Namespace: "wrong-ns", Name: "rg"}: createModifiedRefGrant(func(rg *v1beta1.ReferenceGrant) {
-					rg.Namespace = "wrong-ns"
-				}),
-			},
-			allowed: false,
-		},
-		{
-			msg: "not allowed; no ref group with the right 'from' Group",
-			refGrants: map[types.NamespacedName]*v1beta1.ReferenceGrant{
-				{Namespace: "test", Name: "rg"}: createModifiedRefGrant(func(rg *v1beta1.ReferenceGrant) {
-					rg.Spec.From[0].Group = "wrong.group"
-				}),
-			},
-			allowed: false,
-		},
-		{
-			msg: "not allowed; no ref group with the right 'from' Kind",
-			refGrants: map[types.NamespacedName]*v1beta1.ReferenceGrant{
-				{Namespace: "test", Name: "rg"}: createModifiedRefGrant(func(rg *v1beta1.ReferenceGrant) {
-					rg.Spec.From[0].Kind = "WrongKind"
-				}),
-			},
-			allowed: false,
-		},
-		{
-			msg: "not allowed; no ref group with the right 'from' Namespace",
-			refGrants: map[types.NamespacedName]*v1beta1.ReferenceGrant{
-				{Namespace: "test", Name: "rg"}: createModifiedRefGrant(func(rg *v1beta1.ReferenceGrant) {
-					rg.Spec.From[0].Namespace = "wrong-ns"
-				}),
-			},
-			allowed: false,
-		},
-		{
-			msg: "not allowed; no ref group with the right 'to' Group",
-			refGrants: map[types.NamespacedName]*v1beta1.ReferenceGrant{
-				{Namespace: "test", Name: "rg"}: createModifiedRefGrant(func(rg *v1beta1.ReferenceGrant) {
-					rg.Spec.To[0].Group = "wrong.group"
-				}),
-			},
-			allowed: false,
-		},
-		{
-			msg: "not allowed; no ref group with the right 'to' Kind",
-			refGrants: map[types.NamespacedName]*v1beta1.ReferenceGrant{
-				{Namespace: "test", Name: "rg"}: createModifiedRefGrant(func(rg *v1beta1.ReferenceGrant) {
-					rg.Spec.To[0].Kind = "WrongKind"
-				}),
-			},
-			allowed: false,
-		},
-		{
-			msg: "not allowed; no ref group with the right 'to' Name",
-			refGrants: map[types.NamespacedName]*v1beta1.ReferenceGrant{
-				{Namespace: "test", Name: "rg"}: createModifiedRefGrant(func(rg *v1beta1.ReferenceGrant) {
-					rg.Spec.To[0].Name = helpers.GetPointer(v1beta1.ObjectName("wrong-name"))
-				}),
-			},
-			allowed: false,
+			msg:        "allowed; matches all-in-namespace reference grant",
+			overrideTo: &toResource{kind: "Secret", name: secretNsName.Name, namespace: "all-in-namespace"},
+			allowed:    true,
 		},
 	}
+
+	resolver := newReferenceGrantResolver(refGrants)
 
 	for _, test := range tests {
 		t.Run(test.msg, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 
-			allowed := refGrantAllowsGatewayToSecret(test.refGrants, gwNs, secretNsName)
-			g.Expect(allowed).To(Equal(test.allowed))
+			to := toResource{kind: "Secret", name: secretNsName.Name, namespace: secretNsName.Namespace}
+			if test.overrideTo != nil {
+				to = *test.overrideTo
+			}
+
+			from := fromResource{group: v1beta1.GroupName, kind: "Gateway", namespace: gwNs}
+			if test.overrideFrom != nil {
+				from = *test.overrideFrom
+			}
+
+			g.Expect(resolver.refAllowed(to, from)).To(Equal(test.allowed))
 		})
 	}
+}
+
+func TestToSecret(t *testing.T) {
+	ref := toSecret(types.NamespacedName{Namespace: "ns", Name: "secret"})
+
+	exp := toResource{
+		kind:      "Secret",
+		namespace: "ns",
+		name:      "secret",
+	}
+
+	g := NewGomegaWithT(t)
+	g.Expect(ref).To(Equal(exp))
+}
+
+func TestToService(t *testing.T) {
+	ref := toService(types.NamespacedName{Namespace: "ns", Name: "service"})
+
+	exp := toResource{
+		kind:      "Service",
+		namespace: "ns",
+		name:      "service",
+	}
+
+	g := NewGomegaWithT(t)
+	g.Expect(ref).To(Equal(exp))
+}
+
+func TestFromGateway(t *testing.T) {
+	ref := fromGateway("ns")
+
+	exp := fromResource{
+		group:     v1beta1.GroupName,
+		kind:      "Gateway",
+		namespace: "ns",
+	}
+
+	g := NewGomegaWithT(t)
+	g.Expect(ref).To(Equal(exp))
+}
+
+func TestFromHTTPRoute(t *testing.T) {
+	ref := fromHTTPRoute("ns")
+
+	exp := fromResource{
+		group:     v1beta1.GroupName,
+		kind:      "HTTPRoute",
+		namespace: "ns",
+	}
+
+	g := NewGomegaWithT(t)
+	g.Expect(ref).To(Equal(exp))
 }

--- a/internal/state/graph/reference_grant_test.go
+++ b/internal/state/graph/reference_grant_test.go
@@ -116,8 +116,7 @@ func TestReferenceGrantResolver(t *testing.T) {
 		{
 			msg:          "wrong 'from' group",
 			overrideFrom: &fromResource{group: "wrong.group", kind: "Gateway", namespace: gwNs},
-
-			allowed: false,
+			allowed:      false,
 		},
 		{
 			msg:          "wrong 'from' namespace",


### PR DESCRIPTION
### Proposed changes

Allow HTTPRoutes to reference Backends in different namespaces if a ReferenceGrant permits it.

Problem: NKG does not allow HTTPRoutes to reference Backends in different namespaces. 

Solution: Allow HTTPRoutes to reference Backends in different namespaces if a ReferenceGrant permits it. Both SecretObjectReferences and BackendObjectReferences are resolved through the referenceGrantResolver. The referenceGrantResolver transforms the map of ReferenceGrants into a structure that allows for O(n) lookup of references. 

Testing: Added & modified unit tests. Made sure all ReferenceGrant conformance tests passed, including the new `HTTPRouteInvalidReferenceGrant ` test.

Closes #695 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
