### PR TITLE
Fix builder docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ OUT_DIR ?= $(shell pwd)/build/out## The folder where the binary will be stored
 ARCH ?= amd64## The architecture of the image and/or binary. For example: amd64 or arm64
 override HELM_TEMPLATE_COMMON_ARGS += --set creator=template --set nameOverride=nginx-gateway## The common options for the Helm template command.
 override HELM_TEMPLATE_EXTRA_ARGS_FOR_ALL_MANIFESTS_FILE += --include-crds --set service.create=false## The options to be passed to the full Helm templating command only.
-override DOCKER_BUILD_OPTIONS += --build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg DATE=$(DATE)## The options for the docker build command. For example, --pull
 override NGINX_DOCKER_BUILD_OPTIONS += --build-arg NJS_DIR=$(NJS_DIR) --build-arg NGINX_CONF_DIR=$(NGINX_CONF_DIR)
 .DEFAULT_GOAL := help
 
@@ -36,7 +35,7 @@ build-images: build-nkg-image build-nginx-image ## Build the NKG and nginx docke
 
 .PHONY: build-nkg-image
 build-nkg-image: check-for-docker build ## Build the NKG docker image
-	docker build --platform linux/$(ARCH) $(strip $(DOCKER_BUILD_OPTIONS)) --target $(strip $(TARGET)) -f build/Dockerfile -t $(strip $(PREFIX)):$(strip $(TAG)) .
+	docker build --platform linux/$(ARCH) --target $(strip $(TARGET)) -f build/Dockerfile -t $(strip $(PREFIX)):$(strip $(TAG)) .
 
 .PHONY: build-nginx-image
 build-nginx-image: check-for-docker ## Build the custom nginx image

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,6 +4,7 @@ FROM golang:1.21 as builder
 WORKDIR /go/src/github.com/nginxinc/nginx-kubernetes-gateway
 
 COPY . /go/src/github.com/nginxinc/nginx-kubernetes-gateway
+RUN go mod download
 RUN make build
 
 FROM alpine:3.18 as capabilizer

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,15 +4,10 @@ ARG VERSION
 ARG GIT_COMMIT
 ARG DATE
 
-WORKDIR /go/src/github.com/nginxinc/nginx-kubernetes-gateway/cmd/gateway
+WORKDIR /go/src/github.com/nginxinc/nginx-kubernetes-gateway
 
-COPY go.mod go.sum /go/src/github.com/nginxinc/nginx-kubernetes-gateway
-RUN go mod download
-
-COPY cmd /go/src/github.com/nginxinc/nginx-kubernetes-gateway/cmd
-COPY internal /go/src/github.com/nginxinc/nginx-kubernetes-gateway/internal
-COPY pkg /go/src/github.com/nginxinc/nginx-kubernetes-gateway/pkg
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -a -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${GIT_COMMIT} -X main.date=${DATE}" -o gateway .
+COPY . /go/src/github.com/nginxinc/nginx-kubernetes-gateway
+RUN make build
 
 FROM alpine:3.18 as capabilizer
 RUN apk add --no-cache libcap
@@ -22,7 +17,7 @@ COPY ./build/out/gateway /usr/bin/
 RUN setcap 'cap_kill=+ep' /usr/bin/gateway
 
 FROM capabilizer as container-capabilizer
-COPY --from=builder /go/src/github.com/nginxinc/nginx-kubernetes-gateway/cmd/gateway/gateway /usr/bin/
+COPY --from=builder /go/src/github.com/nginxinc/nginx-kubernetes-gateway/build/out/gateway /usr/bin/
 RUN setcap 'cap_kill=+ep' /usr/bin/gateway
 
 FROM capabilizer as goreleaser-capabilizer

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,8 +3,10 @@ FROM golang:1.21 as builder
 
 WORKDIR /go/src/github.com/nginxinc/nginx-kubernetes-gateway
 
-COPY . /go/src/github.com/nginxinc/nginx-kubernetes-gateway
+COPY go.mod go.sum /go/src/github.com/nginxinc/nginx-kubernetes-gateway
 RUN go mod download
+
+COPY . /go/src/github.com/nginxinc/nginx-kubernetes-gateway
 RUN make build
 
 FROM alpine:3.18 as capabilizer

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,5 @@
 # syntax=docker/dockerfile:1.4
 FROM golang:1.21 as builder
-ARG VERSION
-ARG GIT_COMMIT
-ARG DATE
 
 WORKDIR /go/src/github.com/nginxinc/nginx-kubernetes-gateway
 


### PR DESCRIPTION
Problem: The builder docker image was out of date and didn't copy the correct files.
Solution: Copy the whole directory and run the make command to ensure everything is always in sync.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
