### PR TITLE
[Do not merge] Test upgrade to Gateway API 0.8.0-rc2

### DIFF
--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -1,7 +1,7 @@
 NKG_TAG = edge
 NKG_PREFIX = nginx-kubernetes-gateway
 NGINX_IMAGE_NAME = $(NKG_PREFIX)/nginx
-GW_API_VERSION ?= 0.7.1
+GW_API_VERSION ?= 0.8.0-rc2
 GATEWAY_CLASS = nginx
 SUPPORTED_FEATURES = HTTPRoute,HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,HTTPRoutePortRedirect,HTTPRouteSchemeRedirect,GatewayClassObservedGenerationBump
 KIND_KUBE_CONFIG=$${HOME}/.kube/kind/config

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.8.2 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.14.0 // indirect
@@ -87,3 +87,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace sigs.k8s.io/gateway-api => sigs.k8s.io/gateway-api v0.8.0-rc2

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
@@ -259,8 +259,8 @@ sigs.k8s.io/controller-runtime v0.15.1 h1:9UvgKD4ZJGcj24vefUFgZFP3xej/3igL9BsOUT
 sigs.k8s.io/controller-runtime v0.15.1/go.mod h1:7ngYvp1MLT+9GeZ+6lH3LOlcHkp/+tzA/fmHa4iq9kk=
 sigs.k8s.io/controller-tools v0.13.0 h1:NfrvuZ4bxyolhDBt/rCZhDnx3M2hzlhgo5n3Iv2RykI=
 sigs.k8s.io/controller-tools v0.13.0/go.mod h1:5vw3En2NazbejQGCeWKRrE7q4P+CW8/klfVqP8QZkgA=
-sigs.k8s.io/gateway-api v0.7.1 h1:Tts2jeepVkPA5rVG/iO+S43s9n7Vp7jCDhZDQYtPigQ=
-sigs.k8s.io/gateway-api v0.7.1/go.mod h1:Xv0+ZMxX0lu1nSSDIIPEfbVztgNZ+3cfiYrJsa2Ooso=
+sigs.k8s.io/gateway-api v0.8.0-rc2 h1:i1Kw21ygkAgCOciX9P4XoZGWXO7vW+B29Rw3tFQtiAI=
+sigs.k8s.io/gateway-api v0.8.0-rc2/go.mod h1:tqe6NjoISYTfXctrVWkPhJ4+7mA9ns0/sfT19O1TkSM=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=

--- a/internal/framework/status/gateway.go
+++ b/internal/framework/status/gateway.go
@@ -35,14 +35,14 @@ func prepareGatewayStatus(
 	}
 
 	ipAddrType := v1beta1.IPAddressType
-	gwPodIP := v1beta1.GatewayAddress{
+	gwPodIP := v1beta1.GatewayStatusAddress{
 		Type:  &ipAddrType,
 		Value: podIP,
 	}
 
 	return v1beta1.GatewayStatus{
 		Listeners:  listenerStatuses,
-		Addresses:  []v1beta1.GatewayAddress{gwPodIP},
+		Addresses:  []v1beta1.GatewayStatusAddress{gwPodIP},
 		Conditions: convertConditions(gatewayStatus.Conditions, gatewayStatus.ObservedGeneration, transitionTime),
 	}
 }

--- a/internal/framework/status/gateway_test.go
+++ b/internal/framework/status/gateway_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestPrepareGatewayStatus(t *testing.T) {
 	ipAddrType := v1beta1.IPAddressType
-	podIP := v1beta1.GatewayAddress{
+	podIP := v1beta1.GatewayStatusAddress{
 		Type:  &ipAddrType,
 		Value: "1.2.3.4",
 	}
@@ -49,7 +49,7 @@ func TestPrepareGatewayStatus(t *testing.T) {
 				Conditions:     CreateExpectedAPIConditions("ListenerTest", 1, transitionTime),
 			},
 		},
-		Addresses: []v1beta1.GatewayAddress{podIP},
+		Addresses: []v1beta1.GatewayStatusAddress{podIP},
 	}
 
 	g := NewGomegaWithT(t)

--- a/internal/framework/status/updater_test.go
+++ b/internal/framework/status/updater_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Updater", func() {
 			hr            *v1beta1.HTTPRoute
 			ng            *nkgAPI.NginxGateway
 			ipAddrType    = v1beta1.IPAddressType
-			addr          = v1beta1.GatewayAddress{
+			addr          = v1beta1.GatewayStatusAddress{
 				Type:  &ipAddrType,
 				Value: "1.2.3.4",
 			}
@@ -155,7 +155,7 @@ var _ = Describe("Updater", func() {
 								SupportedKinds: []v1beta1.RouteGroupKind{{Kind: "HTTPRoute"}},
 							},
 						},
-						Addresses: []v1beta1.GatewayAddress{addr},
+						Addresses: []v1beta1.GatewayStatusAddress{addr},
 					},
 				}
 			}
@@ -189,7 +189,7 @@ var _ = Describe("Updater", func() {
 								Message:            staticConds.GatewayMessageGatewayConflict,
 							},
 						},
-						Addresses: []v1beta1.GatewayAddress{addr},
+						Addresses: []v1beta1.GatewayStatusAddress{addr},
 					},
 				}
 			}


### PR DESCRIPTION
### Proposed changes

Problem:
Uncertainty if an upgrade Gateway API v0.8.0-rc2 breaks anything

Solution:
- Update the Gateway API dependency to 0.8.0-rc2
- Update conformance related files

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
