### PR TITLE
Check for changes in generated files in GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check if go.mod and go.sum are up to date
         run: go mod tidy && git diff --exit-code -- go.mod go.sum
 
+      - name: Check if generated files are up to date
+        run: make generate && git diff --exit-code
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Problem: If we forget to run `make generate`, the out-of-date code can be committed to the main branch. See an example of a problem [here](https://github.com/nginxinc/nginx-kubernetes-gateway/pull/784).

Solution: Add a step to the Checks and variables job in the ci workflow that checks if the generated files have changed. If they have changed, the job will fail, and the PR will be blocked. 

Testing: Verified that the job works as expected.