### PR TITLE
Wait for release to exist for conformance tests

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -132,6 +132,14 @@ jobs:
           echo "KUBECONFIG=${{ github.workspace }}/kube-${{ github.run_id }}" >> "$GITHUB_ENV"
         working-directory: ./conformance
 
+      - name: Wait for release to exist
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: lewagon/wait-on-check-action@e106e5c43e8ca1edea6383a39a01c5ca495fd812 # v1.3.1
+        with:
+          ref: ${{ github.ref }}
+          check-name: 'Build Image'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup conformance tests
         run: |
           nkg_prefix=$(echo ${{ steps.nkg-meta.outputs.tags }} | cut -d ":" -f 1)
@@ -145,14 +153,6 @@ jobs:
       - name: Run conformance tests
         run: make run-conformance-tests TAG=${{ github.sha }} VERSION=${{ github.ref_name }}
         working-directory: ./conformance
-
-      - name: Wait for release to exist
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: lewagon/wait-on-check-action@e106e5c43e8ca1edea6383a39a01c5ca495fd812 # v1.3.1
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Build Binary'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload profile to release
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Problem: The release needs to exist before we run the conformance tests on a release tag.

Solution: Move the "wait" job to earlier in the process.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
