### PR TITLE
Skip conformance tests on tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,7 @@ jobs:
     name: Gateway Conformance Tests
     runs-on: ubuntu-22.04
     needs: vars
+    if: ${{ github.ref_type != 'tag' }}    
     steps:
       - name: Checkout Repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -233,7 +234,7 @@ jobs:
   build:
     name: Build Image
     runs-on: ubuntu-22.04
-    needs: [vars, binary, conformance-tests]
+    needs: [vars, binary]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3


### PR DESCRIPTION
### Proposed changes

The conformance test pipeline is failing for tags. They are ran on the release branch so we don't need to run them again - this commit adds a skip condition when the ref_type of the trigger is a tag
### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
