### PR TITLE
Update incorrect link - release 0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For a list of supported Gateway API resources and features, see the [Gateway API
 
 We publish NGINX Kubernetes Gateway releases on GitHub. See our [releases page](https://github.com/nginxinc/nginx-kubernetes-gateway/releases).
 
-The latest release is [0.2.0](https://github.com/nginxinc/kubernetes-ingress/releases/tag/v0.2.0).
+The latest release is [0.2.0](https://github.com/nginxinc/nginx-kubernetes-gateway/releases/tag/v0.2.0).
 
 The edge version is useful for experimenting with new features that are not yet published in a release. To use, choose the *edge* version built from the [latest commit](https://github.com/nginxinc/nginx-kubernetes-gateway/commits/main) from the main branch.
 


### PR DESCRIPTION
### Proposed changes

Problem: Link to latest release points to kubernetes-ingress repo.

Solution: Update link to point to this repo.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
