### PR TITLE
Set support level to Core in the Gateway API Compatibility doc

### DIFF
--- a/docs/gateway-api-compatibility.md
+++ b/docs/gateway-api-compatibility.md
@@ -4,22 +4,21 @@ This document describes which Gateway API resources NGINX Kubernetes Gateway sup
 
 ## Summary
 
-| Resource                            | Support Status      |
-|-------------------------------------|---------------------|
-| [GatewayClass](#gatewayclass)       | Partially supported |
-| [Gateway](#gateway)                 | Partially supported |
-| [HTTPRoute](#httproute)             | Partially supported |
-| [TLSRoute](#tlsroute)               | Not supported       |
-| [TCPRoute](#tcproute)               | Not supported       |
-| [UDPRoute](#udproute)               | Not supported       |
-| [ReferenceGrant](#referencegrant)   | Supported           |
-| [Custom policies](#custom-policies) | Not supported       |
+| Resource                            | Support Level | API Version |
+|-------------------------------------|---------------|-------------|
+| [GatewayClass](#gatewayclass)       | Core          | v1beta1     |
+| [Gateway](#gateway)                 | Core          | v1beta1     |
+| [HTTPRoute](#httproute)             | Core          | v1beta1     |
+| [ReferenceGrant](#referencegrant)   | Core          | v1beta1     |
+| [Custom policies](#custom-policies) | Not supported | N/A         |
+| [TLSRoute](#tlsroute)               | Not supported | N/A         |
+| [TCPRoute](#tcproute)               | Not supported | N/A         |
+| [UDPRoute](#udproute)               | Not supported | N/A         |
 
 ## Terminology
 
-We use the following words to describe support status:
-
-- *Supported*. The resource or field is fully supported and conformant to the Gateway API specification.
+- *Support Level*. See the Gateway API [support levels](https://gateway-api.sigs.k8s.io/concepts/conformance/#2-support-levels).
+- *Supported*. The resource or field is fully supported.
 - *Partially supported*. The resource or field is supported partially or with limitations. It will become fully
   supported in future releases.
 - *Not supported*. The resource or field is not yet supported. It will become partially or fully supported in future
@@ -37,7 +36,7 @@ the [Gateway API documentation](https://gateway-api.sigs.k8s.io/references/spec/
 
 ### GatewayClass
 
-> Status: Partially supported.
+> Support Level: Core.
 
 NGINX Kubernetes Gateway supports only a single GatewayClass resource configured via `--gatewayclass` flag
 of the [static-mode](./cli-help.md#static-mode) command.
@@ -57,7 +56,7 @@ Fields:
 
 ### Gateway
 
-> Status: Partially supported.
+> Support Level: Core.
 
 NGINX Kubernetes Gateway supports only a single Gateway resource. The Gateway resource must reference NGINX Kubernetes
 Gateway's corresponding GatewayClass.
@@ -75,38 +74,37 @@ Fields:
         * `tls`
             * `mode` - partially supported. Allowed value: `Terminate`.
             * `certificateRefs` - The TLS certificate and key must be stored in a Secret resource of
-              type `kubernetes.io/tls`. Only a single reference is supported. You must deploy the Secret before the
-              Gateway resource.
+              type `kubernetes.io/tls`. Only a single reference is supported.
             * `options` - not supported.
         * `allowedRoutes` - supported.
     * `addresses` - not supported.
 * `status`
     * `addresses` - Pod IPAddress supported.
-    * `conditions` - Supported (Condition/Status/Reason):
+    * `conditions` - supported (Condition/Status/Reason):
         * `Accepted/True/Accepted`
         * `Accepted/True/ListenersNotValid`
         * `Accepted/False/ListenersNotValid`
         * `Accepted/False/Invalid`
-        * `Accepted/False/UnsupportedValue`: Custom reason for when a value of a field in a Gateway is invalid or not
+        * `Accepted/False/UnsupportedValue`- custom reason for when a value of a field in a Gateway is invalid or not
           supported.
-        * `Accepted/False/GatewayConflict`: Custom reason for when the Gateway is ignored due to a conflicting Gateway.
+        * `Accepted/False/GatewayConflict`- custom reason for when the Gateway is ignored due to a conflicting Gateway.
           NKG only supports a single Gateway.
         * `Programmed/True/Programmed`
         * `Programmed/False/Invalid`
-        * `Programmed/False/GatewayConflict`: Custom reason for when the Gateway is ignored due to a conflicting
+        * `Programmed/False/GatewayConflict`- custom reason for when the Gateway is ignored due to a conflicting
           Gateway. NKG only supports a single Gateway.
     * `listeners`
         * `name` - supported.
         * `supportedKinds` - supported.
         * `attachedRoutes` - supported.
-        * `conditions` - Supported (Condition/Status/Reason):
+        * `conditions` - supported (Condition/Status/Reason):
             * `Accepted/True/Accepted`
             * `Accepted/False/UnsupportedProtocol`
             * `Accepted/False/InvalidCertificateRef`
             * `Accepted/False/ProtocolConflict`
-            * `Accepted/False/UnsupportedValue`: Custom reason for when a value of a field in a Listener is invalid or
+            * `Accepted/False/UnsupportedValue`- custom reason for when a value of a field in a Listener is invalid or
               not supported.
-            * `Accepted/False/GatewayConflict`: Custom reason for when the Gateway is ignored due to a conflicting
+            * `Accepted/False/GatewayConflict` - custom reason for when the Gateway is ignored due to a conflicting
               Gateway. NKG only supports a single Gateway.
             * `Programmed/True/Programmed`
             * `Programmed/False/Invalid`
@@ -118,7 +116,7 @@ Fields:
 
 ### HTTPRoute
 
-> Status: Partially supported.
+> Support Level: Core.
 
 Fields:
 
@@ -149,33 +147,20 @@ Fields:
             * `Accepted/False/NoMatchingListenerHostname`
             * `Accepted/False/NoMatchingParent`
             * `Accepted/False/NotAllowedByListeners`
-            * `Accepted/False/UnsupportedValue`: Custom reason for when the HTTPRoute includes an invalid or unsupported
+            * `Accepted/False/UnsupportedValue` - custom reason for when the HTTPRoute includes an invalid or unsupported
               value.
-            * `Accepted/False/InvalidListener`: Custom reason for when the HTTPRoute references an invalid listener.
-            * `Accepted/False/GatewayNotProgrammed`: Custom reason for when the Gateway is not Programmed. HTTPRoute may
+            * `Accepted/False/InvalidListener` - custom reason for when the HTTPRoute references an invalid listener.
+            * `Accepted/False/GatewayNotProgrammed` - custom reason for when the Gateway is not Programmed. HTTPRoute may
               be valid and configured, but will maintain this status as long as the Gateway is not Programmed.
             * `ResolvedRefs/True/ResolvedRefs`
             * `ResolvedRefs/False/InvalidKind`
             * `ResolvedRefs/False/RefNotPermitted`
             * `ResolvedRefs/False/BackendNotFound`
-            * `ResolvedRefs/False/UnsupportedValue`: Custom reason for when one of the HTTPRoute rules has a backendRef
+            * `ResolvedRefs/False/UnsupportedValue` - custom reason for when one of the HTTPRoute rules has a backendRef
               with an unsupported value.
-
-### TLSRoute
-
-> Status: Not supported.
-
-### TCPRoute
-
-> Status: Not supported.
-
-### UDPRoute
-
-> Status: Not supported.
 
 ### ReferenceGrant
 
-> Status: Supported.
 > Support Level: Core
 
 Fields:
@@ -189,6 +174,18 @@ Fields:
         * `group` - supported.
         * `kind` - supports `Gateway` and `HTTPRoute`.
         * `namespace`- supported.
+
+### TLSRoute
+
+> Status: Not supported.
+
+### TCPRoute
+
+> Status: Not supported.
+
+### UDPRoute
+
+> Status: Not supported.
 
 ### Custom Policies
 

--- a/docs/gateway-api-compatibility.md
+++ b/docs/gateway-api-compatibility.md
@@ -4,28 +4,32 @@ This document describes which Gateway API resources NGINX Kubernetes Gateway sup
 
 ## Summary
 
-| Resource                            | Support Level | API Version |
-|-------------------------------------|---------------|-------------|
-| [GatewayClass](#gatewayclass)       | Core          | v1beta1     |
-| [Gateway](#gateway)                 | Core          | v1beta1     |
-| [HTTPRoute](#httproute)             | Core          | v1beta1     |
-| [ReferenceGrant](#referencegrant)   | Core          | v1beta1     |
-| [Custom policies](#custom-policies) | Not supported | N/A         |
-| [TLSRoute](#tlsroute)               | Not supported | N/A         |
-| [TCPRoute](#tcproute)               | Not supported | N/A         |
-| [UDPRoute](#udproute)               | Not supported | N/A         |
+| Resource                            | Core Support Level | Extended Support Level | Implementation-Specific Support Level | API Version |
+|-------------------------------------|--------------------|------------------------|---------------------------------------|-------------|
+| [GatewayClass](#gatewayclass)       | Supported          | Not supported          | Not Supported                         | v1beta1     |
+| [Gateway](#gateway)                 | Supported          | Not supported          | Not Supported                         | v1beta1     |
+| [HTTPRoute](#httproute)             | Supported          | Partially supported    | Not Supported                         | v1beta1     |
+| [ReferenceGrant](#referencegrant)   | Supported          | N/A                    | Not Supported                         | v1beta1     |
+| [Custom policies](#custom-policies) | Not supported      | N/A                    | Not Supported                         | N/A         |
+| [TLSRoute](#tlsroute)               | Not supported      | Not supported          | Not Supported                         | N/A         |
+| [TCPRoute](#tcproute)               | Not supported      | Not supported          | Not Supported                         | N/A         |
+| [UDPRoute](#udproute)               | Not supported      | Not supported          | Not Supported                         | N/A         |
 
 ## Terminology
 
-- *Support Level*. See the Gateway API [support levels](https://gateway-api.sigs.k8s.io/concepts/conformance/#2-support-levels).
+Gateway API features has three [support levels](https://gateway-api.sigs.k8s.io/concepts/conformance/#2-support-levels):
+Core, Extended and Implementation-specific. We use the following terms to describe the support status for each level and
+resource field:
+
 - *Supported*. The resource or field is fully supported.
 - *Partially supported*. The resource or field is supported partially or with limitations. It will become fully
   supported in future releases.
 - *Not supported*. The resource or field is not yet supported. It will become partially or fully supported in future
   releases.
 
-Note: it might be possible that NGINX Kubernetes Gateway will never support some resources and/or fields of the Gateway
-API. We will document these decisions on a case by case basis.
+> Note: it might be possible that NGINX Kubernetes Gateway will never support some resources and/or fields of the Gateway API. We will document these decisions on a case by case basis.
+
+> NGINX Kubernetes Gateway doesn't support any features from the experimental release channel.
 
 ## Resources
 
@@ -36,10 +40,13 @@ the [Gateway API documentation](https://gateway-api.sigs.k8s.io/references/spec/
 
 ### GatewayClass
 
-> Support Level: Core.
+> Support Levels:
+> - Core: Supported.
+> - Extended: Not supported.
+> - Implementation-specific: Not supported.
 
-NGINX Kubernetes Gateway supports only a single GatewayClass resource configured via `--gatewayclass` flag
-of the [static-mode](./cli-help.md#static-mode) command.
+NGINX Kubernetes Gateway supports only a single GatewayClass resource configured via `--gatewayclass` flag of
+the [static-mode](./cli-help.md#static-mode) command.
 
 Fields:
 
@@ -56,11 +63,13 @@ Fields:
 
 ### Gateway
 
-> Support Level: Core.
+> Support Levels:
+> - Core: Supported.
+> - Extended: Not supported.
+> - Implementation-specific: Not supported.
 
 NGINX Kubernetes Gateway supports only a single Gateway resource. The Gateway resource must reference NGINX Kubernetes
-Gateway's corresponding GatewayClass.
-See [static-mode](./cli-help.md#static-mode) command for more info.
+Gateway's corresponding GatewayClass. See [static-mode](./cli-help.md#static-mode) command for more info.
 
 Fields:
 
@@ -116,7 +125,10 @@ Fields:
 
 ### HTTPRoute
 
-> Support Level: Core.
+> Support Levels:
+> - Core: Supported.
+> - Extended: Partially supported.
+> - Implementation-specific: Not supported.
 
 Fields:
 
@@ -147,11 +159,11 @@ Fields:
             * `Accepted/False/NoMatchingListenerHostname`
             * `Accepted/False/NoMatchingParent`
             * `Accepted/False/NotAllowedByListeners`
-            * `Accepted/False/UnsupportedValue` - custom reason for when the HTTPRoute includes an invalid or unsupported
-              value.
+            * `Accepted/False/UnsupportedValue` - custom reason for when the HTTPRoute includes an invalid or
+              unsupported value.
             * `Accepted/False/InvalidListener` - custom reason for when the HTTPRoute references an invalid listener.
-            * `Accepted/False/GatewayNotProgrammed` - custom reason for when the Gateway is not Programmed. HTTPRoute may
-              be valid and configured, but will maintain this status as long as the Gateway is not Programmed.
+            * `Accepted/False/GatewayNotProgrammed` - custom reason for when the Gateway is not Programmed. HTTPRoute
+              may be valid and configured, but will maintain this status as long as the Gateway is not Programmed.
             * `ResolvedRefs/True/ResolvedRefs`
             * `ResolvedRefs/False/InvalidKind`
             * `ResolvedRefs/False/RefNotPermitted`
@@ -161,7 +173,10 @@ Fields:
 
 ### ReferenceGrant
 
-> Support Level: Core
+> Support Levels:
+> - Core: Supported.
+> - Extended: N/A.
+> - Implementation-specific: N/A
 
 Fields:
 


### PR DESCRIPTION
### Proposed changes

Problem: The Gateway Compatibility doc does not accurately describe that we support all Core v1beta1 resources and fields.

Solution: Change the format of the compatibility table to show the support level and API version. Also make language and capitalization consistent.

Testing: N/A

Closes #849 
Closes #605 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
