### PR TITLE
Automatically close stale issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,8 +24,8 @@ jobs:
           stale-pr-label: "stale"
           exempt-all-assignees: true
           exempt-all-milestones: true
-          exempt-issue-labels: "backlog"
-          exempt-pr-labels: "backlog"
+          exempt-issue-labels: "backlog, backlog candidate"
+          exempt-pr-labels: "backlog, backlog candidate"
           operations-per-run: 100
           days-before-stale: 90
           days-before-close: 10

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,31 @@
+name: "Close stale issues and PRs"
+on:
+  schedule:
+    - cron: "30 2 * * *" # run every day at 02:30 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    permissions:
+      issues: write # for actions/stale to close stale issues
+      pull-requests: write # for actions/stale to close stale PRs
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: "This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 10 days."
+          stale-pr-message: "This PR is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 10 days."
+          close-issue-message: "This issue was closed because it has been stalled for 10 days with no activity."
+          close-pr-message: "This PR was closed because it has been stalled for 10 days with no activity."
+          stale-issue-label: "stale"
+          stale-pr-label: "stale"
+          exempt-all-assignees: true
+          exempt-all-milestones: true
+          exempt-issue-labels: "backlog"
+          exempt-pr-labels: "backlog"
+          operations-per-run: 100
+          days-before-stale: 90
+          days-before-close: 10


### PR DESCRIPTION
### Proposed changes

Problem: Issues are hard to manage

Solution: Add a workflow to manage stale issues/PRs automatically. An issue/PR is marked as stale after 90 days of inactivity and closed 10 days after that if no action is taken.

Closes #853

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
