### PR TITLE
Fix docs links and helm version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This release adds a Helm chart, dynamic control plane logging, Prometheus metric
 FEATURES:
 
 - Helm chart. [PR-840](https://github.com/nginxinc/nginx-kubernetes-gateway/pull/840)
-- Use custom nginx container. [PR-934](https://github.com/nginxinc/nginx-kubernetes-gateway/pull/911)
+- Use custom nginx container. [PR-934](https://github.com/nginxinc/nginx-kubernetes-gateway/pull/934)
 - Support dynamic control plane logging. [PR-943](https://github.com/nginxinc/nginx-kubernetes-gateway/pull/943)
 - Support websocket connections. [PR-962](https://github.com/nginxinc/nginx-kubernetes-gateway/pull/962)
 - Support Prometheus metrics. [PR-999](https://github.com/nginxinc/nginx-kubernetes-gateway/pull/999)

--- a/deploy/helm-chart/README.md
+++ b/deploy/helm-chart/README.md
@@ -30,7 +30,7 @@ To install the chart with the release name `my-release` (`my-release` is the nam
 nginx-gateway namespace (with optional `--create-namespace` flag - you can omit if the namespace already exists):
 
 ```shell
-helm install my-release oci://ghcr.io/nginxinc/charts/nginx-kubernetes-gateway --version 0.6.0 --create-namespace --wait -n nginx-gateway
+helm install my-release oci://ghcr.io/nginxinc/charts/nginx-kubernetes-gateway --version 0.1.0 --create-namespace --wait -n nginx-gateway
 ```
 
 ### Installing the Chart via Sources
@@ -38,7 +38,7 @@ helm install my-release oci://ghcr.io/nginxinc/charts/nginx-kubernetes-gateway -
 #### Pulling the Chart
 
 ```shell
-helm pull oci://ghcr.io/nginxinc/charts/nginx-kubernetes-gateway --untar --version 0.6.0
+helm pull oci://ghcr.io/nginxinc/charts/nginx-kubernetes-gateway --untar --version 0.1.0
 cd nginx-kubernetes-gateway
 ```
 
@@ -83,7 +83,7 @@ Warning: kubectl apply should be used on resource created by either kubectl crea
 To upgrade the release `my-release`, run:
 
 ```shell
-helm upgrade my-release oci://ghcr.io/nginxinc/charts/nginx-kubernetes-gateway --version 0.6.0 -n nginx-gateway
+helm upgrade my-release oci://ghcr.io/nginxinc/charts/nginx-kubernetes-gateway --version 0.1.0 -n nginx-gateway
 ```
 
 ### Upgrading the Chart from the Sources


### PR DESCRIPTION
Helm install version should be the chart version, not the app version. Also fixed a broken link
