### PR TITLE
Ensure latest apk package versions

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,7 +10,7 @@ COPY . /go/src/github.com/nginxinc/nginx-kubernetes-gateway
 RUN make build
 
 FROM alpine:3.18 as capabilizer
-RUN apk add --no-cache libcap
+RUN apk update && apk add --no-cache libcap
 
 FROM capabilizer as local-capabilizer
 COPY ./build/out/gateway /usr/bin/


### PR DESCRIPTION
Problem: For security reasons, we need to ensure that we use the latest versions of packages when building our container image.

Solution: Run apk update before adding packages.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
