### PR TITLE
Refactor codebase using generic GetPointer function

### DIFF
--- a/internal/framework/helpers/helpers.go
+++ b/internal/framework/helpers/helpers.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // Diff prints the diff between two structs.
@@ -19,46 +18,6 @@ func Diff(want, got any) string {
 		return "(-want +got)\n" + r
 	}
 	return r
-}
-
-// GetStringPointer takes a string and returns a pointer to it.
-func GetStringPointer(s string) *string {
-	return &s
-}
-
-// GetIntPointer takes an int and returns a pointer to it.
-func GetIntPointer(i int) *int {
-	return &i
-}
-
-// GetInt32Pointer takes an int32 and returns a pointer to it.
-func GetInt32Pointer(i int32) *int32 {
-	return &i
-}
-
-// GetHTTPMethodPointer takes an HTTPMethod and returns a pointer to it.
-func GetHTTPMethodPointer(m v1beta1.HTTPMethod) *v1beta1.HTTPMethod {
-	return &m
-}
-
-// GetHeaderMatchTypePointer takes an HeaderMatchType and returns a pointer to it.
-func GetHeaderMatchTypePointer(t v1beta1.HeaderMatchType) *v1beta1.HeaderMatchType {
-	return &t
-}
-
-// GetQueryParamMatchTypePointer takes an QueryParamMatchType and returns a pointer to it.
-func GetQueryParamMatchTypePointer(t v1beta1.QueryParamMatchType) *v1beta1.QueryParamMatchType {
-	return &t
-}
-
-// GetTLSModePointer takes a TLSModeType and returns a pointer to it.
-func GetTLSModePointer(t v1beta1.TLSModeType) *v1beta1.TLSModeType {
-	return &t
-}
-
-// GetBoolPointer takes a bool and returns a pointer to it.
-func GetBoolPointer(b bool) *bool {
-	return &b
 }
 
 // GetPointer takes a value of any type and returns a pointer to it.

--- a/internal/framework/status/updater_test.go
+++ b/internal/framework/status/updater_test.go
@@ -210,9 +210,9 @@ var _ = Describe("Updater", func() {
 								{
 									ControllerName: v1beta1.GatewayController(gatewayCtrlName),
 									ParentRef: v1beta1.ParentReference{
-										Namespace:   (*v1beta1.Namespace)(helpers.GetStringPointer("test")),
+										Namespace:   (*v1beta1.Namespace)(helpers.GetPointer("test")),
 										Name:        "gateway",
-										SectionName: (*v1beta1.SectionName)(helpers.GetStringPointer("http")),
+										SectionName: (*v1beta1.SectionName)(helpers.GetPointer("http")),
 									},
 									Conditions: status.CreateExpectedAPIConditions("Test", 5, fakeClockTime),
 								},

--- a/internal/mode/static/state/dataplane/configuration_test.go
+++ b/internal/mode/static/state/dataplane/configuration_test.go
@@ -32,7 +32,7 @@ func TestBuildConfiguration(t *testing.T) {
 				Matches: []v1beta1.HTTPRouteMatch{
 					{
 						Path: &v1beta1.HTTPPathMatch{
-							Value: helpers.GetStringPointer(p.path),
+							Value: helpers.GetPointer(p.path),
 							Type:  helpers.GetPointer(p.pathType),
 						},
 					},
@@ -48,9 +48,9 @@ func TestBuildConfiguration(t *testing.T) {
 				CommonRouteSpec: v1beta1.CommonRouteSpec{
 					ParentRefs: []v1beta1.ParentReference{
 						{
-							Namespace:   (*v1beta1.Namespace)(helpers.GetStringPointer("test")),
+							Namespace:   (*v1beta1.Namespace)(helpers.GetPointer("test")),
 							Name:        "gateway",
-							SectionName: (*v1beta1.SectionName)(helpers.GetStringPointer(listenerName)),
+							SectionName: (*v1beta1.SectionName)(helpers.GetPointer(listenerName)),
 						},
 					},
 				},
@@ -218,7 +218,7 @@ func TestBuildConfiguration(t *testing.T) {
 	redirect := v1beta1.HTTPRouteFilter{
 		Type: v1beta1.HTTPRouteFilterRequestRedirect,
 		RequestRedirect: &v1beta1.HTTPRequestRedirectFilter{
-			Hostname: (*v1beta1.PreciseHostname)(helpers.GetStringPointer("foo.example.com")),
+			Hostname: (*v1beta1.PreciseHostname)(helpers.GetPointer("foo.example.com")),
 		},
 	}
 	addFilters(hr5, []v1beta1.HTTPRouteFilter{redirect})
@@ -350,7 +350,7 @@ func TestBuildConfiguration(t *testing.T) {
 			Mode: helpers.GetPointer(v1beta1.TLSModeTerminate),
 			CertificateRefs: []v1beta1.SecretObjectReference{
 				{
-					Kind:      (*v1beta1.Kind)(helpers.GetStringPointer("Secret")),
+					Kind:      (*v1beta1.Kind)(helpers.GetPointer("Secret")),
 					Namespace: helpers.GetPointer(v1beta1.Namespace(secret1NsName.Namespace)),
 					Name:      v1beta1.ObjectName(secret1NsName.Name),
 				},
@@ -367,7 +367,7 @@ func TestBuildConfiguration(t *testing.T) {
 			Mode: helpers.GetPointer(v1beta1.TLSModeTerminate),
 			CertificateRefs: []v1beta1.SecretObjectReference{
 				{
-					Kind:      (*v1beta1.Kind)(helpers.GetStringPointer("Secret")),
+					Kind:      (*v1beta1.Kind)(helpers.GetPointer("Secret")),
 					Namespace: helpers.GetPointer(v1beta1.Namespace(secret2NsName.Namespace)),
 					Name:      v1beta1.ObjectName(secret2NsName.Name),
 				},
@@ -386,7 +386,7 @@ func TestBuildConfiguration(t *testing.T) {
 			Mode: helpers.GetPointer(v1beta1.TLSModeTerminate),
 			CertificateRefs: []v1beta1.SecretObjectReference{
 				{
-					Kind:      (*v1beta1.Kind)(helpers.GetStringPointer("Secret")),
+					Kind:      (*v1beta1.Kind)(helpers.GetPointer("Secret")),
 					Namespace: helpers.GetPointer(v1beta1.Namespace(secret2NsName.Namespace)),
 					Name:      v1beta1.ObjectName(secret2NsName.Name),
 				},
@@ -1506,7 +1506,7 @@ func TestGetPath(t *testing.T) {
 		msg      string
 	}{
 		{
-			path:     &v1beta1.HTTPPathMatch{Value: helpers.GetStringPointer("/abc")},
+			path:     &v1beta1.HTTPPathMatch{Value: helpers.GetPointer("/abc")},
 			expected: "/abc",
 			msg:      "normal case",
 		},
@@ -1521,7 +1521,7 @@ func TestGetPath(t *testing.T) {
 			msg:      "nil value",
 		},
 		{
-			path:     &v1beta1.HTTPPathMatch{Value: helpers.GetStringPointer("")},
+			path:     &v1beta1.HTTPPathMatch{Value: helpers.GetPointer("")},
 			expected: "/",
 			msg:      "empty value",
 		},

--- a/internal/mode/static/state/dataplane/configuration_test.go
+++ b/internal/mode/static/state/dataplane/configuration_test.go
@@ -347,7 +347,7 @@ func TestBuildConfiguration(t *testing.T) {
 		Port:     443,
 		Protocol: v1beta1.HTTPSProtocolType,
 		TLS: &v1beta1.GatewayTLSConfig{
-			Mode: helpers.GetTLSModePointer(v1beta1.TLSModeTerminate),
+			Mode: helpers.GetPointer(v1beta1.TLSModeTerminate),
 			CertificateRefs: []v1beta1.SecretObjectReference{
 				{
 					Kind:      (*v1beta1.Kind)(helpers.GetStringPointer("Secret")),
@@ -364,7 +364,7 @@ func TestBuildConfiguration(t *testing.T) {
 		Port:     8443,
 		Protocol: v1beta1.HTTPSProtocolType,
 		TLS: &v1beta1.GatewayTLSConfig{
-			Mode: helpers.GetTLSModePointer(v1beta1.TLSModeTerminate),
+			Mode: helpers.GetPointer(v1beta1.TLSModeTerminate),
 			CertificateRefs: []v1beta1.SecretObjectReference{
 				{
 					Kind:      (*v1beta1.Kind)(helpers.GetStringPointer("Secret")),
@@ -383,7 +383,7 @@ func TestBuildConfiguration(t *testing.T) {
 		Port:     443,
 		Protocol: v1beta1.HTTPSProtocolType,
 		TLS: &v1beta1.GatewayTLSConfig{
-			Mode: helpers.GetTLSModePointer(v1beta1.TLSModeTerminate),
+			Mode: helpers.GetPointer(v1beta1.TLSModeTerminate),
 			CertificateRefs: []v1beta1.SecretObjectReference{
 				{
 					Kind:      (*v1beta1.Kind)(helpers.GetStringPointer("Secret")),

--- a/internal/mode/static/state/graph/gateway_listener_test.go
+++ b/internal/mode/static/state/graph/gateway_listener_test.go
@@ -49,22 +49,22 @@ func TestValidateHTTPSListener(t *testing.T) {
 	secretNs := "secret-ns"
 
 	validSecretRef := v1beta1.SecretObjectReference{
-		Kind:      (*v1beta1.Kind)(helpers.GetStringPointer("Secret")),
+		Kind:      (*v1beta1.Kind)(helpers.GetPointer("Secret")),
 		Name:      "secret",
-		Namespace: (*v1beta1.Namespace)(helpers.GetStringPointer(secretNs)),
+		Namespace: (*v1beta1.Namespace)(helpers.GetPointer(secretNs)),
 	}
 
 	invalidSecretRefGroup := v1beta1.SecretObjectReference{
-		Group:     (*v1beta1.Group)(helpers.GetStringPointer("some-group")),
-		Kind:      (*v1beta1.Kind)(helpers.GetStringPointer("Secret")),
+		Group:     (*v1beta1.Group)(helpers.GetPointer("some-group")),
+		Kind:      (*v1beta1.Kind)(helpers.GetPointer("Secret")),
 		Name:      "secret",
-		Namespace: (*v1beta1.Namespace)(helpers.GetStringPointer(secretNs)),
+		Namespace: (*v1beta1.Namespace)(helpers.GetPointer(secretNs)),
 	}
 
 	invalidSecretRefKind := v1beta1.SecretObjectReference{
-		Kind:      (*v1beta1.Kind)(helpers.GetStringPointer("ConfigMap")),
+		Kind:      (*v1beta1.Kind)(helpers.GetPointer("ConfigMap")),
 		Name:      "secret",
-		Namespace: (*v1beta1.Namespace)(helpers.GetStringPointer(secretNs)),
+		Namespace: (*v1beta1.Namespace)(helpers.GetPointer(secretNs)),
 	}
 
 	tests := []struct {
@@ -184,22 +184,22 @@ func TestValidateListenerHostname(t *testing.T) {
 			name:      "nil hostname",
 		},
 		{
-			hostname:  (*v1beta1.Hostname)(helpers.GetStringPointer("")),
+			hostname:  (*v1beta1.Hostname)(helpers.GetPointer("")),
 			expectErr: false,
 			name:      "empty hostname",
 		},
 		{
-			hostname:  (*v1beta1.Hostname)(helpers.GetStringPointer("foo.example.com")),
+			hostname:  (*v1beta1.Hostname)(helpers.GetPointer("foo.example.com")),
 			expectErr: false,
 			name:      "valid hostname",
 		},
 		{
-			hostname:  (*v1beta1.Hostname)(helpers.GetStringPointer("*.example.com")),
+			hostname:  (*v1beta1.Hostname)(helpers.GetPointer("*.example.com")),
 			expectErr: false,
 			name:      "wildcard hostname",
 		},
 		{
-			hostname:  (*v1beta1.Hostname)(helpers.GetStringPointer("example$com")),
+			hostname:  (*v1beta1.Hostname)(helpers.GetPointer("example$com")),
 			expectErr: true,
 			name:      "invalid hostname",
 		},

--- a/internal/mode/static/state/graph/gateway_listener_test.go
+++ b/internal/mode/static/state/graph/gateway_listener_test.go
@@ -76,7 +76,7 @@ func TestValidateHTTPSListener(t *testing.T) {
 			l: v1beta1.Listener{
 				Port: 443,
 				TLS: &v1beta1.GatewayTLSConfig{
-					Mode:            helpers.GetTLSModePointer(v1beta1.TLSModeTerminate),
+					Mode:            helpers.GetPointer(v1beta1.TLSModeTerminate),
 					CertificateRefs: []v1beta1.SecretObjectReference{validSecretRef},
 				},
 			},
@@ -87,7 +87,7 @@ func TestValidateHTTPSListener(t *testing.T) {
 			l: v1beta1.Listener{
 				Port: 0,
 				TLS: &v1beta1.GatewayTLSConfig{
-					Mode:            helpers.GetTLSModePointer(v1beta1.TLSModeTerminate),
+					Mode:            helpers.GetPointer(v1beta1.TLSModeTerminate),
 					CertificateRefs: []v1beta1.SecretObjectReference{validSecretRef},
 				},
 			},
@@ -98,7 +98,7 @@ func TestValidateHTTPSListener(t *testing.T) {
 			l: v1beta1.Listener{
 				Port: 443,
 				TLS: &v1beta1.GatewayTLSConfig{
-					Mode:            helpers.GetTLSModePointer(v1beta1.TLSModeTerminate),
+					Mode:            helpers.GetPointer(v1beta1.TLSModeTerminate),
 					CertificateRefs: []v1beta1.SecretObjectReference{validSecretRef},
 					Options:         map[v1beta1.AnnotationKey]v1beta1.AnnotationValue{"key": "val"},
 				},
@@ -110,7 +110,7 @@ func TestValidateHTTPSListener(t *testing.T) {
 			l: v1beta1.Listener{
 				Port: 443,
 				TLS: &v1beta1.GatewayTLSConfig{
-					Mode:            helpers.GetTLSModePointer(v1beta1.TLSModePassthrough),
+					Mode:            helpers.GetPointer(v1beta1.TLSModePassthrough),
 					CertificateRefs: []v1beta1.SecretObjectReference{validSecretRef},
 				},
 			},
@@ -123,7 +123,7 @@ func TestValidateHTTPSListener(t *testing.T) {
 			l: v1beta1.Listener{
 				Port: 443,
 				TLS: &v1beta1.GatewayTLSConfig{
-					Mode:            helpers.GetTLSModePointer(v1beta1.TLSModeTerminate),
+					Mode:            helpers.GetPointer(v1beta1.TLSModeTerminate),
 					CertificateRefs: []v1beta1.SecretObjectReference{invalidSecretRefGroup},
 				},
 			},
@@ -136,7 +136,7 @@ func TestValidateHTTPSListener(t *testing.T) {
 			l: v1beta1.Listener{
 				Port: 443,
 				TLS: &v1beta1.GatewayTLSConfig{
-					Mode:            helpers.GetTLSModePointer(v1beta1.TLSModeTerminate),
+					Mode:            helpers.GetPointer(v1beta1.TLSModeTerminate),
 					CertificateRefs: []v1beta1.SecretObjectReference{invalidSecretRefKind},
 				},
 			},
@@ -149,7 +149,7 @@ func TestValidateHTTPSListener(t *testing.T) {
 			l: v1beta1.Listener{
 				Port: 443,
 				TLS: &v1beta1.GatewayTLSConfig{
-					Mode:            helpers.GetTLSModePointer(v1beta1.TLSModeTerminate),
+					Mode:            helpers.GetPointer(v1beta1.TLSModeTerminate),
 					CertificateRefs: []v1beta1.SecretObjectReference{validSecretRef, validSecretRef},
 				},
 			},

--- a/internal/mode/static/state/graph/graph_test.go
+++ b/internal/mode/static/state/graph/graph_test.go
@@ -66,7 +66,7 @@ func TestBuildGraph(t *testing.T) {
 										Kind:      (*v1beta1.Kind)(helpers.GetPointer("Service")),
 										Name:      "foo",
 										Namespace: (*v1beta1.Namespace)(helpers.GetPointer("service")),
-										Port:      (*v1beta1.PortNumber)(helpers.GetPointer(int32(80))),
+										Port:      (*v1beta1.PortNumber)(helpers.GetPointer[int32](80)),
 									},
 								},
 							},

--- a/internal/mode/static/state/graph/graph_test.go
+++ b/internal/mode/static/state/graph/graph_test.go
@@ -134,7 +134,7 @@ func TestBuildGraph(t *testing.T) {
 						Hostname: nil,
 						Port:     443,
 						TLS: &v1beta1.GatewayTLSConfig{
-							Mode: helpers.GetTLSModePointer(v1beta1.TLSModeTerminate),
+							Mode: helpers.GetPointer(v1beta1.TLSModeTerminate),
 							CertificateRefs: []v1beta1.SecretObjectReference{
 								{
 									Kind:      helpers.GetPointer[v1beta1.Kind]("Secret"),

--- a/internal/mode/static/state/graph/graph_test.go
+++ b/internal/mode/static/state/graph/graph_test.go
@@ -40,9 +40,9 @@ func TestBuildGraph(t *testing.T) {
 				CommonRouteSpec: v1beta1.CommonRouteSpec{
 					ParentRefs: []v1beta1.ParentReference{
 						{
-							Namespace:   (*v1beta1.Namespace)(helpers.GetStringPointer("test")),
+							Namespace:   (*v1beta1.Namespace)(helpers.GetPointer("test")),
 							Name:        v1beta1.ObjectName(gatewayName),
-							SectionName: (*v1beta1.SectionName)(helpers.GetStringPointer(listenerName)),
+							SectionName: (*v1beta1.SectionName)(helpers.GetPointer(listenerName)),
 						},
 					},
 				},
@@ -55,7 +55,7 @@ func TestBuildGraph(t *testing.T) {
 							{
 								Path: &v1beta1.HTTPPathMatch{
 									Type:  helpers.GetPointer(v1beta1.PathMatchPathPrefix),
-									Value: helpers.GetStringPointer("/"),
+									Value: helpers.GetPointer("/"),
 								},
 							},
 						},
@@ -63,9 +63,9 @@ func TestBuildGraph(t *testing.T) {
 							{
 								BackendRef: v1beta1.BackendRef{
 									BackendObjectReference: v1beta1.BackendObjectReference{
-										Kind:      (*v1beta1.Kind)(helpers.GetStringPointer("Service")),
+										Kind:      (*v1beta1.Kind)(helpers.GetPointer("Service")),
 										Name:      "foo",
-										Namespace: (*v1beta1.Namespace)(helpers.GetStringPointer("service")),
+										Namespace: (*v1beta1.Namespace)(helpers.GetPointer("service")),
 										Port:      (*v1beta1.PortNumber)(helpers.GetPointer(int32(80))),
 									},
 								},

--- a/internal/mode/static/state/graph/graph_test.go
+++ b/internal/mode/static/state/graph/graph_test.go
@@ -66,7 +66,7 @@ func TestBuildGraph(t *testing.T) {
 										Kind:      (*v1beta1.Kind)(helpers.GetStringPointer("Service")),
 										Name:      "foo",
 										Namespace: (*v1beta1.Namespace)(helpers.GetStringPointer("service")),
-										Port:      (*v1beta1.PortNumber)(helpers.GetInt32Pointer(80)),
+										Port:      (*v1beta1.PortNumber)(helpers.GetPointer(int32(80))),
 									},
 								},
 							},

--- a/internal/mode/static/state/graph/httproute_test.go
+++ b/internal/mode/static/state/graph/httproute_test.go
@@ -540,7 +540,7 @@ func TestBindRouteToListeners(t *testing.T) {
 		return &Listener{
 			Source: v1beta1.Listener{
 				Name:     v1beta1.SectionName(name),
-				Hostname: (*v1beta1.Hostname)(helpers.GetStringPointer("foo.example.com")),
+				Hostname: (*v1beta1.Hostname)(helpers.GetPointer("foo.example.com")),
 			},
 			Valid:  true,
 			Routes: map[types.NamespacedName]*Route{},

--- a/internal/mode/static/state/relationship/capturer_test.go
+++ b/internal/mode/static/state/relationship/capturer_test.go
@@ -21,9 +21,9 @@ func createBackendRefs(backendNames ...v1beta1.ObjectName) []v1beta1.HTTPBackend
 		refs = append(refs, v1beta1.HTTPBackendRef{
 			BackendRef: v1beta1.BackendRef{
 				BackendObjectReference: v1beta1.BackendObjectReference{
-					Kind:      (*v1beta1.Kind)(helpers.GetStringPointer("Service")),
+					Kind:      (*v1beta1.Kind)(helpers.GetPointer("Service")),
 					Name:      name,
-					Namespace: (*v1beta1.Namespace)(helpers.GetStringPointer("test")),
+					Namespace: (*v1beta1.Namespace)(helpers.GetPointer("test")),
 				},
 			},
 		})

--- a/internal/mode/static/state/relationship/relationships_test.go
+++ b/internal/mode/static/state/relationship/relationships_test.go
@@ -20,7 +20,7 @@ func TestGetBackendServiceNamesFromRoute(t *testing.T) {
 						Kind:      (*v1beta1.Kind)(helpers.GetPointer("Service")),
 						Name:      svcName,
 						Namespace: (*v1beta1.Namespace)(helpers.GetPointer("test")),
-						Port:      (*v1beta1.PortNumber)(helpers.GetPointer(int32(80))),
+						Port:      (*v1beta1.PortNumber)(helpers.GetPointer[int32](80)),
 					},
 				},
 			},
@@ -94,7 +94,7 @@ func TestGetBackendServiceNamesFromRoute(t *testing.T) {
 											helpers.GetPointer("test"),
 										),
 										Port: (*v1beta1.PortNumber)(
-											helpers.GetPointer(int32(80)),
+											helpers.GetPointer[int32](80),
 										),
 									},
 								},

--- a/internal/mode/static/state/relationship/relationships_test.go
+++ b/internal/mode/static/state/relationship/relationships_test.go
@@ -17,9 +17,9 @@ func TestGetBackendServiceNamesFromRoute(t *testing.T) {
 			{
 				BackendRef: v1beta1.BackendRef{
 					BackendObjectReference: v1beta1.BackendObjectReference{
-						Kind:      (*v1beta1.Kind)(helpers.GetStringPointer("Service")),
+						Kind:      (*v1beta1.Kind)(helpers.GetPointer("Service")),
 						Name:      svcName,
-						Namespace: (*v1beta1.Namespace)(helpers.GetStringPointer("test")),
+						Namespace: (*v1beta1.Namespace)(helpers.GetPointer("test")),
 						Port:      (*v1beta1.PortNumber)(helpers.GetPointer(int32(80))),
 					},
 				},
@@ -48,7 +48,7 @@ func TestGetBackendServiceNamesFromRoute(t *testing.T) {
 					BackendRefs: getModifiedRefs(
 						"invalid-kind",
 						func(refs []v1beta1.HTTPBackendRef) []v1beta1.HTTPBackendRef {
-							refs[0].Kind = (*v1beta1.Kind)(helpers.GetStringPointer("Invalid"))
+							refs[0].Kind = (*v1beta1.Kind)(helpers.GetPointer("Invalid"))
 							return refs
 						},
 					),
@@ -67,7 +67,7 @@ func TestGetBackendServiceNamesFromRoute(t *testing.T) {
 						"diff-namespace",
 						func(refs []v1beta1.HTTPBackendRef) []v1beta1.HTTPBackendRef {
 							refs[0].Namespace = (*v1beta1.Namespace)(
-								helpers.GetStringPointer("not-test"),
+								helpers.GetPointer("not-test"),
 							)
 							return refs
 						},
@@ -87,11 +87,11 @@ func TestGetBackendServiceNamesFromRoute(t *testing.T) {
 								BackendRef: v1beta1.BackendRef{
 									BackendObjectReference: v1beta1.BackendObjectReference{
 										Kind: (*v1beta1.Kind)(
-											helpers.GetStringPointer("Service"),
+											helpers.GetPointer("Service"),
 										),
 										Name: "multiple-refs2",
 										Namespace: (*v1beta1.Namespace)(
-											helpers.GetStringPointer("test"),
+											helpers.GetPointer("test"),
 										),
 										Port: (*v1beta1.PortNumber)(
 											helpers.GetPointer(int32(80)),

--- a/internal/mode/static/state/relationship/relationships_test.go
+++ b/internal/mode/static/state/relationship/relationships_test.go
@@ -20,7 +20,7 @@ func TestGetBackendServiceNamesFromRoute(t *testing.T) {
 						Kind:      (*v1beta1.Kind)(helpers.GetStringPointer("Service")),
 						Name:      svcName,
 						Namespace: (*v1beta1.Namespace)(helpers.GetStringPointer("test")),
-						Port:      (*v1beta1.PortNumber)(helpers.GetInt32Pointer(80)),
+						Port:      (*v1beta1.PortNumber)(helpers.GetPointer(int32(80))),
 					},
 				},
 			},
@@ -94,7 +94,7 @@ func TestGetBackendServiceNamesFromRoute(t *testing.T) {
 											helpers.GetStringPointer("test"),
 										),
 										Port: (*v1beta1.PortNumber)(
-											helpers.GetInt32Pointer(80),
+											helpers.GetPointer(int32(80)),
 										),
 									},
 								},

--- a/internal/mode/static/state/resolver/resolver_test.go
+++ b/internal/mode/static/state/resolver/resolver_test.go
@@ -75,7 +75,7 @@ var (
 		Endpoints:   []discoveryV1.Endpoint{readyEndpoint1},
 		Ports: []discoveryV1.EndpointPort{
 			{
-				Name: helpers.GetStringPointer("other-svc-port"),
+				Name: helpers.GetPointer("other-svc-port"),
 				Port: helpers.GetPointer(int32(8080)),
 			},
 		},
@@ -238,7 +238,7 @@ func TestIgnoreEndpointSlice(t *testing.T) {
 				AddressType: discoveryV1.AddressTypeIPv4,
 				Ports: []discoveryV1.EndpointPort{
 					{
-						Name: helpers.GetStringPointer("other-svc-port"),
+						Name: helpers.GetPointer("other-svc-port"),
 						Port: &port4000,
 					},
 				},
@@ -401,15 +401,15 @@ func TestFindPort(t *testing.T) {
 			msg: "no matching endpoint name",
 			ports: []discoveryV1.EndpointPort{
 				{
-					Name: helpers.GetStringPointer("other-svc-port"),
+					Name: helpers.GetPointer("other-svc-port"),
 					Port: helpers.GetPointer(int32(8080)),
 				},
 				{
-					Name: helpers.GetStringPointer("other-svc-port2"),
+					Name: helpers.GetPointer("other-svc-port2"),
 					Port: helpers.GetPointer(int32(8081)),
 				},
 				{
-					Name: helpers.GetStringPointer("other-svc-port3"),
+					Name: helpers.GetPointer("other-svc-port3"),
 					Port: helpers.GetPointer(int32(8082)),
 				},
 			},
@@ -424,11 +424,11 @@ func TestFindPort(t *testing.T) {
 			msg: "matching endpoint name",
 			ports: []discoveryV1.EndpointPort{
 				{
-					Name: helpers.GetStringPointer("other-svc-port"),
+					Name: helpers.GetPointer("other-svc-port"),
 					Port: helpers.GetPointer(int32(8080)),
 				},
 				{
-					Name: helpers.GetStringPointer("other-svc-port2"),
+					Name: helpers.GetPointer("other-svc-port2"),
 					Port: helpers.GetPointer(int32(8081)),
 				},
 				{
@@ -448,7 +448,7 @@ func TestFindPort(t *testing.T) {
 			ports: []discoveryV1.EndpointPort{
 				{
 					// If a service port is unnamed (empty string), then the endpoint port will also be empty string.
-					Name: helpers.GetStringPointer(""),
+					Name: helpers.GetPointer(""),
 					Port: helpers.GetPointer(int32(8080)),
 				},
 			},

--- a/internal/mode/static/state/resolver/resolver_test.go
+++ b/internal/mode/static/state/resolver/resolver_test.go
@@ -20,12 +20,12 @@ var (
 
 	readyEndpoint1 = discoveryV1.Endpoint{
 		Addresses:  addresses,
-		Conditions: discoveryV1.EndpointConditions{Ready: helpers.GetBoolPointer(true)},
+		Conditions: discoveryV1.EndpointConditions{Ready: helpers.GetPointer(true)},
 	}
 
 	notReadyEndpoint = discoveryV1.Endpoint{
 		Addresses:  addresses,
-		Conditions: discoveryV1.EndpointConditions{Ready: helpers.GetBoolPointer(false)},
+		Conditions: discoveryV1.EndpointConditions{Ready: helpers.GetPointer(false)},
 	}
 
 	mixedValidityEndpointSlice = discoveryV1.EndpointSlice{
@@ -303,7 +303,7 @@ func TestEndpointReady(t *testing.T) {
 			msg: "endpoint ready",
 			endpoint: discoveryV1.Endpoint{
 				Conditions: discoveryV1.EndpointConditions{
-					Ready: helpers.GetBoolPointer(true),
+					Ready: helpers.GetPointer(true),
 				},
 			},
 			ready: true,
@@ -321,7 +321,7 @@ func TestEndpointReady(t *testing.T) {
 			msg: "endpoint not ready",
 			endpoint: discoveryV1.Endpoint{
 				Conditions: discoveryV1.EndpointConditions{
-					Ready: helpers.GetBoolPointer(false),
+					Ready: helpers.GetPointer(false),
 				},
 			},
 			ready: false,
@@ -482,7 +482,7 @@ func TestCalculateReadyEndpoints(t *testing.T) {
 				{
 					Addresses: []string{"1.0.0.1"},
 					Conditions: discoveryV1.EndpointConditions{
-						Ready: helpers.GetBoolPointer(true),
+						Ready: helpers.GetPointer(true),
 					},
 				},
 				{
@@ -498,7 +498,7 @@ func TestCalculateReadyEndpoints(t *testing.T) {
 				{
 					Addresses: []string{"2.0.0.1", "2.0.0.2", "2.0.0.3"},
 					Conditions: discoveryV1.EndpointConditions{
-						Ready: helpers.GetBoolPointer(true),
+						Ready: helpers.GetPointer(true),
 					},
 				},
 			},

--- a/internal/mode/static/state/resolver/resolver_test.go
+++ b/internal/mode/static/state/resolver/resolver_test.go
@@ -34,7 +34,7 @@ var (
 		Ports: []discoveryV1.EndpointPort{
 			{
 				Name: &svcPortName,
-				Port: helpers.GetInt32Pointer(80),
+				Port: helpers.GetPointer(int32(80)),
 			},
 		},
 	}
@@ -54,7 +54,7 @@ var (
 		Ports: []discoveryV1.EndpointPort{
 			{
 				Name: &svcPortName,
-				Port: helpers.GetInt32Pointer(80),
+				Port: helpers.GetPointer(int32(80)),
 			},
 		},
 	}
@@ -65,7 +65,7 @@ var (
 		Ports: []discoveryV1.EndpointPort{
 			{
 				Name: &svcPortName,
-				Port: helpers.GetInt32Pointer(80),
+				Port: helpers.GetPointer(int32(80)),
 			},
 		},
 	}
@@ -76,7 +76,7 @@ var (
 		Ports: []discoveryV1.EndpointPort{
 			{
 				Name: helpers.GetStringPointer("other-svc-port"),
-				Port: helpers.GetInt32Pointer(8080),
+				Port: helpers.GetPointer(int32(8080)),
 			},
 		},
 	}
@@ -387,7 +387,7 @@ func TestFindPort(t *testing.T) {
 			ports: []discoveryV1.EndpointPort{
 				{
 					Name: nil,
-					Port: helpers.GetInt32Pointer(8080),
+					Port: helpers.GetPointer(int32(8080)),
 				},
 			},
 			svcPort: v1.ServicePort{
@@ -402,15 +402,15 @@ func TestFindPort(t *testing.T) {
 			ports: []discoveryV1.EndpointPort{
 				{
 					Name: helpers.GetStringPointer("other-svc-port"),
-					Port: helpers.GetInt32Pointer(8080),
+					Port: helpers.GetPointer(int32(8080)),
 				},
 				{
 					Name: helpers.GetStringPointer("other-svc-port2"),
-					Port: helpers.GetInt32Pointer(8081),
+					Port: helpers.GetPointer(int32(8081)),
 				},
 				{
 					Name: helpers.GetStringPointer("other-svc-port3"),
-					Port: helpers.GetInt32Pointer(8082),
+					Port: helpers.GetPointer(int32(8082)),
 				},
 			},
 			svcPort: v1.ServicePort{
@@ -425,15 +425,15 @@ func TestFindPort(t *testing.T) {
 			ports: []discoveryV1.EndpointPort{
 				{
 					Name: helpers.GetStringPointer("other-svc-port"),
-					Port: helpers.GetInt32Pointer(8080),
+					Port: helpers.GetPointer(int32(8080)),
 				},
 				{
 					Name: helpers.GetStringPointer("other-svc-port2"),
-					Port: helpers.GetInt32Pointer(8081),
+					Port: helpers.GetPointer(int32(8081)),
 				},
 				{
 					Name: &svcPortName, // match
-					Port: helpers.GetInt32Pointer(8082),
+					Port: helpers.GetPointer(int32(8082)),
 				},
 			},
 			svcPort: v1.ServicePort{
@@ -449,7 +449,7 @@ func TestFindPort(t *testing.T) {
 				{
 					// If a service port is unnamed (empty string), then the endpoint port will also be empty string.
 					Name: helpers.GetStringPointer(""),
-					Port: helpers.GetInt32Pointer(8080),
+					Port: helpers.GetPointer(int32(8080)),
 				},
 			},
 			svcPort: v1.ServicePort{

--- a/internal/mode/static/state/resolver/resolver_test.go
+++ b/internal/mode/static/state/resolver/resolver_test.go
@@ -34,7 +34,7 @@ var (
 		Ports: []discoveryV1.EndpointPort{
 			{
 				Name: &svcPortName,
-				Port: helpers.GetPointer(int32(80)),
+				Port: helpers.GetPointer[int32](80),
 			},
 		},
 	}
@@ -54,7 +54,7 @@ var (
 		Ports: []discoveryV1.EndpointPort{
 			{
 				Name: &svcPortName,
-				Port: helpers.GetPointer(int32(80)),
+				Port: helpers.GetPointer[int32](80),
 			},
 		},
 	}
@@ -65,7 +65,7 @@ var (
 		Ports: []discoveryV1.EndpointPort{
 			{
 				Name: &svcPortName,
-				Port: helpers.GetPointer(int32(80)),
+				Port: helpers.GetPointer[int32](80),
 			},
 		},
 	}
@@ -76,7 +76,7 @@ var (
 		Ports: []discoveryV1.EndpointPort{
 			{
 				Name: helpers.GetPointer("other-svc-port"),
-				Port: helpers.GetPointer(int32(8080)),
+				Port: helpers.GetPointer[int32](8080),
 			},
 		},
 	}
@@ -387,7 +387,7 @@ func TestFindPort(t *testing.T) {
 			ports: []discoveryV1.EndpointPort{
 				{
 					Name: nil,
-					Port: helpers.GetPointer(int32(8080)),
+					Port: helpers.GetPointer[int32](8080),
 				},
 			},
 			svcPort: v1.ServicePort{
@@ -402,15 +402,15 @@ func TestFindPort(t *testing.T) {
 			ports: []discoveryV1.EndpointPort{
 				{
 					Name: helpers.GetPointer("other-svc-port"),
-					Port: helpers.GetPointer(int32(8080)),
+					Port: helpers.GetPointer[int32](8080),
 				},
 				{
 					Name: helpers.GetPointer("other-svc-port2"),
-					Port: helpers.GetPointer(int32(8081)),
+					Port: helpers.GetPointer[int32](8081),
 				},
 				{
 					Name: helpers.GetPointer("other-svc-port3"),
-					Port: helpers.GetPointer(int32(8082)),
+					Port: helpers.GetPointer[int32](8082),
 				},
 			},
 			svcPort: v1.ServicePort{
@@ -425,15 +425,15 @@ func TestFindPort(t *testing.T) {
 			ports: []discoveryV1.EndpointPort{
 				{
 					Name: helpers.GetPointer("other-svc-port"),
-					Port: helpers.GetPointer(int32(8080)),
+					Port: helpers.GetPointer[int32](8080),
 				},
 				{
 					Name: helpers.GetPointer("other-svc-port2"),
-					Port: helpers.GetPointer(int32(8081)),
+					Port: helpers.GetPointer[int32](8081),
 				},
 				{
 					Name: &svcPortName, // match
-					Port: helpers.GetPointer(int32(8082)),
+					Port: helpers.GetPointer[int32](8082),
 				},
 			},
 			svcPort: v1.ServicePort{
@@ -449,7 +449,7 @@ func TestFindPort(t *testing.T) {
 				{
 					// If a service port is unnamed (empty string), then the endpoint port will also be empty string.
 					Name: helpers.GetPointer(""),
-					Port: helpers.GetPointer(int32(8080)),
+					Port: helpers.GetPointer[int32](8080),
 				},
 			},
 			svcPort: v1.ServicePort{

--- a/internal/mode/static/state/resolver/service_resolver_test.go
+++ b/internal/mode/static/state/resolver/service_resolver_test.go
@@ -38,7 +38,7 @@ func createSlice(
 			{
 				Addresses: addresses,
 				Conditions: discoveryV1.EndpointConditions{
-					Ready: helpers.GetBoolPointer(true),
+					Ready: helpers.GetPointer(true),
 				},
 			},
 			{
@@ -48,8 +48,8 @@ func createSlice(
 					"1.0.0.3",
 				}, // these endpoints should be ignored because they are not ready
 				Conditions: discoveryV1.EndpointConditions{
-					Serving:     helpers.GetBoolPointer(true),
-					Terminating: helpers.GetBoolPointer(true),
+					Serving:     helpers.GetPointer(true),
+					Terminating: helpers.GetPointer(true),
 				},
 			},
 			{


### PR DESCRIPTION
### Proposed changes

Problem: We were still using typed GetPointer functions even after we had created a generic GetPointer function.

Solution: Replaced all uses of typed GetPointer functions with the generic GetPointer function and removed typed GetPointer functions from the codebase.

Testing: Since these changes only affected test files, I ensured that all the tests still pass.

Closes #822

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
