### PR TITLE
Remove Gateway API types from Configuration-related types in dataplane package

### DIFF
--- a/internal/mode/static/nginx/config/maps_test.go
+++ b/internal/mode/static/nginx/config/maps_test.go
@@ -16,7 +16,7 @@ func TestExecuteMaps(t *testing.T) {
 		{
 			MatchRules: []dataplane.MatchRule{
 				{
-					Filters: dataplane.Filters{
+					Filters: dataplane.HTTPFilters{
 						RequestHeaderModifiers: &dataplane.HTTPHeaderFilter{
 							Add: []dataplane.HTTPHeader{
 								{
@@ -28,7 +28,7 @@ func TestExecuteMaps(t *testing.T) {
 					},
 				},
 				{
-					Filters: dataplane.Filters{
+					Filters: dataplane.HTTPFilters{
 						RequestHeaderModifiers: &dataplane.HTTPHeaderFilter{
 							Add: []dataplane.HTTPHeader{
 								{
@@ -40,7 +40,7 @@ func TestExecuteMaps(t *testing.T) {
 					},
 				},
 				{
-					Filters: dataplane.Filters{
+					Filters: dataplane.HTTPFilters{
 						RequestHeaderModifiers: &dataplane.HTTPHeaderFilter{
 							Set: []dataplane.HTTPHeader{
 								{
@@ -100,7 +100,7 @@ func TestBuildAddHeaderMaps(t *testing.T) {
 		{
 			MatchRules: []dataplane.MatchRule{
 				{
-					Filters: dataplane.Filters{
+					Filters: dataplane.HTTPFilters{
 						RequestHeaderModifiers: &dataplane.HTTPHeaderFilter{
 							Add: []dataplane.HTTPHeader{
 								{
@@ -126,7 +126,7 @@ func TestBuildAddHeaderMaps(t *testing.T) {
 					},
 				},
 				{
-					Filters: dataplane.Filters{
+					Filters: dataplane.HTTPFilters{
 						RequestHeaderModifiers: &dataplane.HTTPHeaderFilter{
 							Set: []dataplane.HTTPHeader{
 								{

--- a/internal/mode/static/state/dataplane/configuration_test.go
+++ b/internal/mode/static/state/dataplane/configuration_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -223,6 +222,9 @@ func TestBuildConfiguration(t *testing.T) {
 		},
 	}
 	addFilters(hr5, []v1beta1.HTTPRouteFilter{redirect})
+	expRedirect := HTTPRequestRedirectFilter{
+		Hostname: helpers.GetPointer("foo.example.com"),
+	}
 
 	hr6, expHR6Groups, routeHR6 := createTestResources(
 		"hr-6",
@@ -592,10 +594,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      0,
 										BackendGroup: expHR2Groups[0],
-										Source:       hr2,
+										Source:       &hr2.ObjectMeta,
 									},
 								},
 							},
@@ -610,10 +610,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      0,
 										BackendGroup: expHR1Groups[0],
-										Source:       hr1,
+										Source:       &hr1.ObjectMeta,
 									},
 								},
 							},
@@ -681,10 +679,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      0,
 										BackendGroup: expHTTPSHR2Groups[0],
-										Source:       httpsHR2,
+										Source:       &httpsHR2.ObjectMeta,
 									},
 								},
 							},
@@ -700,10 +696,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      0,
 										BackendGroup: expHTTPSHR5Groups[0],
-										Source:       httpsHR5,
+										Source:       &httpsHR5.ObjectMeta,
 									},
 								},
 							},
@@ -719,10 +713,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      0,
 										BackendGroup: expHTTPSHR1Groups[0],
-										Source:       httpsHR1,
+										Source:       &httpsHR1.ObjectMeta,
 									},
 								},
 							},
@@ -803,16 +795,12 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      0,
 										BackendGroup: expHR3Groups[0],
-										Source:       hr3,
+										Source:       &hr3.ObjectMeta,
 									},
 									{
-										MatchIdx:     0,
-										RuleIdx:      1,
 										BackendGroup: expHR4Groups[1],
-										Source:       hr4,
+										Source:       &hr4.ObjectMeta,
 									},
 								},
 							},
@@ -821,10 +809,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      0,
 										BackendGroup: expHR4Groups[0],
-										Source:       hr4,
+										Source:       &hr4.ObjectMeta,
 									},
 								},
 							},
@@ -833,10 +819,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      1,
 										BackendGroup: expHR3Groups[1],
-										Source:       hr3,
+										Source:       &hr3.ObjectMeta,
 									},
 								},
 							},
@@ -858,16 +842,12 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      0,
 										BackendGroup: expHTTPSHR3Groups[0],
-										Source:       httpsHR3,
+										Source:       &httpsHR3.ObjectMeta,
 									},
 									{
-										MatchIdx:     0,
-										RuleIdx:      1,
 										BackendGroup: expHTTPSHR4Groups[1],
-										Source:       httpsHR4,
+										Source:       &httpsHR4.ObjectMeta,
 									},
 								},
 							},
@@ -876,10 +856,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      0,
 										BackendGroup: expHTTPSHR4Groups[0],
-										Source:       httpsHR4,
+										Source:       &httpsHR4.ObjectMeta,
 									},
 								},
 							},
@@ -888,10 +866,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      1,
 										BackendGroup: expHTTPSHR3Groups[1],
-										Source:       httpsHR3,
+										Source:       &httpsHR3.ObjectMeta,
 									},
 								},
 							},
@@ -989,10 +965,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      0,
 										BackendGroup: expHR3Groups[0],
-										Source:       hr3,
+										Source:       &hr3.ObjectMeta,
 									},
 								},
 							},
@@ -1001,10 +975,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      1,
 										BackendGroup: expHR3Groups[1],
-										Source:       hr3,
+										Source:       &hr3.ObjectMeta,
 									},
 								},
 							},
@@ -1023,10 +995,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      0,
 										BackendGroup: expHR8Groups[0],
-										Source:       hr8,
+										Source:       &hr8.ObjectMeta,
 									},
 								},
 							},
@@ -1035,10 +1005,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      1,
 										BackendGroup: expHR8Groups[1],
-										Source:       hr8,
+										Source:       &hr8.ObjectMeta,
 									},
 								},
 							},
@@ -1060,10 +1028,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      0,
 										BackendGroup: expHTTPSHR3Groups[0],
-										Source:       httpsHR3,
+										Source:       &httpsHR3.ObjectMeta,
 									},
 								},
 							},
@@ -1072,10 +1038,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      1,
 										BackendGroup: expHTTPSHR3Groups[1],
-										Source:       httpsHR3,
+										Source:       &httpsHR3.ObjectMeta,
 									},
 								},
 							},
@@ -1100,10 +1064,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      0,
 										BackendGroup: expHTTPSHR7Groups[0],
-										Source:       httpsHR7,
+										Source:       &httpsHR7.ObjectMeta,
 									},
 								},
 							},
@@ -1112,10 +1074,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      1,
 										BackendGroup: expHTTPSHR7Groups[1],
-										Source:       httpsHR7,
+										Source:       &httpsHR7.ObjectMeta,
 									},
 								},
 							},
@@ -1244,12 +1204,10 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      0,
-										Source:       hr5,
+										Source:       &hr5.ObjectMeta,
 										BackendGroup: expHR5Groups[0],
-										Filters: Filters{
-											RequestRedirect: redirect.RequestRedirect,
+										Filters: HTTPFilters{
+											RequestRedirect: &expRedirect,
 										},
 									},
 								},
@@ -1259,12 +1217,10 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      1,
-										Source:       hr5,
+										Source:       &hr5.ObjectMeta,
 										BackendGroup: expHR5Groups[1],
-										Filters: Filters{
-											InvalidFilter: &InvalidFilter{},
+										Filters: HTTPFilters{
+											InvalidFilter: &InvalidHTTPFilter{},
 										},
 									},
 								},
@@ -1328,10 +1284,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      0,
 										BackendGroup: expHR6Groups[0],
-										Source:       hr6,
+										Source:       &hr6.ObjectMeta,
 									},
 								},
 							},
@@ -1353,10 +1307,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      0,
 										BackendGroup: expHTTPSHR6Groups[0],
-										Source:       httpsHR6,
+										Source:       &httpsHR6.ObjectMeta,
 									},
 								},
 							},
@@ -1419,10 +1371,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypeExact,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      1,
 										BackendGroup: expHR7Groups[1],
-										Source:       hr7,
+										Source:       &hr7.ObjectMeta,
 									},
 								},
 							},
@@ -1431,10 +1381,8 @@ func TestBuildConfiguration(t *testing.T) {
 								PathType: PathTypePrefix,
 								MatchRules: []MatchRule{
 									{
-										MatchIdx:     0,
-										RuleIdx:      0,
 										BackendGroup: expHR7Groups[0],
-										Source:       hr7,
+										Source:       &hr7.ObjectMeta,
 									},
 								},
 							},
@@ -1500,16 +1448,12 @@ func TestBuildConfiguration(t *testing.T) {
 								MatchRules: []MatchRule{
 									// duplicate match rules since two listeners both match this route's hostname
 									{
-										MatchIdx:     0,
-										RuleIdx:      0,
 										BackendGroup: expHTTPSHR5Groups[0],
-										Source:       httpsHR5,
+										Source:       &httpsHR5.ObjectMeta,
 									},
 									{
-										MatchIdx:     0,
-										RuleIdx:      0,
 										BackendGroup: expHTTPSHR5Groups[0],
-										Source:       httpsHR5,
+										Source:       &httpsHR5.ObjectMeta,
 									},
 								},
 							},
@@ -1595,13 +1539,13 @@ func TestCreateFilters(t *testing.T) {
 	redirect1 := v1beta1.HTTPRouteFilter{
 		Type: v1beta1.HTTPRouteFilterRequestRedirect,
 		RequestRedirect: &v1beta1.HTTPRequestRedirectFilter{
-			Hostname: (*v1beta1.PreciseHostname)(helpers.GetStringPointer("foo.example.com")),
+			Hostname: helpers.GetPointer[v1beta1.PreciseHostname]("foo.example.com"),
 		},
 	}
 	redirect2 := v1beta1.HTTPRouteFilter{
 		Type: v1beta1.HTTPRouteFilterRequestRedirect,
 		RequestRedirect: &v1beta1.HTTPRequestRedirectFilter{
-			Hostname: (*v1beta1.PreciseHostname)(helpers.GetStringPointer("bar.example.com")),
+			Hostname: helpers.GetPointer[v1beta1.PreciseHostname]("bar.example.com"),
 		},
 	}
 	requestHeaderModifiers1 := v1beta1.HTTPRouteFilter{
@@ -1627,22 +1571,34 @@ func TestCreateFilters(t *testing.T) {
 		},
 	}
 
+	expectedRedirect1 := HTTPRequestRedirectFilter{
+		Hostname: helpers.GetPointer("foo.example.com"),
+	}
+	expectedHeaderModifier1 := HTTPHeaderFilter{
+		Set: []HTTPHeader{
+			{
+				Name:  "MyBespokeHeader",
+				Value: "my-value",
+			},
+		},
+	}
+
 	tests := []struct {
-		expected Filters
+		expected HTTPFilters
 		msg      string
 		filters  []v1beta1.HTTPRouteFilter
 	}{
 		{
 			filters:  []v1beta1.HTTPRouteFilter{},
-			expected: Filters{},
+			expected: HTTPFilters{},
 			msg:      "no filters",
 		},
 		{
 			filters: []v1beta1.HTTPRouteFilter{
 				redirect1,
 			},
-			expected: Filters{
-				RequestRedirect: redirect1.RequestRedirect,
+			expected: HTTPFilters{
+				RequestRedirect: &expectedRedirect1,
 			},
 			msg: "one filter",
 		},
@@ -1651,8 +1607,8 @@ func TestCreateFilters(t *testing.T) {
 				redirect1,
 				redirect2,
 			},
-			expected: Filters{
-				RequestRedirect: redirect1.RequestRedirect,
+			expected: HTTPFilters{
+				RequestRedirect: &expectedRedirect1,
 			},
 			msg: "two filters, first wins",
 		},
@@ -1662,9 +1618,9 @@ func TestCreateFilters(t *testing.T) {
 				redirect2,
 				requestHeaderModifiers1,
 			},
-			expected: Filters{
-				RequestRedirect:        redirect1.RequestRedirect,
-				RequestHeaderModifiers: convertHTTPFilter(requestHeaderModifiers1.RequestHeaderModifier),
+			expected: HTTPFilters{
+				RequestRedirect:        &expectedRedirect1,
+				RequestHeaderModifiers: &expectedHeaderModifier1,
 			},
 			msg: "two redirect filters, one request header modifier, first redirect wins",
 		},
@@ -1675,90 +1631,21 @@ func TestCreateFilters(t *testing.T) {
 				requestHeaderModifiers1,
 				requestHeaderModifiers2,
 			},
-			expected: Filters{
-				RequestRedirect:        redirect1.RequestRedirect,
-				RequestHeaderModifiers: convertHTTPFilter(requestHeaderModifiers1.RequestHeaderModifier),
+			expected: HTTPFilters{
+				RequestRedirect:        &expectedRedirect1,
+				RequestHeaderModifiers: &expectedHeaderModifier1,
 			},
 			msg: "two redirect filters, two request header modifier, first value for each wins",
 		},
 	}
 
 	for _, test := range tests {
-		result := createFilters(test.filters)
-		if diff := cmp.Diff(test.expected, result); diff != "" {
-			t.Errorf("createFilters() %q mismatch (-want +got):\n%s", test.msg, diff)
-		}
-	}
-}
+		t.Run(test.msg, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			result := createHTTPFilters(test.filters)
 
-func TestMatchRuleGetMatch(t *testing.T) {
-	hr := &v1beta1.HTTPRoute{
-		Spec: v1beta1.HTTPRouteSpec{
-			Rules: []v1beta1.HTTPRouteRule{
-				{
-					Matches: []v1beta1.HTTPRouteMatch{
-						{
-							Path: &v1beta1.HTTPPathMatch{
-								Value: helpers.GetStringPointer("/path-1"),
-							},
-						},
-						{
-							Path: &v1beta1.HTTPPathMatch{
-								Value: helpers.GetStringPointer("/path-2"),
-							},
-						},
-					},
-				},
-				{
-					Matches: []v1beta1.HTTPRouteMatch{
-						{
-							Path: &v1beta1.HTTPPathMatch{
-								Value: helpers.GetStringPointer("/path-3"),
-							},
-						},
-						{
-							Path: &v1beta1.HTTPPathMatch{
-								Value: helpers.GetStringPointer("/path-4"),
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	tests := []struct {
-		name    string
-		expPath string
-		rule    MatchRule
-	}{
-		{
-			name:    "first match in first rule",
-			expPath: "/path-1",
-			rule:    MatchRule{MatchIdx: 0, RuleIdx: 0, Source: hr},
-		},
-		{
-			name:    "second match in first rule",
-			expPath: "/path-2",
-			rule:    MatchRule{MatchIdx: 1, RuleIdx: 0, Source: hr},
-		},
-		{
-			name:    "second match in second rule",
-			expPath: "/path-4",
-			rule:    MatchRule{MatchIdx: 1, RuleIdx: 1, Source: hr},
-		},
-	}
-
-	for _, tc := range tests {
-		actual := tc.rule.GetMatch()
-		if *actual.Path.Value != tc.expPath {
-			t.Errorf(
-				"MatchRule.GetMatch() returned incorrect match with path: %s, expected path: %s for test case: %q",
-				*actual.Path.Value,
-				tc.expPath,
-				tc.name,
-			)
-		}
+			g.Expect(helpers.Diff(test.expected, result)).To(BeEmpty())
+		})
 	}
 }
 
@@ -2061,38 +1948,6 @@ func TestBuildBackendGroups(t *testing.T) {
 	g.Expect(result).To(ConsistOf(expGroups))
 }
 
-func TestConvertPathType(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	tests := []struct {
-		expected PathType
-		pathType v1beta1.PathMatchType
-		panic    bool
-	}{
-		{
-			expected: PathTypePrefix,
-			pathType: v1beta1.PathMatchPathPrefix,
-		},
-		{
-			expected: PathTypeExact,
-			pathType: v1beta1.PathMatchExact,
-		},
-		{
-			pathType: v1beta1.PathMatchRegularExpression,
-			panic:    true,
-		},
-	}
-
-	for _, tc := range tests {
-		if tc.panic {
-			g.Expect(func() { convertPathType(tc.pathType) }).To(Panic())
-		} else {
-			result := convertPathType(tc.pathType)
-			g.Expect(result).To(Equal(tc.expected))
-		}
-	}
-}
-
 func TestHostnameMoreSpecific(t *testing.T) {
 	tests := []struct {
 		host1     *v1beta1.Hostname
@@ -2151,35 +2006,4 @@ func TestHostnameMoreSpecific(t *testing.T) {
 			g.Expect(listenerHostnameMoreSpecific(tc.host1, tc.host2)).To(Equal(tc.host1Wins))
 		})
 	}
-}
-
-func TestConvertHTTPFilter(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	httpFilter := &v1beta1.HTTPHeaderFilter{
-		Set: []v1beta1.HTTPHeader{{
-			Name:  "My-Set-Header",
-			Value: "my-value",
-		}},
-		Add: []v1beta1.HTTPHeader{{
-			Name:  "My-Add-Header",
-			Value: "my-value",
-		}},
-		Remove: []string{"My-remove-header"},
-	}
-
-	expected := HTTPHeaderFilter{
-		Set: []HTTPHeader{{
-			Name:  "My-Set-Header",
-			Value: "my-value",
-		}},
-		Add: []HTTPHeader{{
-			Name:  "My-Add-Header",
-			Value: "my-value",
-		}},
-		Remove: []string{"My-remove-header"},
-	}
-
-	result := convertHTTPFilter(httpFilter)
-	g.Expect(*result).To(Equal(expected))
 }

--- a/internal/mode/static/state/dataplane/convert.go
+++ b/internal/mode/static/state/dataplane/convert.go
@@ -1,0 +1,80 @@
+package dataplane
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+func convertMatch(m v1beta1.HTTPRouteMatch) Match {
+	match := Match{}
+
+	if m.Method != nil {
+		method := string(*m.Method)
+		match.Method = &method
+	}
+
+	if len(m.Headers) != 0 {
+		match.Headers = make([]HTTPHeaderMatch, 0, len(m.Headers))
+		for _, h := range m.Headers {
+			match.Headers = append(match.Headers, HTTPHeaderMatch{
+				Name:  string(h.Name),
+				Value: h.Value,
+			})
+		}
+	}
+
+	if len(m.QueryParams) != 0 {
+		match.QueryParams = make([]HTTPQueryParamMatch, 0, len(m.QueryParams))
+		for _, q := range m.QueryParams {
+			match.QueryParams = append(match.QueryParams, HTTPQueryParamMatch{
+				Name:  string(q.Name),
+				Value: q.Value,
+			})
+		}
+	}
+
+	return match
+}
+
+func convertHTTPRequestRedirectFilter(filter *v1beta1.HTTPRequestRedirectFilter) *HTTPRequestRedirectFilter {
+	return &HTTPRequestRedirectFilter{
+		Scheme:     filter.Scheme,
+		Hostname:   (*string)(filter.Hostname),
+		Port:       (*int32)(filter.Port),
+		StatusCode: filter.StatusCode,
+	}
+}
+
+func convertHTTPHeaderFilter(filter *v1beta1.HTTPHeaderFilter) *HTTPHeaderFilter {
+	result := &HTTPHeaderFilter{
+		Remove: filter.Remove,
+	}
+
+	if len(filter.Set) != 0 {
+		result.Set = make([]HTTPHeader, 0, len(filter.Set))
+		for _, s := range filter.Set {
+			result.Set = append(result.Set, HTTPHeader{Name: string(s.Name), Value: s.Value})
+		}
+	}
+
+	if len(filter.Add) != 0 {
+		result.Add = make([]HTTPHeader, 0, len(filter.Add))
+		for _, a := range filter.Add {
+			result.Add = append(result.Add, HTTPHeader{Name: string(a.Name), Value: a.Value})
+		}
+	}
+
+	return result
+}
+
+func convertPathType(pathType v1beta1.PathMatchType) PathType {
+	switch pathType {
+	case v1beta1.PathMatchPathPrefix:
+		return PathTypePrefix
+	case v1beta1.PathMatchExact:
+		return PathTypeExact
+	default:
+		panic(fmt.Sprintf("unsupported path type: %s", pathType))
+	}
+}

--- a/internal/mode/static/state/dataplane/convert_test.go
+++ b/internal/mode/static/state/dataplane/convert_test.go
@@ -1,0 +1,242 @@
+package dataplane
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/nginxinc/nginx-kubernetes-gateway/internal/framework/helpers"
+)
+
+func TestConvertMatch(t *testing.T) {
+	path := v1beta1.HTTPPathMatch{
+		Type:  helpers.GetPointer(v1beta1.PathMatchPathPrefix),
+		Value: helpers.GetPointer("/"),
+	}
+
+	tests := []struct {
+		match    v1beta1.HTTPRouteMatch
+		name     string
+		expected Match
+	}{
+		{
+			match: v1beta1.HTTPRouteMatch{
+				Path: &path,
+			},
+			expected: Match{},
+			name:     "path only",
+		},
+		{
+			match: v1beta1.HTTPRouteMatch{
+				Path:   &path,
+				Method: helpers.GetPointer(v1beta1.HTTPMethodGet),
+			},
+			expected: Match{
+				Method: helpers.GetPointer("GET"),
+			},
+			name: "path and method",
+		},
+		{
+			match: v1beta1.HTTPRouteMatch{
+				Path: &path,
+				Headers: []v1beta1.HTTPHeaderMatch{
+					{
+						Name:  "Test-Header",
+						Value: "test-header-value",
+					},
+				},
+			},
+			expected: Match{
+				Headers: []HTTPHeaderMatch{
+					{
+						Name:  "Test-Header",
+						Value: "test-header-value",
+					},
+				},
+			},
+			name: "path and header",
+		},
+		{
+			match: v1beta1.HTTPRouteMatch{
+				Path: &path,
+				QueryParams: []v1beta1.HTTPQueryParamMatch{
+					{
+						Name:  "Test-Param",
+						Value: "test-param-value",
+					},
+				},
+			},
+			expected: Match{
+				QueryParams: []HTTPQueryParamMatch{
+					{
+						Name:  "Test-Param",
+						Value: "test-param-value",
+					},
+				},
+			},
+			name: "path and query param",
+		},
+		{
+			match: v1beta1.HTTPRouteMatch{
+				Path:   &path,
+				Method: helpers.GetPointer(v1beta1.HTTPMethodGet),
+				Headers: []v1beta1.HTTPHeaderMatch{
+					{
+						Name:  "Test-Header",
+						Value: "test-header-value",
+					},
+				},
+				QueryParams: []v1beta1.HTTPQueryParamMatch{
+					{
+						Name:  "Test-Param",
+						Value: "test-param-value",
+					},
+				},
+			},
+			expected: Match{
+				Method: helpers.GetPointer("GET"),
+				Headers: []HTTPHeaderMatch{
+					{
+						Name:  "Test-Header",
+						Value: "test-header-value",
+					},
+				},
+				QueryParams: []HTTPQueryParamMatch{
+					{
+						Name:  "Test-Param",
+						Value: "test-param-value",
+					},
+				},
+			},
+			name: "path, method, header, and query param",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			result := convertMatch(test.match)
+			g.Expect(helpers.Diff(result, test.expected)).To(BeEmpty())
+		})
+	}
+}
+
+func TestConvertHTTPRequestRedirectFilter(t *testing.T) {
+	tests := []struct {
+		filter   *v1beta1.HTTPRequestRedirectFilter
+		expected *HTTPRequestRedirectFilter
+		name     string
+	}{
+		{
+			filter:   &v1beta1.HTTPRequestRedirectFilter{},
+			expected: &HTTPRequestRedirectFilter{},
+			name:     "empty",
+		},
+		{
+			filter: &v1beta1.HTTPRequestRedirectFilter{
+				Scheme:     helpers.GetPointer("https"),
+				Hostname:   helpers.GetPointer[v1beta1.PreciseHostname]("example.com"),
+				Port:       helpers.GetPointer[v1beta1.PortNumber](8443),
+				StatusCode: helpers.GetPointer(302),
+			},
+			expected: &HTTPRequestRedirectFilter{
+				Scheme:     helpers.GetPointer("https"),
+				Hostname:   helpers.GetPointer("example.com"),
+				Port:       helpers.GetPointer[int32](8443),
+				StatusCode: helpers.GetPointer(302),
+			},
+			name: "full",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			result := convertHTTPRequestRedirectFilter(test.filter)
+			g.Expect(result).To(Equal(test.expected))
+		})
+	}
+}
+
+func TestConvertHTTPHeaderFilter(t *testing.T) {
+	tests := []struct {
+		filter   *v1beta1.HTTPHeaderFilter
+		expected *HTTPHeaderFilter
+		name     string
+	}{
+		{
+			filter:   &v1beta1.HTTPHeaderFilter{},
+			expected: &HTTPHeaderFilter{},
+			name:     "empty",
+		},
+		{
+			filter: &v1beta1.HTTPHeaderFilter{
+				Set: []v1beta1.HTTPHeader{{
+					Name:  "My-Set-Header",
+					Value: "my-value",
+				}},
+				Add: []v1beta1.HTTPHeader{{
+					Name:  "My-Add-Header",
+					Value: "my-value",
+				}},
+				Remove: []string{"My-remove-header"},
+			},
+			expected: &HTTPHeaderFilter{
+				Set: []HTTPHeader{{
+					Name:  "My-Set-Header",
+					Value: "my-value",
+				}},
+				Add: []HTTPHeader{{
+					Name:  "My-Add-Header",
+					Value: "my-value",
+				}},
+				Remove: []string{"My-remove-header"},
+			},
+			name: "full",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			result := convertHTTPHeaderFilter(test.filter)
+			g.Expect(result).To(Equal(test.expected))
+		})
+	}
+}
+
+func TestConvertPathType(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	tests := []struct {
+		pathType v1beta1.PathMatchType
+		expected PathType
+		panic    bool
+	}{
+		{
+			expected: PathTypePrefix,
+			pathType: v1beta1.PathMatchPathPrefix,
+		},
+		{
+			expected: PathTypeExact,
+			pathType: v1beta1.PathMatchExact,
+		},
+		{
+			pathType: v1beta1.PathMatchRegularExpression,
+			panic:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		if tc.panic {
+			g.Expect(func() { convertPathType(tc.pathType) }).To(Panic())
+		} else {
+			result := convertPathType(tc.pathType)
+			g.Expect(result).To(Equal(tc.expected))
+		}
+	}
+}

--- a/internal/mode/static/state/dataplane/sort.go
+++ b/internal/mode/static/state/dataplane/sort.go
@@ -37,39 +37,35 @@ If ties still exist within the Route that has been given precedence,
 matching precedence MUST be granted to the first matching rule meeting the above criteria.
 
 higherPriority will determine precedence by comparing len(headers), len(query parameters), creation timestamp,
-and namespace name. The other criteria are handled by NGINX.
+and namespace name. It gives higher priority to rules with a method match. The other criteria are handled by NGINX.
 */
 func higherPriority(rule1, rule2 MatchRule) bool {
-	// Get the matches from the rules
-	match1 := rule1.GetMatch()
-	match2 := rule2.GetMatch()
-
 	// Compare if a method exists on one of the matches but not the other.
 	// The match with the method specified wins.
-	if match1.Method != nil && match2.Method == nil {
+	if rule1.Match.Method != nil && rule2.Match.Method == nil {
 		return true
 	}
-	if match2.Method != nil && match1.Method == nil {
+	if rule2.Match.Method != nil && rule1.Match.Method == nil {
 		return false
 	}
 
 	// Compare the number of header matches.
 	// The match with the largest number of header matches wins.
-	l1 := len(match1.Headers)
-	l2 := len(match2.Headers)
+	l1 := len(rule1.Match.Headers)
+	l2 := len(rule2.Match.Headers)
 
 	if l1 != l2 {
 		return l1 > l2
 	}
 	// If the number of headers is equal then compare the number of query param matches.
 	// The match with the most query param matches wins.
-	l1 = len(match1.QueryParams)
-	l2 = len(match2.QueryParams)
+	l1 = len(rule1.Match.QueryParams)
+	l2 = len(rule2.Match.QueryParams)
 
 	if l1 != l2 {
 		return l1 > l2
 	}
 
 	// If still tied, compare the object meta of the two routes.
-	return nkgsort.LessObjectMeta(&rule1.Source.ObjectMeta, &rule2.Source.ObjectMeta)
+	return nkgsort.LessObjectMeta(rule1.Source, rule2.Source)
 }

--- a/internal/mode/static/state/dataplane/sort_test.go
+++ b/internal/mode/static/state/dataplane/sort_test.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/nginxinc/nginx-kubernetes-gateway/internal/framework/helpers"
 )
@@ -16,208 +16,148 @@ func TestSort(t *testing.T) {
 	earlier := metav1.Now()
 	later := metav1.NewTime(earlier.Add(1 * time.Second))
 
-	// matches
-	pathOnlyMatch := v1beta1.HTTPRouteMatch{
-		Path: &v1beta1.HTTPPathMatch{
-			Value: helpers.GetStringPointer("/path"), // path match only (low priority)
-		},
+	earlierTimestampMeta := &metav1.ObjectMeta{
+		Name:              "hr1",
+		Namespace:         "test",
+		CreationTimestamp: earlier,
 	}
-	twoHeaderMatch := v1beta1.HTTPRouteMatch{
-		Path: &v1beta1.HTTPPathMatch{
-			Value: helpers.GetStringPointer("/path"),
-		},
-		Headers: []v1beta1.HTTPHeaderMatch{
-			{
-				Name:  "header1",
-				Value: "value1",
-			},
-			{
-				Name:  "header2",
-				Value: "value2",
-			},
-		},
+	laterTimestampMeta := &metav1.ObjectMeta{
+		Name:              "hr2",
+		Namespace:         "test",
+		CreationTimestamp: later,
 	}
-	threeHeaderMatch := v1beta1.HTTPRouteMatch{
-		Path: &v1beta1.HTTPPathMatch{
-			Value: helpers.GetStringPointer("/path"),
-		},
-		Headers: []v1beta1.HTTPHeaderMatch{
-			{
-				Name:  "header1",
-				Value: "value1",
-			},
-			{
-				Name:  "header2",
-				Value: "value2",
-			},
-			{
-				Name:  "header3",
-				Value: "value3",
-			},
-		},
-	}
-	twoHeaderOneParamMatch := v1beta1.HTTPRouteMatch{
-		Path: &v1beta1.HTTPPathMatch{
-			Value: helpers.GetStringPointer("/path"),
-		},
-		Headers: []v1beta1.HTTPHeaderMatch{
-			{
-				Name:  "header1",
-				Value: "value1",
-			},
-			{
-				Name:  "header2",
-				Value: "value2",
-			},
-		},
-		QueryParams: []v1beta1.HTTPQueryParamMatch{
-			{
-				Name:  "key1",
-				Value: "value1",
-			},
-		},
-	}
-	methodMatch := v1beta1.HTTPRouteMatch{
-		Path: &v1beta1.HTTPPathMatch{
-			Value: helpers.GetStringPointer("/path"),
-		},
-		Method: helpers.GetPointer(v1beta1.HTTPMethodPost),
+	laterTimestampButAlphabeticallyFirstMeta := &metav1.ObjectMeta{
+		Name:              "hr3",
+		Namespace:         "a-test",
+		CreationTimestamp: later,
 	}
 
-	hr1 := v1beta1.HTTPRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "hr1",
-			Namespace:         "test",
-			CreationTimestamp: earlier,
-		},
-		Spec: v1beta1.HTTPRouteSpec{
-			Rules: []v1beta1.HTTPRouteRule{
+	pathOnly := MatchRule{
+		Match:  Match{},
+		Source: earlierTimestampMeta,
+	}
+	twoHeadersEarlierTimestamp := MatchRule{
+		Match: Match{
+			Headers: []HTTPHeaderMatch{
 				{
-					Matches: []v1beta1.HTTPRouteMatch{pathOnlyMatch},
+					Name:  "header1",
+					Value: "value1",
 				},
 				{
-					Matches: []v1beta1.HTTPRouteMatch{twoHeaderMatch},
-				},
-				{
-					Matches: []v1beta1.HTTPRouteMatch{
-						twoHeaderOneParamMatch, // tie decided on params
-						threeHeaderMatch,       // tie decided on headers
-						methodMatch,            // tie decided on method
-					},
+					Name:  "header2",
+					Value: "value2",
 				},
 			},
 		},
+		Source: earlierTimestampMeta,
 	}
-
-	hr2 := v1beta1.HTTPRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "hr2",
-			Namespace:         "test",
-			CreationTimestamp: later,
-		},
-		Spec: v1beta1.HTTPRouteSpec{
-			Rules: []v1beta1.HTTPRouteRule{
+	twoHeadersOneParam := MatchRule{
+		Match: Match{
+			Headers: []HTTPHeaderMatch{
 				{
-					Matches: []v1beta1.HTTPRouteMatch{twoHeaderMatch}, // tie decided on creation timestamp
+					Name:  "header1",
+					Value: "value1",
+				},
+				{
+					Name:  "header2",
+					Value: "value2",
+				},
+			},
+			QueryParams: []HTTPQueryParamMatch{
+				{
+					Name:  "key1",
+					Value: "value1",
 				},
 			},
 		},
+		Source: earlierTimestampMeta,
 	}
-
-	hr3 := v1beta1.HTTPRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "hr3",
-			Namespace:         "a-test", // tie decided by namespace name
-			CreationTimestamp: later,
-		},
-		Spec: v1beta1.HTTPRouteSpec{
-			Rules: []v1beta1.HTTPRouteRule{
+	threeHeaders := MatchRule{
+		Match: Match{
+			Headers: []HTTPHeaderMatch{
 				{
-					Matches: []v1beta1.HTTPRouteMatch{twoHeaderMatch},
+					Name:  "header1",
+					Value: "value1",
+				},
+				{
+					Name:  "header2",
+					Value: "value2",
+				},
+				{
+					Name:  "header3",
+					Value: "value3",
 				},
 			},
 		},
+		Source: earlierTimestampMeta,
+	}
+	methodEarlierTimestamp := MatchRule{
+		Match: Match{
+			Method: helpers.GetPointer("POST"),
+		},
+		Source: earlierTimestampMeta,
+	}
+	methodLaterTimestamp := MatchRule{
+		Match: Match{
+			Method: helpers.GetPointer("POST"),
+		},
+		Source: earlierTimestampMeta,
+	}
+	twoHeadersLaterTimestamp := MatchRule{
+		Match: Match{
+			Headers: []HTTPHeaderMatch{
+				{
+					Name:  "header1",
+					Value: "value1",
+				},
+				{
+					Name:  "header2",
+					Value: "value2",
+				},
+			},
+		},
+		Source: laterTimestampMeta,
+	}
+	twoHeadersLaterTimestampButAlphabeticallyBefore := MatchRule{
+		Match: Match{
+			Headers: []HTTPHeaderMatch{
+				{
+					Name:  "header1",
+					Value: "value1",
+				},
+				{
+					Name:  "header2",
+					Value: "value2",
+				},
+			},
+		},
+		Source: laterTimestampButAlphabeticallyFirstMeta,
 	}
 
-	routes := []MatchRule{
-		{
-			MatchIdx: 0, // pathOnlyMatch
-			RuleIdx:  0,
-			Source:   &hr1,
-		},
-		{
-			MatchIdx: 0, // twoHeaderMatch / earlier timestamp
-			RuleIdx:  1,
-			Source:   &hr1,
-		},
-		{
-			MatchIdx: 0, // twoHeaderOneParamMatch
-			RuleIdx:  2,
-			Source:   &hr1,
-		},
-		{
-			MatchIdx: 1, // threeHeaderMatch
-			RuleIdx:  2,
-			Source:   &hr1,
-		},
-		{
-			MatchIdx: 2, // methodMatch
-			RuleIdx:  2,
-			Source:   &hr1,
-		},
-		{
-			MatchIdx: 0, // twoHeaderMatch / later timestamp / test/hr2
-			RuleIdx:  0,
-			Source:   &hr2,
-		},
-		{
-			MatchIdx: 0, // twoHeaderMatch / later timestamp / a-test/hr3
-			RuleIdx:  0,
-			Source:   &hr3,
-		},
+	rules := []MatchRule{
+		methodLaterTimestamp,
+		pathOnly,
+		twoHeadersEarlierTimestamp,
+		twoHeadersOneParam,
+		threeHeaders,
+		methodEarlierTimestamp,
+		twoHeadersLaterTimestamp,
+		twoHeadersLaterTimestampButAlphabeticallyBefore,
 	}
 
-	sortedRoutes := []MatchRule{
-		{
-			MatchIdx: 2, // methodMatch
-			RuleIdx:  2,
-			Source:   &hr1,
-		},
-		{
-			MatchIdx: 1, // threeHeaderMatch
-			RuleIdx:  2,
-			Source:   &hr1,
-		},
-		{
-			MatchIdx: 0, // twoHeaderOneParamMatch
-			RuleIdx:  2,
-			Source:   &hr1,
-		},
-		{
-			MatchIdx: 0, // twoHeaderMatch / earlier timestamp
-			RuleIdx:  1,
-			Source:   &hr1,
-		},
-		{
-			MatchIdx: 0, // twoHeaderMatch / later timestamp / a-test/hr3
-			RuleIdx:  0,
-			Source:   &hr3,
-		},
-		{
-			MatchIdx: 0, // twoHeaderMatch / later timestamp / test/hr2
-			RuleIdx:  0,
-			Source:   &hr2,
-		},
-		{
-			MatchIdx: 0, // pathOnlyMatch
-			RuleIdx:  0,
-			Source:   &hr1,
-		},
+	sortedRules := []MatchRule{
+		methodEarlierTimestamp,
+		methodLaterTimestamp,
+		threeHeaders,
+		twoHeadersOneParam,
+		twoHeadersEarlierTimestamp,
+		twoHeadersLaterTimestampButAlphabeticallyBefore,
+		twoHeadersLaterTimestamp,
+		pathOnly,
 	}
 
-	sortMatchRules(routes)
+	sortMatchRules(rules)
 
-	if diff := cmp.Diff(sortedRoutes, routes); diff != "" {
-		t.Errorf("sortMatchRules() mismatch (-want +got):\n%s", diff)
-	}
+	g := NewGomegaWithT(t)
+	g.Expect(cmp.Diff(sortedRules, rules)).To(BeEmpty())
 }

--- a/internal/mode/static/state/dataplane/types.go
+++ b/internal/mode/static/state/dataplane/types.go
@@ -1,0 +1,178 @@
+package dataplane
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/nginxinc/nginx-kubernetes-gateway/internal/mode/static/state/resolver"
+)
+
+// PathType is the type of the path in a PathRule.
+type PathType string
+
+const (
+	// PathTypePrefix indicates that the path is a prefix.
+	PathTypePrefix PathType = "prefix"
+	// PathTypeExact indicates that the path is exact.
+	PathTypeExact PathType = "exact"
+)
+
+// Configuration is an intermediate representation of dataplane configuration.
+type Configuration struct {
+	// SSLKeyPairs holds all unique SSLKeyPairs.
+	SSLKeyPairs map[SSLKeyPairID]SSLKeyPair
+	// HTTPServers holds all HTTPServers.
+	HTTPServers []VirtualServer
+	// SSLServers holds all SSLServers.
+	SSLServers []VirtualServer
+	// Upstreams holds all unique Upstreams.
+	Upstreams []Upstream
+	// BackendGroups holds all unique BackendGroups.
+	BackendGroups []BackendGroup
+}
+
+// SSLKeyPairID is a unique identifier for a SSLKeyPair.
+// The ID is safe to use as a file name.
+type SSLKeyPairID string
+
+// SSLKeyPair is an SSL private/public key pair.
+type SSLKeyPair struct {
+	Cert, Key []byte
+}
+
+// VirtualServer is a virtual server.
+type VirtualServer struct {
+	// SSL holds the SSL configuration for the server.
+	SSL *SSL
+	// Hostname is the hostname of the server.
+	Hostname string
+	// PathRules is a collection of routing rules.
+	PathRules []PathRule
+	// IsDefault indicates whether the server is the default server.
+	IsDefault bool
+	// Port is the port of the server.
+	Port int32
+}
+
+// Upstream is a pool of endpoints to be load balanced.
+type Upstream struct {
+	// Name is the name of the Upstream. Will be unique for each service/port combination.
+	Name string
+	// ErrorMsg contains the error message if the Upstream is invalid.
+	ErrorMsg string
+	// Endpoints are the endpoints of the Upstream.
+	Endpoints []resolver.Endpoint
+}
+
+// SSL is the SSL configuration for a server.
+type SSL struct {
+	KeyPairID SSLKeyPairID
+}
+
+// PathRule represents routing rules that share a common path.
+type PathRule struct {
+	// Path is a path. For example, '/hello'.
+	Path string
+	// PathType is the type of the path.
+	PathType PathType
+	// MatchRules holds routing rules.
+	MatchRules []MatchRule
+}
+
+// InvalidHTTPFilter is a special filter for handling the case when configured filters are invalid.
+type InvalidHTTPFilter struct{}
+
+// HTTPFilters hold the filters for a MatchRule.
+type HTTPFilters struct {
+	InvalidFilter          *InvalidHTTPFilter
+	RequestRedirect        *HTTPRequestRedirectFilter
+	RequestHeaderModifiers *HTTPHeaderFilter
+}
+
+// HTTPHeader represents an HTTP header.
+type HTTPHeader struct {
+	Name  string
+	Value string
+}
+
+// HTTPHeaderFilter manipulates HTTP headers.
+type HTTPHeaderFilter struct {
+	Set    []HTTPHeader
+	Add    []HTTPHeader
+	Remove []string
+}
+
+// HTTPRequestRedirectFilter redirects HTTP requests.
+type HTTPRequestRedirectFilter struct {
+	Scheme     *string
+	Hostname   *string
+	Port       *int32
+	StatusCode *int
+}
+
+// HTTPHeaderMatch matches an HTTP header.
+type HTTPHeaderMatch struct {
+	Name  string
+	Value string
+}
+
+// HTTPQueryParamMatch matches an HTTP query parameter.
+type HTTPQueryParamMatch struct {
+	Name  string
+	Value string
+}
+
+// MatchRule represents a routing rule. It corresponds directly to a Match in the HTTPRoute resource.
+// An HTTPRoute is guaranteed to have at least one rule with one match.
+// If no rule or match is specified by the user, the default rule {{path:{ type: "PathPrefix", value: "/"}}}
+// is set by the schema.
+type MatchRule struct {
+	// Filters holds the filters for the MatchRule.
+	Filters HTTPFilters
+	// Source is the ObjectMeta of the resource that includes the rule.
+	Source *metav1.ObjectMeta
+	// Match holds the match for the rule.
+	Match Match
+	// BackendGroup is the group of Backends that the rule routes to.
+	BackendGroup BackendGroup
+}
+
+// Match represents a match for a routing rule which consist of matches against various HTTP request attributes.
+type Match struct {
+	Method      *string
+	Headers     []HTTPHeaderMatch
+	QueryParams []HTTPQueryParamMatch
+}
+
+// BackendGroup represents a group of Backends for a routing rule in an HTTPRoute.
+type BackendGroup struct {
+	// Source is the NamespacedName of the HTTPRoute the group belongs to.
+	Source types.NamespacedName
+	// Backends is a list of Backends in the Group.
+	Backends []Backend
+	// RuleIdx is the index of the corresponding rule in the HTTPRoute.
+	RuleIdx int
+}
+
+// Name returns the name of the backend group.
+// This name must be unique across all HTTPRoutes and all rules within the same HTTPRoute.
+// The RuleIdx is used to make the name unique across all rules within the same HTTPRoute.
+// The RuleIdx may change for a given rule if an update is made to the HTTPRoute, but it will always match the index
+// of the rule in the stored HTTPRoute.
+func (bg *BackendGroup) Name() string {
+	return fmt.Sprintf("%s__%s_rule%d", bg.Source.Namespace, bg.Source.Name, bg.RuleIdx)
+}
+
+// Backend represents a Backend for a routing rule.
+type Backend struct {
+	// UpstreamName is the name of the upstream for this backend.
+	UpstreamName string
+	// Weight is the weight of the BackendRef.
+	// The possible values of weight are 0-1,000,000.
+	// If weight is 0, no traffic should be forwarded for this entry.
+	Weight int32
+	// Valid indicates whether the Backend is valid.
+	Valid bool
+}


### PR DESCRIPTION
### Proposed changes

Problem:

Configuration-related types in the data plane package include Gateway API types.

As a result:
- We need to make any validation-related assumptions about them (ex. certain fields cannot be not nil) in the config package.
- It makes it difficult maintain/extend and potentially allow for supporting more routing resource types (outside of Gateway API) in the future.
- It makes unit tests more complicated in the config package

Solution:

- Remove Gateway API types from Configuration-related types.
- Move the types to types.go file.
- Move converters to convert.go

Testing: Unit testing

Closes https://github.com/nginxinc/nginx-kubernetes-gateway/issues/660

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
