### PR TITLE
Remove dots in helm release name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
       - name: Install Chart
         run: >
           helm install
-          helm-$(echo ${{ steps.nkg-meta.outputs.tags }} | cut -d ":" -f 2)
+          helm-$(echo ${{ steps.nkg-meta.outputs.tags }} | tr '.' '-' | cut -d ":" -f 2)
           .
           --wait
           --create-namespace


### PR DESCRIPTION
Problem: Helm tests are failing when there is a dot in the branch or tag name, as this is used for the helm release name which is not allowed

Solution: Replace any dots in the release name with dashes

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
