### PR TITLE
Run conformance tests on minimum k8s version

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -29,6 +29,9 @@ jobs:
   conformance-tests:
     name: Gateway Conformance Tests
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        k8s-version: ["1.23.17", "latest"]
     permissions:
       contents: write # needed for uploading release artifacts
     steps:
@@ -128,7 +131,8 @@ jobs:
       - name: Deploy Kubernetes
         id: k8s
         run: |
-          make create-kind-cluster KIND_KUBE_CONFIG=${{ github.workspace }}/kube-${{ github.run_id }}
+          k8s_version=${{ matrix.k8s-version }}
+          make create-kind-cluster KIND_KUBE_CONFIG=${{ github.workspace }}/kube-${{ github.run_id }} ${{ ! contains(matrix.k8s-version, 'latest') && 'KIND_IMAGE=kindest/node:v${k8s_version}' || '' }}
           echo "KUBECONFIG=${{ github.workspace }}/kube-${{ github.run_id }}" >> "$GITHUB_ENV"
         working-directory: ./conformance
 
@@ -155,7 +159,7 @@ jobs:
         working-directory: ./conformance
 
       - name: Upload profile to release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ matrix.k8s-version == 'latest' && startsWith(github.ref, 'refs/tags/') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ github.ref_name }} conformance-profile.yaml

--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -4,6 +4,7 @@ NGINX_IMAGE_NAME = $(NKG_PREFIX)/nginx
 GW_API_VERSION ?= 0.8.0
 GATEWAY_CLASS = nginx
 SUPPORTED_FEATURES = HTTPRoute,HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,HTTPRoutePortRedirect,HTTPRouteSchemeRedirect,GatewayClassObservedGenerationBump
+KIND_IMAGE ?= $(shell grep -m1 'FROM kindest/node' <tests/Dockerfile | awk -F'[ ]' '{print $$2}')
 KIND_KUBE_CONFIG=$${HOME}/.kube/kind/config
 TAG = latest
 PREFIX = conformance-test-runner
@@ -30,7 +31,6 @@ build-test-runner-image: ## Build conformance test runner image
 
 .PHONY: create-kind-cluster
 create-kind-cluster: ## Create a kind cluster
-	$(eval KIND_IMAGE=$(shell grep -m1 'FROM kindest/node' <tests/Dockerfile | awk -F'[ ]' '{print $$2}'))
 	kind create cluster --image $(KIND_IMAGE)
 	kind export kubeconfig --kubeconfig $(KIND_KUBE_CONFIG)
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -45,6 +45,7 @@ update-nkg-manifest            Update the NKG deployment manifest image names an
 | NKG_TAG                 | edge                                                                                                          | The tag for the locally built NKG image                                                                                   |
 | NKG_PREFIX              | nginx-kubernetes-gateway                                                                                      | The prefix for the locally built NKG image                                                                                |
 | GW_API_VERSION          | 0.8.0                                                                                                         | Tag for the Gateway API version to check out. Set to `main` to get the latest version                                     |
+| KIND_IMAGE              | Latest kind image, as defined in the tests/Dockerfile                                                         | The kind image to use                                                                                            |
 | KIND_KUBE_CONFIG        | ~/.kube/kind/config                                                                                           | The location of the kubeconfig                                                                                            |
 | GATEWAY_CLASS           | nginx                                                                                                         | The gateway class that should be used for the tests                                                                       |
 | SUPPORTED_FEATURES      | HTTPRoute,HTTPRouteQueryParamMatching, HTTPRouteMethodMatching,HTTPRoutePortRedirect, HTTPRouteSchemeRedirect | The supported features that should be tested by the conformance tests. Ensure the list is comma separated with no spaces. |
@@ -59,6 +60,13 @@ update-nkg-manifest            Update the NKG deployment manifest image names an
 
 ```makefile
 make create-kind-cluster
+```
+
+> Note: The default kind cluster deployed is the latest available version. You can specify a different version by
+> defining the kind image to use through the KIND_IMAGE variable, e.g.
+
+```makefile
+make create-kind-cluster KIND_IMAGE=kindest/node:v1.27.3
 ```
 
 ### Step 2 - Install Nginx Kubernetes Gateway to configured kind cluster


### PR DESCRIPTION
### Proposed changes

As a developer
I would like the conformance tests to run on both the latest and minimum supported kubernetes versions
So that I can have confidence that my changes work on all k8s versions we currently support

Solution:
Create a matrix for conformance tests to run both the latest and minimum supported kubernetes versions.

Note: The minimum required version of k8s is 1.23 not 1.22. The Gateway APIs cannot be installed into 1.22:

```
kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.8.0/standard-install.yaml

error: error validating "https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.8.0/standard-install.yaml": error validating data: [ValidationError(CustomResourceDefinition.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.controllerName): unknown field "x-kubernetes-validations" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps, ValidationError(CustomResourceDefinition.spec.versions[1].schema.openAPIV3Schema.properties.spec.properties.controllerName): unknown field "x-kubernetes-validations" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps]; if you choose to ignore these errors, turn validation off with --validate=false
```

See https://github.com/kubernetes-sigs/gateway-api/releases

Closes #937 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
