### PR TITLE
Run helm tests on tag event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,6 @@ jobs:
     name: Helm Tests
     runs-on: ubuntu-22.04
     needs: [vars, binary]
-    if: ${{ github.ref_type != 'tag' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0


### PR DESCRIPTION
### Proposed changes

Problem: The Helm publish step isn't running on tags because helm tests are a requirement for the publish step, and we are not currently running the tests when the ref type is a tag

Solution: Run the helm tests for tags

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
