### PR TITLE
Sign checksum with cosign

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
     needs: [vars, unit-tests, njs-unit-tests]
     permissions:
       contents: write # for goreleaser/goreleaser-action and lucacome/draft-release to create/update releases
+      id-token: write # for goreleaser/goreleaser-action to sign artifacts
     steps:
       - name: Checkout Repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -123,6 +124,10 @@ jobs:
 
       - name: Download Syft
         uses: anchore/sbom-action/download-syft@78fc58e266e87a38d4194b2137a3d4e9bcaf7ca1 # v0.14.3
+        if: startsWith(github.ref, 'refs/tags/')
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 # v3.1.1
         if: startsWith(github.ref, 'refs/tags/')
 
       - name: Build binary

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,6 +32,18 @@ blobs:
   - provider: azblob
     bucket: '{{.Env.AZURE_BUCKET_NAME}}'
 
+signs:
+  - cmd: cosign
+    artifacts: checksum
+    output: true
+    certificate: '${artifact}.pem'
+    args:
+      - sign-blob
+      - "--output-signature=${signature}"
+      - "--output-certificate=${certificate}"
+      - "${artifact}"
+      - "--yes"
+
 announce:
   slack:
     enabled: true


### PR DESCRIPTION
### Proposed changes
Problem: Artifacts are not signed and it's not possible to prove they've not been tampered with.

Solution: Add config to sign artifacts. Since the checksum contains the SHAs of the artifacts, signing the checksums is enough to ensure that the artifacts were not modified.

GoReleaser uses cosign to sign the artifact and uploads .sig and .pem to the release.

Closes #895 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
