### PR TITLE
Add NGINX reload counters

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -89,8 +89,9 @@ NGINX Kubernetes Gateway exports the following metrics:
 - NGINX Kubernetes Gateway metrics:
   - nginx_reloads_total. Number of successful NGINX reloads.
   - nginx_reload_errors_total. Number of unsuccessful NGINX reloads.
-  - nginx_last_reload_status. Status of the last NGINX reload, 0 meaning down and 1 up.
-  - nginx_last_reload_milliseconds. Duration in milliseconds of the last NGINX reload.
+  - nginx_stale_config. 1 means NKG failed to configure NGINX with the latest version of the configuration, which means
+    NGINX is running with a stale version.
+  - nginx_last_reload_milliseconds. Duration in milliseconds of NGINX reloads.
   - These metrics have the namespace `nginx_kubernetes_gateway`, and include the label `class` which is set to the
     Gateway class of NKG. For example, `nginx_kubernetes_gateway_nginx_reloads_total{class="nginx"}`.
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -91,7 +91,7 @@ NGINX Kubernetes Gateway exports the following metrics:
   - nginx_reload_errors_total. Number of unsuccessful NGINX reloads.
   - nginx_stale_config. 1 means NKG failed to configure NGINX with the latest version of the configuration, which means
     NGINX is running with a stale version.
-  - nginx_last_reload_milliseconds. Duration in milliseconds of NGINX reloads.
+  - nginx_last_reload_milliseconds. Duration in milliseconds of NGINX reloads (histogram).
   - These metrics have the namespace `nginx_kubernetes_gateway`, and include the label `class` which is set to the
     Gateway class of NKG. For example, `nginx_kubernetes_gateway_nginx_reloads_total{class="nginx"}`.
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -86,6 +86,14 @@ NGINX Kubernetes Gateway exports the following metrics:
   - These metrics have the namespace `nginx_kubernetes_gateway`, and include the label `class` which is set to the
     Gateway class of NKG. For example, `nginx_kubernetes_gateway_connections_accepted{class="nginx"}`.
 
+- NGINX Kubernetes Gateway metrics:
+  - nginx_reloads_total. Number of successful NGINX reloads.
+  - nginx_reload_errors_total. Number of unsuccessful NGINX reloads.
+  - nginx_last_reload_status. Status of the last NGINX reload, 0 meaning down and 1 up.
+  - nginx_last_reload_milliseconds. Duration in milliseconds of the last NGINX reload.
+  - These metrics have the namespace `nginx_kubernetes_gateway`, and include the label `class` which is set to the
+    Gateway class of NKG. For example, `nginx_kubernetes_gateway_nginx_reloads_total{class="nginx"}`.
+
 - [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime) metrics. These include:
   - Total number of reconciliation errors per controller
   - Length of reconcile queue per controller

--- a/internal/mode/static/manager.go
+++ b/internal/mode/static/manager.go
@@ -130,7 +130,7 @@ func StartManager(cfg config.Config) error {
 		return fmt.Errorf("NGINX is not running: %w", err)
 	}
 
-	var mgrCollector nkgmetrics.ManagerCollector
+	var mgrCollector ngxruntime.ManagerCollector
 	mgrCollector = nkgmetrics.NewManagerFakeCollector()
 	if cfg.MetricsConfig.Enabled {
 		mgrCollector, err = configureNginxMetrics(cfg.GatewayClassName)

--- a/internal/mode/static/metrics/collector.go
+++ b/internal/mode/static/metrics/collector.go
@@ -6,20 +6,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// ManagerCollector is an interface for the metrics of the Nginx runtime manager
-type ManagerCollector interface {
-	IncNginxReloadCount()
-	IncNginxReloadErrors()
-	UpdateLastReloadTime(ms time.Duration)
-}
-
 // ManagerMetricsCollector implements ManagerCollector interface and prometheus.Collector interface
 type ManagerMetricsCollector struct {
 	// Metrics
-	reloadsTotal     prometheus.Counter
-	reloadsError     prometheus.Counter
-	lastReloadStatus prometheus.Gauge
-	lastReloadTime   prometheus.Gauge
+	reloadsTotal    prometheus.Counter
+	reloadsError    prometheus.Counter
+	configStale     prometheus.Gauge
+	reloadsDuration prometheus.Histogram
 }
 
 // NewManagerMetricsCollector creates a new ManagerMetricsCollector
@@ -40,70 +33,71 @@ func NewManagerMetricsCollector(constLabels map[string]string) *ManagerMetricsCo
 				ConstLabels: constLabels,
 			},
 		),
-		lastReloadStatus: prometheus.NewGauge(
+		configStale: prometheus.NewGauge(
 			prometheus.GaugeOpts{
-				Name:        "nginx_last_reload_status",
+				Name:        "nginx_stale_config",
 				Namespace:   metricsNamespace,
-				Help:        "Status of the last NGINX reload",
+				Help:        "Indicates if NGINX is not serving the latest configuration.",
 				ConstLabels: constLabels,
 			},
 		),
-		lastReloadTime: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Name:        "nginx_last_reload_milliseconds",
+		reloadsDuration: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name:        "nginx_reloads_milliseconds",
 				Namespace:   metricsNamespace,
-				Help:        "Duration in milliseconds of the last NGINX reload",
+				Help:        "Duration in milliseconds of NGINX reloads",
 				ConstLabels: constLabels,
+				Buckets:     []float64{100.0, 200.0, 300.0, 400.0, 500.0},
 			},
 		),
 	}
 	return nc
 }
 
-// IncNginxReloadCount increments the counter of successful NGINX reloads and sets the last reload status to true.
+// IncNginxReloadCount increments the counter of successful NGINX reloads and sets the stale config status to false.
 func (mc *ManagerMetricsCollector) IncNginxReloadCount() {
 	mc.reloadsTotal.Inc()
-	mc.updateLastReloadStatus(true)
+	mc.updateConfigStaleStatus(false)
 }
 
-// IncNginxReloadErrors increments the counter of NGINX reload errors and sets the last reload status to false.
+// IncNginxReloadErrors increments the counter of NGINX reload errors and sets the stale config status to true.
 func (mc *ManagerMetricsCollector) IncNginxReloadErrors() {
 	mc.reloadsError.Inc()
-	mc.updateLastReloadStatus(false)
+	mc.updateConfigStaleStatus(true)
 }
 
-// updateLastReloadStatus updates the last NGINX reload status metric.
-func (mc *ManagerMetricsCollector) updateLastReloadStatus(up bool) {
+// updateConfigStaleStatus updates the last NGINX reload status metric.
+func (mc *ManagerMetricsCollector) updateConfigStaleStatus(stale bool) {
 	var status float64
-	if up {
+	if stale {
 		status = 1.0
 	}
-	mc.lastReloadStatus.Set(status)
+	mc.configStale.Set(status)
 }
 
 // UpdateLastReloadTime updates the last NGINX reload time.
 func (mc *ManagerMetricsCollector) UpdateLastReloadTime(duration time.Duration) {
-	mc.lastReloadTime.Set(float64(duration / time.Millisecond))
+	mc.reloadsDuration.Observe(float64(duration / time.Millisecond))
 }
 
 // Describe implements prometheus.Collector interface Describe method.
 func (mc *ManagerMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 	mc.reloadsTotal.Describe(ch)
 	mc.reloadsError.Describe(ch)
-	mc.lastReloadStatus.Describe(ch)
-	mc.lastReloadTime.Describe(ch)
+	mc.configStale.Describe(ch)
+	mc.reloadsDuration.Describe(ch)
 }
 
 // Collect implements the prometheus.Collector interface Collect method.
 func (mc *ManagerMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 	mc.reloadsTotal.Collect(ch)
 	mc.reloadsError.Collect(ch)
-	mc.lastReloadStatus.Collect(ch)
-	mc.lastReloadTime.Collect(ch)
+	mc.configStale.Collect(ch)
+	mc.reloadsDuration.Collect(ch)
 }
 
 // ManagerFakeCollector is a fake collector that will implement ManagerCollector interface.
-// Used to initilise the ManagerCollector when metrics are disabled to avoid nil pointer errors.
+// Used to initialize the ManagerCollector when metrics are disabled to avoid nil pointer errors.
 type ManagerFakeCollector struct{}
 
 // NewManagerFakeCollector creates a fake collector that implements ManagerCollector interface.

--- a/internal/mode/static/metrics/collector.go
+++ b/internal/mode/static/metrics/collector.go
@@ -1,0 +1,121 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// ManagerCollector is an interface for the metrics of the Nginx runtime manager
+type ManagerCollector interface {
+	IncNginxReloadCount()
+	IncNginxReloadErrors()
+	UpdateLastReloadTime(ms time.Duration)
+}
+
+// ManagerMetricsCollector implements ManagerCollector interface and prometheus.Collector interface
+type ManagerMetricsCollector struct {
+	// Metrics
+	reloadsTotal     prometheus.Counter
+	reloadsError     prometheus.Counter
+	lastReloadStatus prometheus.Gauge
+	lastReloadTime   prometheus.Gauge
+}
+
+// NewManagerMetricsCollector creates a new ManagerMetricsCollector
+func NewManagerMetricsCollector(constLabels map[string]string) *ManagerMetricsCollector {
+	nc := &ManagerMetricsCollector{
+		reloadsTotal: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name:        "nginx_reloads_total",
+				Namespace:   metricsNamespace,
+				Help:        "Number of successful NGINX reloads",
+				ConstLabels: constLabels,
+			}),
+		reloadsError: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name:        "nginx_reload_errors_total",
+				Namespace:   metricsNamespace,
+				Help:        "Number of unsuccessful NGINX reloads",
+				ConstLabels: constLabels,
+			},
+		),
+		lastReloadStatus: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name:        "nginx_last_reload_status",
+				Namespace:   metricsNamespace,
+				Help:        "Status of the last NGINX reload",
+				ConstLabels: constLabels,
+			},
+		),
+		lastReloadTime: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name:        "nginx_last_reload_milliseconds",
+				Namespace:   metricsNamespace,
+				Help:        "Duration in milliseconds of the last NGINX reload",
+				ConstLabels: constLabels,
+			},
+		),
+	}
+	return nc
+}
+
+// IncNginxReloadCount increments the counter of successful NGINX reloads and sets the last reload status to true.
+func (mc *ManagerMetricsCollector) IncNginxReloadCount() {
+	mc.reloadsTotal.Inc()
+	mc.updateLastReloadStatus(true)
+}
+
+// IncNginxReloadErrors increments the counter of NGINX reload errors and sets the last reload status to false.
+func (mc *ManagerMetricsCollector) IncNginxReloadErrors() {
+	mc.reloadsError.Inc()
+	mc.updateLastReloadStatus(false)
+}
+
+// updateLastReloadStatus updates the last NGINX reload status metric.
+func (mc *ManagerMetricsCollector) updateLastReloadStatus(up bool) {
+	var status float64
+	if up {
+		status = 1.0
+	}
+	mc.lastReloadStatus.Set(status)
+}
+
+// UpdateLastReloadTime updates the last NGINX reload time.
+func (mc *ManagerMetricsCollector) UpdateLastReloadTime(duration time.Duration) {
+	mc.lastReloadTime.Set(float64(duration / time.Millisecond))
+}
+
+// Describe implements prometheus.Collector interface Describe method.
+func (mc *ManagerMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
+	mc.reloadsTotal.Describe(ch)
+	mc.reloadsError.Describe(ch)
+	mc.lastReloadStatus.Describe(ch)
+	mc.lastReloadTime.Describe(ch)
+}
+
+// Collect implements the prometheus.Collector interface Collect method.
+func (mc *ManagerMetricsCollector) Collect(ch chan<- prometheus.Metric) {
+	mc.reloadsTotal.Collect(ch)
+	mc.reloadsError.Collect(ch)
+	mc.lastReloadStatus.Collect(ch)
+	mc.lastReloadTime.Collect(ch)
+}
+
+// ManagerFakeCollector is a fake collector that will implement ManagerCollector interface.
+// Used to initilise the ManagerCollector when metrics are disabled to avoid nil pointer errors.
+type ManagerFakeCollector struct{}
+
+// NewManagerFakeCollector creates a fake collector that implements ManagerCollector interface.
+func NewManagerFakeCollector() *ManagerFakeCollector {
+	return &ManagerFakeCollector{}
+}
+
+// IncNginxReloadCount implements a fake IncNginxReloadCount.
+func (mc *ManagerFakeCollector) IncNginxReloadCount() {}
+
+// IncNginxReloadErrors implements a fake IncNginxReloadErrors.
+func (mc *ManagerFakeCollector) IncNginxReloadErrors() {}
+
+// UpdateLastReloadTime implements a fake UpdateLastReloadTime.
+func (mc *ManagerFakeCollector) UpdateLastReloadTime(_ time.Duration) {}

--- a/internal/mode/static/metrics/metrics.go
+++ b/internal/mode/static/metrics/metrics.go
@@ -1,0 +1,4 @@
+package metrics
+
+// nolint:gosec // flagged as potential hardcoded credentials, but is not sensitive
+const metricsNamespace = "nginx_kubernetes_gateway"

--- a/internal/mode/static/metrics/nginx.go
+++ b/internal/mode/static/metrics/nginx.go
@@ -24,7 +24,7 @@ func NewNginxMetricsCollector(constLabels map[string]string) (prometheus.Collect
 	if err != nil {
 		return nil, err
 	}
-	return nginxCollector.NewNginxCollector(client, "nginx_kubernetes_gateway", constLabels), nil
+	return nginxCollector.NewNginxCollector(client, metricsNamespace, constLabels), nil
 }
 
 // getSocketClient gets an http.Client with a unix socket transport.


### PR DESCRIPTION
### Proposed changes

Problem: As an operator of an environment running NKG
I want to track the total number of NGINX reloads and failures for NGINX processes across my environment
So that I can correlate availability issues with excessive NGINX reloads or failures
And so that I can let the NKG know when reloads become a problem.

Solution: Total NGINX reloads and failed reloads are counted and reported via a Prometheus endpoint as a counter.
Also included reload duration histogram and a stale config gauge.

Testing: Manual testing with metrics enabled and disabled. Confirmed that reloads reported = HUP signals observed in the NGINX logs = config version reported in the version endpoint. Example output:

```
<...>
# HELP nginx_kubernetes_gateway_nginx_reload_errors_total Number of unsuccessful NGINX reloads
# TYPE nginx_kubernetes_gateway_nginx_reload_errors_total counter
nginx_kubernetes_gateway_nginx_reload_errors_total{class="nginx"} 0
# HELP nginx_kubernetes_gateway_nginx_reloads_milliseconds Duration in milliseconds of NGINX reloads
# TYPE nginx_kubernetes_gateway_nginx_reloads_milliseconds histogram
nginx_kubernetes_gateway_nginx_reloads_milliseconds_bucket{class="nginx",le="500"} 2
nginx_kubernetes_gateway_nginx_reloads_milliseconds_bucket{class="nginx",le="1000"} 2
nginx_kubernetes_gateway_nginx_reloads_milliseconds_bucket{class="nginx",le="5000"} 2
nginx_kubernetes_gateway_nginx_reloads_milliseconds_bucket{class="nginx",le="10000"} 2
nginx_kubernetes_gateway_nginx_reloads_milliseconds_bucket{class="nginx",le="30000"} 2
nginx_kubernetes_gateway_nginx_reloads_milliseconds_bucket{class="nginx",le="+Inf"} 2
nginx_kubernetes_gateway_nginx_reloads_milliseconds_sum{class="nginx"} 231
nginx_kubernetes_gateway_nginx_reloads_milliseconds_count{class="nginx"} 2
# HELP nginx_kubernetes_gateway_nginx_reloads_total Number of successful NGINX reloads
# TYPE nginx_kubernetes_gateway_nginx_reloads_total counter
nginx_kubernetes_gateway_nginx_reloads_total{class="nginx"} 2
# HELP nginx_kubernetes_gateway_nginx_stale_config Indicates if NGINX is not serving the latest configuration.
# TYPE nginx_kubernetes_gateway_nginx_stale_config gauge
nginx_kubernetes_gateway_nginx_stale_config{class="nginx"} 0
<...>
```

Closes #887

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-kubernetes-gateway/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
