### PR TITLE
Fix example output

### DIFF
--- a/examples/http-header-filter/README.md
+++ b/examples/http-header-filter/README.md
@@ -64,7 +64,7 @@ Headers:
   header 'Accept-Encoding' is 'compress'
   header 'My-cool-header' is 'my-client-value, this-is-an-appended-value'
   header 'My-Overwrite-Header' is 'this-is-the-only-value'
-  header 'Host' is 'echo.example.com'
+  header 'Host' is 'echo.example.com:$GW_PORT'
   header 'Connection' is 'close'
   header 'Accept' is '*/*'
 ```

--- a/examples/https-termination/README.md
+++ b/examples/https-termination/README.md
@@ -109,7 +109,7 @@ To get a redirect for coffee:
 curl --resolve cafe.example.com:$GW_HTTP_PORT:$GW_IP http://cafe.example.com:$GW_HTTP_PORT/coffee --include
 HTTP/1.1 302 Moved Temporarily
 ...
-Location: https://cafe.example.com:443/coffee
+Location: https://cafe.example.com/coffee
 ...
 ```
 
@@ -119,7 +119,7 @@ To get a redirect for tea:
 curl --resolve cafe.example.com:$GW_HTTP_PORT:$GW_IP http://cafe.example.com:$GW_HTTP_PORT/tea --include
 HTTP/1.1 302 Moved Temporarily
 ...
-Location: https://cafe.example.com:443/tea
+Location: https://cafe.example.com/tea
 ...
 ```
 


### PR DESCRIPTION
### Proposed changes

Problem: The example output in the `http-header-filter` and `https-termination` examples are outdated.  

Solution: Updated the example output to match the actual output. 

Testing: Verified actual output matches expected.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
