### PR TITLE
Fix local build

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,7 +18,7 @@ FROM alpine:3.18 as capabilizer
 RUN apk add --no-cache libcap
 
 FROM capabilizer as local-capabilizer
-COPY ./build/.out/gateway /usr/bin/
+COPY ./build/out/gateway /usr/bin/
 RUN setcap 'cap_kill=+ep' /usr/bin/gateway
 
 FROM capabilizer as container-capabilizer


### PR DESCRIPTION
### Proposed changes

Problem:

c52b4da renamed the local build folder.
However, the renaming in the Dockerfile wasn't done so the local building of NKG using local go env become broken.

Solution:
Fix the Dockerfile

Tests:
Manually run `make container`

Note: needs https://github.com/nginxinc/nginx-kubernetes-gateway/pull/888 for successfull testing

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
