### PR TITLE
Add an index page for guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Learn about our [design principles](/docs/developer/design-principles.md) and [a
    available
    on [GitHub Container Registry](https://github.com/nginxinc/nginx-kubernetes-gateway/pkgs/container/nginx-kubernetes-gateway).
 4. Deploy various [examples](examples).
-5. Explore our [documentation and guides](docs).
+5. Read our [guides](/docs/guides).
 
 ## NGINX Kubernetes Gateway Releases
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Learn about our [design principles](/docs/developer/design-principles.md) and [a
    available
    on [GitHub Container Registry](https://github.com/nginxinc/nginx-kubernetes-gateway/pkgs/container/nginx-kubernetes-gateway).
 4. Deploy various [examples](examples).
-5. Read our [guides](/docs/guides).
+5. Explore our [documentation and guides](docs).
 
 ## NGINX Kubernetes Gateway Releases
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,11 @@ This directory contains all of the documentation relating to NGINX Kubernetes Ga
 - [Gateway API Compatibility](gateway-api-compatibility.md): Describes which Gateway API resources NGINX Kubernetes
 Gateway supports and the extent of that support.
 - [Installation](installation.md): Walkthrough on how to install NGINX Kubernetes Gateway on a generic Kubernetes cluster.
+- Guides:
+  - [Securing Traffic using Let's Encrypt and Cert-Manager](guides/integrating-cert-manager.md): Shows how to secure
+    traffic from clients to NGINX Kubernetes Gateway with TLS using Let's Encrypt and Cert-Manager.
+  - [Using NGINX Kubernetes Gateway to Upgrade Applications without Downtime](guides/upgrade-apps-without-downtime.md):
+    Explains how to use NGINX Kubernetes Gateway to upgrade applications without downtime.
 - [Resource Validation](resource-validation.md): Describes how NGINX Kubernetes Gateway validates Gateway API
 resources.
 - [Control Plane Configuration](control-plane-configuration.md): Describes how to dynamically update the NGINX

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,11 +8,6 @@ This directory contains all of the documentation relating to NGINX Kubernetes Ga
 - [Gateway API Compatibility](gateway-api-compatibility.md): Describes which Gateway API resources NGINX Kubernetes
 Gateway supports and the extent of that support.
 - [Installation](installation.md): Walkthrough on how to install NGINX Kubernetes Gateway on a generic Kubernetes cluster.
-- Guides:
-  - [Securing Traffic using Let's Encrypt and Cert-Manager](guides/integrating-cert-manager.md): Shows how to secure
-    traffic from clients to NGINX Kubernetes Gateway with TLS using Let's Encrypt and Cert-Manager.
-  - [Using NGINX Kubernetes Gateway to Upgrade Applications without Downtime](guides/upgrade-apps-without-downtime.md):
-    Explains how to use NGINX Kubernetes Gateway to upgrade applications without downtime.
 - [Resource Validation](resource-validation.md): Describes how NGINX Kubernetes Gateway validates Gateway API
 resources.
 - [Control Plane Configuration](control-plane-configuration.md): Describes how to dynamically update the NGINX
@@ -25,5 +20,6 @@ container.
 
 ### Directories
 
+- [Guides](guides): Guides about configuring NGINX Kubernetes Gateway for various use cases.
 - [Developer](developer/): Docs for developers of the project. Contains guides relating to processes and workflows.
 - [Proposals](proposals/): Enhancement proposals for new features.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,10 @@
+# Guides
+
+This directory contains guides for configuring NGINX Kubernetes Gateway for various use cases.
+
+## Contents
+
+- [Securing Traffic using Let's Encrypt and Cert-Manager](integrating-cert-manager.md): Shows how to secure
+  traffic from clients to NGINX Kubernetes Gateway with TLS using Let's Encrypt and Cert-Manager.
+- [Using NGINX Kubernetes Gateway to Upgrade Applications without Downtime](upgrade-apps-without-downtime.md):
+  Explains how to use NGINX Kubernetes Gateway to upgrade applications without downtime.


### PR DESCRIPTION
### Proposed changes

Problem:
The doc index page (docs/README.md) doesn't include any guides

Solution:
- Add an index page for the guides
- Add a link to the guides directory from the main index page.

Testing: none

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
