### PR TITLE
Set proxy host header to the exact value of the request host header

### DIFF
--- a/internal/nginx/config/maps_template.go
+++ b/internal/nginx/config/maps_template.go
@@ -8,4 +8,13 @@ map {{ $m.Source }} {{ $m.Variable }} {
     {{ end }}
 }
 {{- end }}
+
+# Set $gw_api_compliant_host variable to the value of $http_host unless $http_host is empty, then set it to the value 
+# of $host. We prefer $http_host because it contains the original value of the host header, which is required by the
+# Gateway API. However, in an HTTP/1.0 request, it's possible that $http_host can be empty. In this case, we will use
+# the value of $host. See http://nginx.org/en/docs/http/ngx_http_core_module.html#var_host.
+map $http_host $gw_api_compliant_host {
+    '' $host;
+    default $http_host;
+}
 `

--- a/internal/nginx/config/maps_test.go
+++ b/internal/nginx/config/maps_test.go
@@ -84,6 +84,7 @@ func TestExecuteMaps(t *testing.T) {
 		"map ${http_my_second_add_header} $my_second_add_header_header_var {": 1,
 		"~.* ${http_my_second_add_header},;":                                  1,
 		"map ${http_my_set_header} $my_set_header_header_var {":               0,
+		"map $http_host $gw_api_compliant_host {":                             1,
 	}
 
 	maps := string(executeMaps(conf))

--- a/internal/nginx/config/servers_template.go
+++ b/internal/nginx/config/servers_template.go
@@ -50,7 +50,7 @@ server {
             {{ range $h := $l.ProxySetHeaders }}
         proxy_set_header {{ $h.Name }} "{{ $h.Value }}";
             {{- end }}
-        proxy_set_header Host $host;
+        proxy_set_header Host $gw_api_compliant_host;
         proxy_pass {{ $l.ProxyPass }}$request_uri;
         {{- end }}
     }


### PR DESCRIPTION
### Proposed changes

Problem: The Gateway API expects the response host header to match the exact value of the request host header. We set the proxy host header to the `$host` nginx variable, which does not include any characters after `:`. This causes a conformance test to fail where the host header contains a port. 

Solution: Set the proxy host header to `$http_host` nginx variable when it is non-empty. This variable contains the unmodified host header of the request. However, in an HTTP/1.0 request, it's possible that `$http_host` can be empty. In this case, we will use the value of `$host`. See http://nginx.org/en/docs/http/ngx_http_core_module.html#var_host.

Testing: Ran impacted conformance test
```
--- PASS: TestConformance (22.30s)
    --- PASS: TestConformance/HTTPRouteHostnameIntersection (9.04s)
```

Closes #797 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
