### PR TITLE
Add linting for yaml files

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -62,7 +62,7 @@ jobs:
       #    and modify them (or add more) to build your code if your project
       #    uses a compiled language
 
-      #- run: |
+      # - run: |
       #   make bootstrap
       #   make release
 

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -107,7 +107,7 @@ jobs:
           nkg_prefix=$(echo ${{ steps.meta.outputs.tags }} | cut -d ":" -f 1)
           nkg_tag=$(echo ${{ steps.meta.outputs.tags }} | cut -d ":" -f 2)
           if [ ${{ github.event_name }} == "schedule" ]; then
-            export GW_API_VERSION=main
+          export GW_API_VERSION=main
           fi
           make install-nkg-local-no-build NKG_PREFIX=${nkg_prefix} NKG_TAG=${nkg_tag}
         working-directory: ./conformance

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,13 +81,13 @@ jobs:
     name: Markdown Lint
     runs-on: ubuntu-22.04
     steps:
-    - name: Checkout Repository
-      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Checkout Repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
-    - uses: DavidAnson/markdownlint-cli2-action@8f3516061301755c97ff833a8e933f09282cc5b5 # v11.0.0
-      with:
-        config: ${{ github.workspace }}/.markdownlint-cli2.yaml
-        globs: '**/*.md'
+      - uses: DavidAnson/markdownlint-cli2-action@8f3516061301755c97ff833a8e933f09282cc5b5 # v11.0.0
+        with:
+          config: ${{ github.workspace }}/.markdownlint-cli2.yaml
+          globs: '**/*.md'
 
   chart-lint:
     name: Chart Lint
@@ -97,3 +97,16 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Lint chart
         run: make lint-helm
+
+  yaml-lint:
+    name: Yaml Lint
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Install yamllint
+        run: pip install yamllint
+
+      - name: Lint YAML files
+        run: yamllint .

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -2,6 +2,7 @@ name: Scorecards supply-chain security
 on:
   # Only the default branch is supported.
   branch_protection_rule:
+    types: [created, edited, deleted]
   schedule:
     - cron: "27 5 * * 0"
   push:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,11 +34,11 @@ linters-settings:
     min-complexity: 15
   govet:
     enable:
-    - fieldalignment
+      - fieldalignment
   lll:
     line-length: 120
 linters:
-    enable:
+  enable:
     - asciicheck
     - errcheck
     - errorlint
@@ -63,7 +63,7 @@ linters:
     - unparam
     - unused
     - wastedassign
-    disable-all: true
+  disable-all: true
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,11 +56,13 @@ repos:
     hooks:
       - id: markdownlint-cli2-fix
 
+  # Rules are in .yamllint.yaml file
+  # See https://yamllint.readthedocs.io/en/stable/rules.html# for rule descriptions
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.29.0
     hooks:
       - id: yamllint
 
 ci:
-  skip: [golang-diff, golangci-lint, prettier, markdownlint-cli2-fix]
+  skip: [golang-diff, golangci-lint, prettier, markdownlint-cli2-fix, yamllint]
   autofix_prs: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,12 +49,17 @@ repos:
       - id: golangci-lint
         args: [--new-from-patch=/tmp/diff.patch]
 
-    # Rules are in .markdownlint-cli2.yaml file
-    # See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md for rule descriptions
+  # Rules are in .markdownlint-cli2.yaml file
+  # See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md for rule descriptions
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.8.1
     hooks:
-    - id: markdownlint-cli2-fix
+      - id: markdownlint-cli2-fix
+
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.29.0
+    hooks:
+      - id: yamllint
 
 ci:
   skip: [golang-diff, golangci-lint, prettier, markdownlint-cli2-fix]

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -6,6 +6,7 @@ yaml-files:
 
 ignore:
   - deploy/helm-chart/templates/
+  - deploy/helm-chart/crds/
 
 rules:
   braces: enable
@@ -28,7 +29,7 @@ rules:
     indent-sequences: consistent
     check-multi-line-strings: true
     ignore: |
-      deploy/manifests/nginx-conf.yaml
+      deploy/manifests/nginx-gateway.yaml
       deploy/manifests/njs-modules.yaml
   key-duplicates: enable
   key-ordering: disable
@@ -38,7 +39,7 @@ rules:
     allow-non-breakable-inline-mappings: true
     ignore: |
       .github/workflows/
-      deploy/manifests/deployment.yaml
+      deploy/manifests/nginx-gateway.yaml
   new-line-at-end-of-file: enable
   new-lines: enable
   octal-values: disable

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -4,6 +4,9 @@ yaml-files:
   - '*.yaml'
   - '*.yml'
 
+ignore:
+  - deploy/helm-chart/templates/
+
 rules:
   braces: enable
   brackets: enable
@@ -13,21 +16,34 @@ rules:
     require-starting-space: true
     ignore-shebangs: true
     min-spaces-from-content: 1
-  comments-indentation:
-    level: warning
+  comments-indentation: enable
   document-end: disable
   document-start: disable
   empty-lines: enable
-  empty-values: disable
+  empty-values: enable
   float-values: disable
   hyphens: enable
-  indentation: enable
+  indentation:
+    spaces: consistent
+    indent-sequences: consistent
+    check-multi-line-strings: true
+    ignore: |
+      deploy/manifests/nginx-conf.yaml
+      deploy/manifests/njs-modules.yaml
   key-duplicates: enable
   key-ordering: disable
-  line-length: disable
+  line-length:
+    max: 120
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
+    ignore: |
+      .github/workflows/
+      deploy/manifests/deployment.yaml
   new-line-at-end-of-file: enable
   new-lines: enable
   octal-values: disable
   quoted-strings: disable
   trailing-spaces: enable
-  truthy: disable
+  truthy:
+    ignore: |
+      .github/workflows/

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,33 @@
+---
+
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+
+rules:
+  braces: enable
+  brackets: enable
+  colons: enable
+  commas: enable
+  comments:
+    require-starting-space: true
+    ignore-shebangs: true
+    min-spaces-from-content: 1
+  comments-indentation:
+    level: warning
+  document-end: disable
+  document-start: disable
+  empty-lines: enable
+  empty-values: disable
+  float-values: disable
+  hyphens: enable
+  indentation: enable
+  key-duplicates: enable
+  key-ordering: disable
+  line-length: disable
+  new-line-at-end-of-file: enable
+  new-lines: enable
+  octal-values: disable
+  quoted-strings: disable
+  trailing-spaces: enable
+  truthy: disable

--- a/examples/http-header-filter/echo-route.yaml
+++ b/examples/http-header-filter/echo-route.yaml
@@ -22,7 +22,7 @@ spec:
         add:
         - name: Accept-Encoding
           value: compress
-        - name:  My-cool-header
+        - name: My-cool-header
           value: this-is-an-appended-value
         remove:
         - User-Agent

--- a/examples/http-header-filter/headers.yaml
+++ b/examples/http-header-filter/headers.yaml
@@ -30,6 +30,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: headers-config
+# yamllint disable rule:indentation
 data:
   nginx.conf: |-
     user  nginx;
@@ -61,7 +62,7 @@ data:
         return s;
     }
     export default {getRequestHeaders};
-
+# yamllint enable rule:indentation
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
### Proposed changes

Problem: The yaml files in the repo were not linted.

Solution: Add yamllint step to pre-commit and as a CI step. All yaml files except the helm template files will be linted before every commit (with some rules excepted for the .github workflow files, any yaml files that include raw NGINX config, and line length in the deployment yaml). Linting rules are in the `.yamllint.yaml` file in the root of the repo. For details on the linting rules, see: https://yamllint.readthedocs.io/en/stable/rules.html# 

Testing: Verified yaml files are linted on pre-commit. 

Closes #539 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
